### PR TITLE
SwiftJS: Node-shaped error reporting (codes, code-frames, no rewriter leak)

### DIFF
--- a/Sources/SwiftJSCore/ChildProcess.swift
+++ b/Sources/SwiftJSCore/ChildProcess.swift
@@ -110,10 +110,28 @@ extension JSRuntime {
                                       forKeyedSubscript: "code" as NSString)
                     handles.resolve?.call(withArguments: [payload])
                 } else {
-                    let err = JSValue(newErrorFromMessage: "Command failed: \(command)\n\(result.stderr)", in: self.context)!
-                    err.setObject(result.status, forKeyedSubscript: "code" as NSString)
-                    err.setObject(result.stdout, forKeyedSubscript: "stdout" as NSString)
-                    err.setObject(result.stderr, forKeyedSubscript: "stderr" as NSString)
+                    // Node's `exec` populates the rejected Error with
+                    // both the numeric exit code (`code`) and a more
+                    // structured shape: `cmd`, `killed`, `signal`,
+                    // `stdout`, `stderr`. Match that surface so error
+                    // matchers in user code can use `err.code === 127`
+                    // / `err.cmd` etc.
+                    let trimmedStderr = result.stderr
+                        .trimmingCharacters(in: .whitespacesAndNewlines)
+                    let suffix = trimmedStderr.isEmpty ? "" : "\n\(trimmedStderr)"
+                    let err = self.makeJSError(
+                        "Command failed: \(command)\(suffix)",
+                        in: self.context,
+                        extras: [
+                            "code": result.status,
+                            "status": result.status,
+                            "cmd": command,
+                            "killed": false,
+                            "signal": NSNull(),
+                            "stdout": result.stdout,
+                            "stderr": result.stderr,
+                        ]
+                    )
                     handles.reject?.call(withArguments: [err])
                 }
             }
@@ -211,7 +229,25 @@ extension JSRuntime {
         let result = pickBackendAndRun(command: command, args: nil, opts: opts)
 
         if result.status != 0 {
-            return throwJS("Command failed: \(command)\n\(result.stderr)")
+            // Match the shape Node throws from execSync — Error with
+            // `status`, `stdout`, `stderr`, `pid`, `signal`, plus a
+            // numeric `code` mirroring `status`. The string form keeps
+            // Node's "Command failed: <cmd>\n<stderr>" message so
+            // existing log-grep'ing code keeps working.
+            let trimmedStderr = result.stderr
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            let suffix = trimmedStderr.isEmpty ? "" : "\n\(trimmedStderr)"
+            return throwJSError(
+                "Command failed: \(command)\(suffix)",
+                extras: [
+                    "code": result.status,
+                    "status": result.status,
+                    "cmd": command,
+                    "signal": NSNull(),
+                    "stdout": result.stdout,
+                    "stderr": result.stderr,
+                ]
+            )
         }
         return encode(bytes: Array(result.stdout.utf8), encoding: encoding)
     }

--- a/Sources/SwiftJSCore/Crypto.swift
+++ b/Sources/SwiftJSCore/Crypto.swift
@@ -91,7 +91,10 @@ extension JSRuntime {
         let digest: @convention(block) (JSValue?) -> Any? = { [weak self] encoding in
             guard let self else { return nil }
             guard let bytes = state.finalize() else {
-                return self.throwJS("Unsupported hash algorithm: \(algorithm)")
+                return self.throwJSError(
+                    "Digest method not supported: \(algorithm)",
+                    code: "ERR_OSSL_EVP_UNSUPPORTED"
+                )
             }
             if let encoding, encoding.isString {
                 let enc = encoding.toString()?.lowercased() ?? "hex"

--- a/Sources/SwiftJSCore/ESMRewriter.swift
+++ b/Sources/SwiftJSCore/ESMRewriter.swift
@@ -223,7 +223,15 @@ public enum ESMRewriter {
                     return "exports.\(alias) = \(name);"
                 }
                 .joined(separator: " ")
-            out += "exports.__esModule = true; " + assignments
+            let replacement = "exports.__esModule = true; " + assignments
+            // Pad with newlines so a multi-line `export { a, b }` block
+            // doesn't shift later line numbers in stack traces.
+            let original = ns.substring(with: m.range)
+            let originalNewlines = original.reduce(0) { $0 + ($1 == "\n" ? 1 : 0) }
+            out += replacement
+            if originalNewlines > 0 {
+                out += String(repeating: "\n", count: originalNewlines)
+            }
             cursor = m.range.location + m.range.length
         }
         out += ns.substring(from: cursor)
@@ -235,17 +243,42 @@ public enum ESMRewriter {
     private static func regexReplace(
         in src: String,
         pattern: String,
-        with replacement: String,
+        with template: String,
         options: NSRegularExpression.Options
     ) -> String {
         guard let re = try? NSRegularExpression(pattern: pattern, options: options) else {
             return src
         }
         let ns = src as NSString
-        return re.stringByReplacingMatches(
-            in: src,
-            range: NSRange(location: 0, length: ns.length),
-            withTemplate: replacement
-        )
+        let matches = re.matches(in: src, range: NSRange(location: 0, length: ns.length))
+        guard !matches.isEmpty else { return src }
+
+        // Build the output manually so we can pad each replacement
+        // with newlines whenever the original match spanned more
+        // lines than the template produces. This keeps line numbers
+        // in the rewritten source aligned with the user's original
+        // source — JSC stack traces and the exception code-frame
+        // both point back to the right line.
+        var out = ""
+        var cursor = 0
+        for m in matches {
+            let prefix = NSRange(location: cursor, length: m.range.location - cursor)
+            out += ns.substring(with: prefix)
+
+            let replacement = re.replacementString(for: m, in: src, offset: 0,
+                                                   template: template)
+            let originalNewlines = ns.substring(with: m.range)
+                .reduce(0) { $0 + ($1 == "\n" ? 1 : 0) }
+            let replacementNewlines = replacement
+                .reduce(0) { $0 + ($1 == "\n" ? 1 : 0) }
+            let padding = max(0, originalNewlines - replacementNewlines)
+            out += replacement
+            if padding > 0 {
+                out += String(repeating: "\n", count: padding)
+            }
+            cursor = m.range.location + m.range.length
+        }
+        out += ns.substring(from: cursor)
+        return out
     }
 }

--- a/Sources/SwiftJSCore/JSRuntime.swift
+++ b/Sources/SwiftJSCore/JSRuntime.swift
@@ -130,9 +130,7 @@ public final class JSRuntime {
             if exception.objectForKeyedSubscript("__swiftjs_exit").toBool() {
                 return
             }
-            let message = exception.toString() ?? "<unknown>"
-            let stack = exception.objectForKeyedSubscript("stack")?.toString() ?? ""
-            self.stderr("\(message)\n\(stack)\n")
+            self.stderr(self.formatException(exception))
             if !self.didExit { self.exitCode = 1 }
         }
 
@@ -183,7 +181,10 @@ public final class JSRuntime {
         // scope so we expose them as globals.
         setGlobal("__filename", url.path)
         setGlobal("__dirname", (url.path as NSString).deletingLastPathComponent)
-        return run(source, name: url.lastPathComponent)
+        // Pass the absolute path as the sourceURL so stack traces and
+        // the code-frame on uncaught exceptions resolve back to the
+        // real on-disk file (rather than a basename relative to cwd).
+        return run(source, name: url.path)
     }
 
     /// Re-sync `process.argv` from the current `argvProvider` value.
@@ -253,6 +254,214 @@ extension JSRuntime {
         let err = JSValue(newErrorFromMessage: message, in: ctx)
         ctx.exception = err
         return err
+    }
+
+    /// Throw a JS Error decorated with the Node-style fields the
+    /// ecosystem expects (`code`, plus any extras the caller wants to
+    /// attach). Returns the exception so callers can `return` it from
+    /// `Any?`-typed bridge blocks.
+    @discardableResult
+    func throwJSError(
+        _ message: String,
+        code: String? = nil,
+        extras: [String: Any] = [:]
+    ) -> JSValue? {
+        guard let ctx = JSContext.current() ?? Optional(context) else { return nil }
+        guard let err = JSValue(newErrorFromMessage: message, in: ctx) else { return nil }
+        if let code { err.setObject(code, forKeyedSubscript: "code" as NSString) }
+        for (k, v) in extras { err.setObject(v, forKeyedSubscript: k as NSString) }
+        ctx.exception = err
+        return err
+    }
+
+    /// Build (but do not throw) a JS Error with `code` and extras.
+    /// Used by async paths that need to reject a Promise rather than
+    /// set `ctx.exception`.
+    func makeJSError(
+        _ message: String,
+        in ctx: JSContext,
+        code: String? = nil,
+        extras: [String: Any] = [:]
+    ) -> JSValue {
+        let err = JSValue(newErrorFromMessage: message, in: ctx)!
+        if let code { err.setObject(code, forKeyedSubscript: "code" as NSString) }
+        for (k, v) in extras { err.setObject(v, forKeyedSubscript: k as NSString) }
+        return err
+    }
+
+    /// Throw a Node-shaped fs/system error. Pulls the POSIX errno out
+    /// of the underlying Foundation error so we can emit the same
+    /// `ENOENT: no such file or directory, open '/x'` shape Node does,
+    /// with `.code`, `.errno`, `.syscall`, `.path` set on the Error.
+    @discardableResult
+    func throwSystemError(
+        _ error: Error,
+        syscall: String,
+        path: String? = nil
+    ) -> JSValue? {
+        let errno = Self.posixErrno(from: error)
+        let code = Self.posixCodeName(errno)
+        let desc = Self.posixDescription(errno, fallback: error.localizedDescription)
+        var msg = "\(code): \(desc), \(syscall)"
+        if let path { msg += " '\(path)'" }
+        var extras: [String: Any] = [
+            "errno": Int(-errno),
+            "syscall": syscall,
+        ]
+        if let path { extras["path"] = path }
+        return throwJSError(msg, code: code, extras: extras)
+    }
+
+    /// Extract POSIX errno from a Foundation/NSError. Cocoa
+    /// file-system errors carry the original POSIXError nested under
+    /// `NSUnderlyingErrorKey`; pull it out so we can map to a Node code.
+    /// Returns 0 if no POSIX errno can be derived.
+    static func posixErrno(from error: Error) -> Int32 {
+        let ns = error as NSError
+        if ns.domain == NSPOSIXErrorDomain { return Int32(ns.code) }
+        if let underlying = ns.userInfo[NSUnderlyingErrorKey] as? NSError,
+           underlying.domain == NSPOSIXErrorDomain {
+            return Int32(underlying.code)
+        }
+        // Cocoa file errors → best-guess mapping for the common cases.
+        if ns.domain == NSCocoaErrorDomain {
+            switch ns.code {
+            case 4 /* NSFileNoSuchFileError */, 260 /* NSFileReadNoSuchFileError */:
+                return ENOENT
+            case 257 /* NSFileReadNoPermissionError */, 513 /* NSFileWriteNoPermissionError */:
+                return EACCES
+            case 516 /* NSFileWriteFileExistsError */:
+                return EEXIST
+            default: break
+            }
+        }
+        return 0
+    }
+
+    /// Map a POSIX errno to its Node-style symbolic code.
+    static func posixCodeName(_ errno: Int32) -> String {
+        switch errno {
+        case ENOENT:    return "ENOENT"
+        case EACCES:    return "EACCES"
+        case EPERM:     return "EPERM"
+        case EEXIST:    return "EEXIST"
+        case ENOTDIR:   return "ENOTDIR"
+        case EISDIR:    return "EISDIR"
+        case ENOTEMPTY: return "ENOTEMPTY"
+        case EBUSY:     return "EBUSY"
+        case ENOSPC:    return "ENOSPC"
+        case EROFS:     return "EROFS"
+        case EMFILE:    return "EMFILE"
+        case ENFILE:    return "ENFILE"
+        case EINVAL:    return "EINVAL"
+        case ENOMEM:    return "ENOMEM"
+        case ELOOP:     return "ELOOP"
+        case ENAMETOOLONG: return "ENAMETOOLONG"
+        case EAGAIN:    return "EAGAIN"
+        case EBADF:     return "EBADF"
+        case EFAULT:    return "EFAULT"
+        case EIO:       return "EIO"
+        default:        return "UNKNOWN"
+        }
+    }
+
+    /// Node-style human-readable description for a POSIX errno.
+    /// Falls back to the OS string if we don't have a hard-coded one.
+    static func posixDescription(_ errno: Int32, fallback: String) -> String {
+        switch errno {
+        case ENOENT:    return "no such file or directory"
+        case EACCES:    return "permission denied"
+        case EPERM:     return "operation not permitted"
+        case EEXIST:    return "file already exists"
+        case ENOTDIR:   return "not a directory"
+        case EISDIR:    return "illegal operation on a directory"
+        case ENOTEMPTY: return "directory not empty"
+        case EBUSY:     return "resource busy or locked"
+        case ENOSPC:    return "no space left on device"
+        case EROFS:     return "read-only file system"
+        case EMFILE, ENFILE: return "too many open files"
+        case EINVAL:    return "invalid argument"
+        case ENAMETOOLONG: return "name too long"
+        case ELOOP:     return "too many symbolic links"
+        case 0:         return fallback
+        default:
+            return String(cString: strerror(errno))
+        }
+    }
+
+    // MARK: - Exception formatting
+    //
+    // Surface uncaught exceptions in a Node-ish shape:
+    //
+    //     <sourceURL>:<line>
+    //     <source line>
+    //         ^
+    //
+    //     <ErrorName>: <message>
+    //         <stack...>
+    //
+    // The code-frame is only produced when we can resolve the
+    // sourceURL to a real on-disk file — for `-e` snippets we fall
+    // back to message + stack. We never reference the rewritten
+    // module wrapper or the ESM-rewritten source: line numbers are
+    // preserved by both transforms, so reading the on-disk file at
+    // the reported line gives the original user source.
+    func formatException(_ exception: JSValue) -> String {
+        let message = exception.toString() ?? "<unknown>"
+        let stack = nonEmpty(exception, "stack")
+
+        let sourceURL = nonEmpty(exception, "sourceURL")
+        let line = exception.objectForKeyedSubscript("line")?.toInt32() ?? 0
+        let column = exception.objectForKeyedSubscript("column")?.toInt32() ?? 0
+
+        var out = ""
+        if let frame = codeFrame(sourceURL: sourceURL, line: line, column: column) {
+            out += frame + "\n\n"
+        }
+        out += message + "\n"
+        if let stack { out += stack + "\n" }
+        return out
+    }
+
+    private func nonEmpty(_ v: JSValue, _ key: String) -> String? {
+        guard let prop = v.objectForKeyedSubscript(key),
+              !prop.isUndefined, !prop.isNull,
+              let s = prop.toString(), !s.isEmpty else { return nil }
+        return s
+    }
+
+    /// Read `sourceURL`'s line `line` and produce a Node-style
+    /// `path:line\n  source\n  ^` frame. Returns nil when the file
+    /// can't be read (e.g. `[eval]` pseudo-paths).
+    private func codeFrame(sourceURL: String?, line: Int32, column: Int32) -> String? {
+        guard let sourceURL, line > 0 else { return nil }
+        let path: String
+        if sourceURL.hasPrefix("file://"), let u = URL(string: sourceURL) {
+            path = u.path
+        } else {
+            path = sourceURL
+        }
+        guard let source = try? String(contentsOfFile: path, encoding: .utf8) else {
+            return nil
+        }
+        let lines = source.split(omittingEmptySubsequences: false,
+                                  whereSeparator: { $0 == "\n" })
+        let idx = Int(line) - 1
+        guard idx >= 0, idx < lines.count else { return nil }
+        let lineText = String(lines[idx])
+        var frame = "\(path):\(line)\n\(lineText)"
+        // Required modules are wrapped in a CommonJS factory whose
+        // prefix lives on the same line as the user's first line, so
+        // the column on line 1 is shifted by the prefix length. We
+        // can't recover the original column without tracking the
+        // offset, so suppress the caret when it would point past the
+        // visible source line — better no caret than a misleading one.
+        if column > 0, Int(column) <= lineText.count + 1 {
+            // JSC columns are 1-based for the visible character.
+            let caret = String(repeating: " ", count: max(0, Int(column) - 1)) + "^"
+            frame += "\n" + caret
+        }
+        return frame
     }
 }
 #endif

--- a/Sources/SwiftJSCore/Modules.swift
+++ b/Sources/SwiftJSCore/Modules.swift
@@ -39,7 +39,7 @@ extension JSRuntime {
             return loadFileModule(spec)
         }
 
-        return throwJS("Cannot find module '\(spec)'")
+        return throwJSError("Cannot find module '\(spec)'", code: "MODULE_NOT_FOUND")
     }
 
     /// Look up the cache directly via the JS object (don't go through
@@ -84,7 +84,7 @@ extension JSRuntime {
         }
 
         guard let source = try? String(contentsOfFile: resolved, encoding: .utf8) else {
-            return throwJS("Cannot find module '\(spec)'")
+            return throwJSError("Cannot find module '\(spec)'", code: "MODULE_NOT_FOUND")
         }
 
         // .json files load as parsed JSON (Node behaviour).
@@ -101,12 +101,14 @@ extension JSRuntime {
         // CommonJS `require`d modules.
         let rewritten = ESMRewriter.rewrite(source)
 
-        // CommonJS wrapper. Note: returns module.exports.
-        let wrapped = """
-        (function(exports, require, module, __filename, __dirname) {
-        \(rewritten)
-        })
-        """
+        // CommonJS wrapper. The prefix lives on the same line as the
+        // user's first line of source so JSC's stack-frame line
+        // numbers map directly back to the original file (Node does
+        // the same trick for the same reason). Column numbers on line
+        // 1 are still off by `prefix.count`, but that's the standard
+        // Node offset and tools that consume stack traces handle it.
+        let prefix = "(function(exports, require, module, __filename, __dirname) { "
+        let wrapped = prefix + rewritten + "\n})"
         let url = URL(fileURLWithPath: resolved)
         guard let factory = context.evaluateScript(wrapped, withSourceURL: url),
               !factory.isUndefined else {
@@ -421,7 +423,7 @@ extension JSRuntime {
                 let bytes = Array(data) as [UInt8]
                 return bufferCtor.invokeMethod("from", withArguments: [bytes])!
             } catch {
-                return self.throwJS(error.localizedDescription)
+                return self.throwSystemError(error, syscall: "open", path: path)
             }
         }
         fs.setObject(block(readFileSync as AnyObject),
@@ -437,24 +439,31 @@ extension JSRuntime {
                 try data.write(to: URL(fileURLWithPath: path))
                 return true
             } catch {
-                _ = self.throwJS(error.localizedDescription)
+                _ = self.throwSystemError(error, syscall: "open", path: path)
                 return false
             }
         }
         fs.setObject(block(writeFileSync as AnyObject),
                      forKeyedSubscript: "writeFileSync" as NSString)
 
-        let appendFileSync: @convention(block) (String, JSValue) -> Bool = { path, value in
+        let appendFileSync: @convention(block) (String, JSValue) -> Bool = { [weak self] path, value in
+            guard let self else { return false }
             let data = Self.dataForWrite(value)
             let url = URL(fileURLWithPath: path)
-            if let handle = try? FileHandle(forWritingTo: url) {
-                handle.seekToEndOfFile()
-                handle.write(data)
-                try? handle.close()
-            } else {
-                try? data.write(to: url)
+            do {
+                if FileManager.default.fileExists(atPath: path) {
+                    let handle = try FileHandle(forWritingTo: url)
+                    defer { try? handle.close() }
+                    handle.seekToEndOfFile()
+                    handle.write(data)
+                } else {
+                    try data.write(to: url)
+                }
+                return true
+            } catch {
+                _ = self.throwSystemError(error, syscall: "open", path: path)
+                return false
             }
-            return true
         }
         fs.setObject(block(appendFileSync as AnyObject),
                      forKeyedSubscript: "appendFileSync" as NSString)
@@ -465,8 +474,14 @@ extension JSRuntime {
         fs.setObject(block(existsSync as AnyObject),
                      forKeyedSubscript: "existsSync" as NSString)
 
-        let readdirSync: @convention(block) (String) -> [String] = { path in
-            (try? FileManager.default.contentsOfDirectory(atPath: path)) ?? []
+        let readdirSync: @convention(block) (String) -> Any? = { [weak self] path in
+            guard let self else { return nil }
+            do {
+                return try FileManager.default.contentsOfDirectory(atPath: path)
+            } catch {
+                _ = self.throwSystemError(error, syscall: "scandir", path: path)
+                return nil
+            }
         }
         fs.setObject(block(readdirSync as AnyObject),
                      forKeyedSubscript: "readdirSync" as NSString)
@@ -486,7 +501,7 @@ extension JSRuntime {
                 )
                 return true
             } catch {
-                _ = self.throwJS(error.localizedDescription)
+                _ = self.throwSystemError(error, syscall: "mkdir", path: path)
                 return false
             }
         }
@@ -501,7 +516,9 @@ extension JSRuntime {
                 try FileManager.default.removeItem(atPath: path)
                 return true
             } catch {
-                if !force { _ = self.throwJS(error.localizedDescription) }
+                if !force {
+                    _ = self.throwSystemError(error, syscall: "unlink", path: path)
+                }
                 return false
             }
         }
@@ -515,7 +532,15 @@ extension JSRuntime {
             let fm = FileManager.default
             var isDir: ObjCBool = false
             guard fm.fileExists(atPath: path, isDirectory: &isDir) else {
-                return self.throwJS("ENOENT: no such file or directory, stat '\(path)'")
+                return self.throwJSError(
+                    "ENOENT: no such file or directory, stat '\(path)'",
+                    code: "ENOENT",
+                    extras: [
+                        "errno": Int(-ENOENT),
+                        "syscall": "stat",
+                        "path": path,
+                    ]
+                )
             }
             let attrs = (try? fm.attributesOfItem(atPath: path)) ?? [:]
             let size = (attrs[.size] as? NSNumber)?.intValue ?? 0

--- a/Sources/SwiftJSCore/Network.swift
+++ b/Sources/SwiftJSCore/Network.swift
@@ -86,7 +86,12 @@ extension JSRuntime {
         let urlString = urlVal.toString() ?? ""
         guard let url = URL(string: urlString) else {
             box.reject?.call(withArguments: [
-                JSValue(newErrorFromMessage: "Invalid URL: \(urlString)", in: ctx)!
+                makeJSError(
+                    "Invalid URL: \(urlString)",
+                    in: ctx,
+                    code: "ERR_INVALID_URL",
+                    extras: ["input": urlString]
+                )
             ])
             return promise
         }
@@ -118,7 +123,11 @@ extension JSRuntime {
                     let reason = s.objectForKeyedSubscript("reason")
                     let err = (reason?.isObject == true)
                         ? reason!
-                        : JSValue(newErrorFromMessage: "The operation was aborted.", in: ctx)!
+                        : makeJSError(
+                            "The operation was aborted.",
+                            in: ctx,
+                            code: "ABORT_ERR"
+                        )
                     box.reject?.call(withArguments: [err])
                     return promise
                 }
@@ -144,15 +153,33 @@ extension JSRuntime {
             let headers = (response as? HTTPURLResponse)?.allHeaderFields ?? [:]
             let respondedURL = response?.url?.absoluteString ?? urlString
             let errorDesc = error?.localizedDescription
+            let errorCode = Self.fetchErrorCode(error)
+            let errnoText: Int? = {
+                guard let urlError = error as? URLError else { return nil }
+                return urlError.errorCode
+            }()
             DispatchQueue.main.async {
                 guard let self else { return }
                 if let s = self.pendingTimers.removeValue(forKey: sentinelID) {
                     s.cancel()
                 }
                 if let errorDesc {
-                    box.reject?.call(withArguments: [
-                        JSValue(newErrorFromMessage: errorDesc, in: self.context)!
-                    ])
+                    var extras: [String: Any] = [
+                        "url": urlString,
+                    ]
+                    if let errnoText { extras["errno"] = errnoText }
+                    let isAbort = (errorCode == "ABORT_ERR")
+                    let err = self.makeJSError(
+                        isAbort ? "The operation was aborted." : errorDesc,
+                        in: self.context,
+                        code: errorCode,
+                        extras: extras
+                    )
+                    if isAbort {
+                        err.setObject("AbortError",
+                                      forKeyedSubscript: "name" as NSString)
+                    }
+                    box.reject?.call(withArguments: [err])
                     return
                 }
                 let respObj = self.makeResponseObject(
@@ -178,6 +205,34 @@ extension JSRuntime {
         }
 
         return promise
+    }
+
+    /// Map a URLError to the closest Node-style symbolic code so JS
+    /// `catch (e) { if (e.code === 'ENOTFOUND') ... }` matches the
+    /// shape user code expects. Falls back to `ERR_NETWORK` for
+    /// anything we don't have a more specific mapping for.
+    fileprivate static func fetchErrorCode(_ error: Error?) -> String? {
+        guard let error else { return nil }
+        guard let urlError = error as? URLError else { return "ERR_NETWORK" }
+        switch urlError.code {
+        case .cancelled:               return "ABORT_ERR"
+        case .timedOut:                return "ETIMEDOUT"
+        case .cannotFindHost:          return "ENOTFOUND"
+        case .cannotConnectToHost:     return "ECONNREFUSED"
+        case .networkConnectionLost:   return "ECONNRESET"
+        case .notConnectedToInternet:  return "ENETDOWN"
+        case .dnsLookupFailed:         return "EAI_AGAIN"
+        case .badURL:                  return "ERR_INVALID_URL"
+        case .unsupportedURL:          return "ERR_INVALID_URL"
+        case .secureConnectionFailed:  return "ERR_TLS"
+        case .serverCertificateUntrusted,
+             .serverCertificateHasBadDate,
+             .serverCertificateHasUnknownRoot,
+             .serverCertificateNotYetValid:
+            return "CERT_HAS_EXPIRED"
+        default:
+            return "ERR_NETWORK"
+        }
     }
 
     private func makeResponseObject(

--- a/Sources/SwiftJSCore/Zlib.swift
+++ b/Sources/SwiftJSCore/Zlib.swift
@@ -15,78 +15,92 @@ extension JSRuntime {
     func makeZlibModule() -> JSValue {
         let zlib = JSValue(newObjectIn: context)!
 
-        // gzipSync(buf|string) → Buffer (gzip format, with header)
-        let gzipSync: @convention(block) (JSValue) -> Any? = { [weak self] input in
-            guard let self else { return nil }
-            let bytes = JSRuntime.bytesForZlibInput(input)
-            guard let out = JSRuntime.zlibCompress(bytes, format: .gzip) else {
-                return self.throwJS("zlib gzip failed")
+        // Each *Sync entry funnels through `bridge`, which decorates a
+        // failed compress/decompress with the underlying zlib message
+        // (`stream.msg`) and a Node-shaped `code` (`Z_DATA_ERROR`,
+        // `Z_BUF_ERROR`, …). Without that, errors looked like the
+        // generic "zlib gunzip failed", and a truncated gzip stream
+        // and an OOM would be indistinguishable to the caller.
+        let bridge: (String, @escaping (JSValue) -> JSResult) -> @convention(block) (JSValue) -> Any? = { [weak self] op, body in
+            { input in
+                guard let self else { return nil }
+                switch body(input) {
+                case .ok(let bytes):
+                    return self.bufferFromBytes(bytes)
+                case .err(let rc, let message):
+                    let code = JSRuntime.zlibCodeName(rc)
+                    let detail = message ?? JSRuntime.zlibDescription(rc)
+                    return self.throwJSError(
+                        "zlib: \(op) failed: \(detail)",
+                        code: code,
+                        extras: ["errno": Int(rc)]
+                    )
+                }
             }
-            return self.bufferFromBytes(out)
+        }
+
+        let gzipSync = bridge("gzip") { input in
+            JSRuntime.zlibCompress(JSRuntime.bytesForZlibInput(input), format: .gzip)
         }
         zlib.setObject(block(gzipSync as AnyObject),
                        forKeyedSubscript: "gzipSync" as NSString)
 
-        // gunzipSync(buf) → Buffer
-        let gunzipSync: @convention(block) (JSValue) -> Any? = { [weak self] input in
-            guard let self else { return nil }
-            let bytes = JSRuntime.bytesForZlibInput(input)
-            guard let out = JSRuntime.zlibDecompress(bytes, format: .gzip) else {
-                return self.throwJS("zlib gunzip failed")
-            }
-            return self.bufferFromBytes(out)
+        let gunzipSync = bridge("gunzip") { input in
+            JSRuntime.zlibDecompress(JSRuntime.bytesForZlibInput(input), format: .gzip)
         }
         zlib.setObject(block(gunzipSync as AnyObject),
                        forKeyedSubscript: "gunzipSync" as NSString)
 
-        // deflateSync(buf|string) → Buffer (zlib format)
-        let deflateSync: @convention(block) (JSValue) -> Any? = { [weak self] input in
-            guard let self else { return nil }
-            let bytes = JSRuntime.bytesForZlibInput(input)
-            guard let out = JSRuntime.zlibCompress(bytes, format: .zlib) else {
-                return self.throwJS("zlib deflate failed")
-            }
-            return self.bufferFromBytes(out)
+        let deflateSync = bridge("deflate") { input in
+            JSRuntime.zlibCompress(JSRuntime.bytesForZlibInput(input), format: .zlib)
         }
         zlib.setObject(block(deflateSync as AnyObject),
                        forKeyedSubscript: "deflateSync" as NSString)
 
-        // inflateSync(buf) → Buffer
-        let inflateSync: @convention(block) (JSValue) -> Any? = { [weak self] input in
-            guard let self else { return nil }
-            let bytes = JSRuntime.bytesForZlibInput(input)
-            guard let out = JSRuntime.zlibDecompress(bytes, format: .zlib) else {
-                return self.throwJS("zlib inflate failed")
-            }
-            return self.bufferFromBytes(out)
+        let inflateSync = bridge("inflate") { input in
+            JSRuntime.zlibDecompress(JSRuntime.bytesForZlibInput(input), format: .zlib)
         }
         zlib.setObject(block(inflateSync as AnyObject),
                        forKeyedSubscript: "inflateSync" as NSString)
 
-        // deflateRawSync / inflateRawSync — raw deflate (no header).
-        let deflateRawSync: @convention(block) (JSValue) -> Any? = { [weak self] input in
-            guard let self else { return nil }
-            let bytes = JSRuntime.bytesForZlibInput(input)
-            guard let out = JSRuntime.zlibCompress(bytes, format: .raw) else {
-                return self.throwJS("zlib deflateRaw failed")
-            }
-            return self.bufferFromBytes(out)
+        let deflateRawSync = bridge("deflateRaw") { input in
+            JSRuntime.zlibCompress(JSRuntime.bytesForZlibInput(input), format: .raw)
         }
         zlib.setObject(block(deflateRawSync as AnyObject),
                        forKeyedSubscript: "deflateRawSync" as NSString)
 
-        let inflateRawSync: @convention(block) (JSValue) -> Any? = { [weak self] input in
-            guard let self else { return nil }
-            let bytes = JSRuntime.bytesForZlibInput(input)
-            guard let out = JSRuntime.zlibDecompress(bytes, format: .raw) else {
-                return self.throwJS("zlib inflateRaw failed")
-            }
-            return self.bufferFromBytes(out)
+        let inflateRawSync = bridge("inflateRaw") { input in
+            JSRuntime.zlibDecompress(JSRuntime.bytesForZlibInput(input), format: .raw)
         }
         zlib.setObject(block(inflateRawSync as AnyObject),
                        forKeyedSubscript: "inflateRawSync" as NSString)
 
         return zlib
+    }
+
+    /// Map a zlib return code (Z_DATA_ERROR, Z_BUF_ERROR, …) to its
+    /// Node-style symbolic name. Used as the `.code` on the JS Error
+    /// thrown from a failed compress/decompress.
+    fileprivate static func zlibCodeName(_ rc: Int32) -> String {
+        switch rc {
+        case Z_STREAM_ERROR: return "Z_STREAM_ERROR"
+        case Z_DATA_ERROR:   return "Z_DATA_ERROR"
+        case Z_MEM_ERROR:    return "Z_MEM_ERROR"
+        case Z_BUF_ERROR:    return "Z_BUF_ERROR"
+        case Z_VERSION_ERROR: return "Z_VERSION_ERROR"
+        default:             return "Z_ERRNO"
+        }
+    }
+
+    fileprivate static func zlibDescription(_ rc: Int32) -> String {
+        switch rc {
+        case Z_STREAM_ERROR:  return "invalid stream state"
+        case Z_DATA_ERROR:    return "incorrect data check / corrupted input"
+        case Z_MEM_ERROR:     return "not enough memory"
+        case Z_BUF_ERROR:     return "no progress is possible"
+        case Z_VERSION_ERROR: return "zlib version mismatch"
+        default:              return "zlib failed (rc=\(rc))"
+        }
     }
 
     private func bufferFromBytes(_ bytes: [UInt8]) -> JSValue {
@@ -124,9 +138,23 @@ private enum ZlibFormat {
     }
 }
 
+/// Result of a single zlib compress/decompress attempt. Carries the
+/// rc and `stream.msg` along with the bytes so the JS side can throw
+/// a Node-shaped Error with a useful diagnostic.
+enum JSResult {
+    case ok([UInt8])
+    case err(rc: Int32, message: String?)
+}
+
+extension JSResult {
+    static func err(_ rc: Int32, _ message: String?) -> JSResult {
+        .err(rc: rc, message: message)
+    }
+}
+
 extension JSRuntime {
 
-    fileprivate static func zlibCompress(_ src: [UInt8], format: ZlibFormat) -> [UInt8]? {
+    fileprivate static func zlibCompress(_ src: [UInt8], format: ZlibFormat) -> JSResult {
         var stream = z_stream()
         let level = Int32(Z_DEFAULT_COMPRESSION)
         let initRC = deflateInit2_(
@@ -138,11 +166,11 @@ extension JSRuntime {
             ZLIB_VERSION,
             Int32(MemoryLayout<z_stream>.size)
         )
-        guard initRC == Z_OK else { return nil }
+        guard initRC == Z_OK else { return .err(initRC, zlibStreamMessage(&stream)) }
         defer { deflateEnd(&stream) }
 
         var output: [UInt8] = []
-        return src.withUnsafeBufferPointer { srcBuf -> [UInt8]? in
+        return src.withUnsafeBufferPointer { srcBuf -> JSResult in
             stream.next_in = UnsafeMutablePointer(mutating: srcBuf.baseAddress)
             stream.avail_in = UInt32(srcBuf.count)
 
@@ -155,13 +183,15 @@ extension JSRuntime {
                 }
                 let written = chunk.count - Int(stream.avail_out)
                 output.append(contentsOf: chunk[..<written])
-                if rc == Z_STREAM_END { return output }
-                if rc != Z_OK && rc != Z_BUF_ERROR { return nil }
+                if rc == Z_STREAM_END { return .ok(output) }
+                if rc != Z_OK && rc != Z_BUF_ERROR {
+                    return .err(rc, zlibStreamMessage(&stream))
+                }
             }
         }
     }
 
-    fileprivate static func zlibDecompress(_ src: [UInt8], format: ZlibFormat) -> [UInt8]? {
+    fileprivate static func zlibDecompress(_ src: [UInt8], format: ZlibFormat) -> JSResult {
         var stream = z_stream()
         let initRC = inflateInit2_(
             &stream,
@@ -169,11 +199,11 @@ extension JSRuntime {
             ZLIB_VERSION,
             Int32(MemoryLayout<z_stream>.size)
         )
-        guard initRC == Z_OK else { return nil }
+        guard initRC == Z_OK else { return .err(initRC, zlibStreamMessage(&stream)) }
         defer { inflateEnd(&stream) }
 
         var output: [UInt8] = []
-        return src.withUnsafeBufferPointer { srcBuf -> [UInt8]? in
+        return src.withUnsafeBufferPointer { srcBuf -> JSResult in
             stream.next_in = UnsafeMutablePointer(mutating: srcBuf.baseAddress)
             stream.avail_in = UInt32(srcBuf.count)
 
@@ -186,10 +216,20 @@ extension JSRuntime {
                 }
                 let written = chunk.count - Int(stream.avail_out)
                 output.append(contentsOf: chunk[..<written])
-                if rc == Z_STREAM_END { return output }
-                if rc != Z_OK { return nil }
+                if rc == Z_STREAM_END { return .ok(output) }
+                if rc != Z_OK {
+                    return .err(rc, zlibStreamMessage(&stream))
+                }
             }
         }
+    }
+
+    /// Pull the human-readable diagnostic out of `stream.msg`, which
+    /// zlib points at a static C string when something goes wrong
+    /// (e.g. "incorrect header check"). Nil when zlib didn't set one.
+    private static func zlibStreamMessage(_ stream: UnsafePointer<z_stream>) -> String? {
+        guard let cstr = stream.pointee.msg else { return nil }
+        return String(cString: cstr)
     }
 }
 #endif


### PR DESCRIPTION
## Summary
Make uncaught errors look like Node and never reference our internal rewrites — so syntax and runtime errors are actionable for humans and LLMs alike.

- **No rewriter leakage.** `ESMRewriter` pads each replacement with newlines whenever the matched original spanned more lines than the template, so multi-line `import { ... }` blocks no longer shift downstream line numbers. The CommonJS module wrapper now runs on the same line as user line 1, so JSC stack frames map directly back to the original `.js` / `.mjs` file.
- **Node-style code frames.** `runFile` passes the absolute path as `sourceURL`, and the top-level exception handler reads that file and prints `path:line / source / ^` ahead of the message and stack — same shape Node uses, including for `SyntaxError`.
- **Structured native-bridge errors.** Every Swift bridge that surfaces an error now throws a JS Error decorated with `.code` / `.errno` / `.syscall` / `.path` / `.cmd` / `.status` / `.stdout` / `.stderr` as appropriate. POSIX errno is extracted from `NSError`/`NSUnderlyingErrorKey` and mapped to Node names: `ENOENT`, `EACCES`, `EEXIST`, `ENOTDIR`, etc. `URLError` maps to `ENOTFOUND`/`ETIMEDOUT`/`ECONNREFUSED`/`ABORT_ERR`/…; zlib failures expose `Z_DATA_ERROR` and the actual `stream.msg` ("incorrect header check") instead of "zlib gunzip failed"; unknown digest gets `ERR_OSSL_EVP_UNSUPPORTED`; missing modules get `MODULE_NOT_FOUND`.

### Before / after
```
$ swift-js script.js   # before
SyntaxError: Unexpected token
    at <wrapper>:N

$ swift-js script.js   # after
/abs/path/script.js:3
  return 42;

SyntaxError: Cannot use abbreviated destructuring syntax for keyword 'return'.
```

```js
// before:  err.code === undefined,  err.message === "The file doesn't exist"
// after:
fs.readFileSync('/no/such')
// → ENOENT: no such file or directory, open '/no/such'
//   err.code === 'ENOENT', err.errno === -2,
//   err.syscall === 'open', err.path === '/no/such'
```

## Test plan
- [x] `swift test --filter SwiftJSCoreTests` — all 82 tests pass.
- [x] Manual: runtime error produces accurate code-frame + stack pointing at the original file (no wrapper line shift).
- [x] Manual: multi-line ESM `import { a, b, c } from './x'` followed by a throw later in the file reports the throw's original line number.
- [x] Manual: error inside a `require`d CommonJS module shows the module's filename and the user's line (no `(function(exports, …) {` leak).
- [x] Manual: `fs.readFileSync` / `statSync` / `mkdirSync` / `unlinkSync` / `readdirSync` / `appendFileSync` all throw with `code: 'ENOENT'` etc.
- [x] Manual: `cp.execSync('exit 7')` throws with `e.code === 7`, `e.status === 7`, `e.cmd`, `e.stdout`, `e.stderr`.
- [x] Manual: `zlib.gunzipSync(notGzip)` → `e.code === 'Z_DATA_ERROR'`, `e.message` includes `incorrect header check`.
- [x] Manual: `crypto.createHash('bogus')` → `e.code === 'ERR_OSSL_EVP_UNSUPPORTED'`.
- [x] Manual: `require('does-not-exist')` → `e.code === 'MODULE_NOT_FOUND'`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)