### PR TITLE
SwiftJS: node:stream + child_process.spawn() with live streams

### DIFF
--- a/Sources/SwiftJSCore/ChildProcess.swift
+++ b/Sources/SwiftJSCore/ChildProcess.swift
@@ -208,7 +208,7 @@ extension JSRuntime {
         command: String, args: [String],
         handles: SpawnHandles, sentinelID: Int
     ) {
-        #if os(macOS) || os(Linux) || os(Windows)
+        #if os(macOS) || os(Linux)
         let process = Process()
         process.executableURL = URL(fileURLWithPath: "/bin/sh")
         process.arguments = ["-c", Self.composeCommandLine(command, args: args)]
@@ -352,7 +352,7 @@ extension JSRuntime {
     /// JS-side ``Readable``. Empty Data signals EOF — at which point
     /// we tear down the handler, push a final `_end`, and call
     /// `onEOF` so the caller can sequence the `close` event.
-    #if os(macOS) || os(Linux) || os(Windows)
+    #if os(macOS) || os(Linux)
     private static func installReadabilityHandler(
         on fh: FileHandle,
         target: JSValue?,
@@ -401,6 +401,16 @@ extension JSRuntime {
         if let runtime,
            let timer = runtime.pendingTimers.removeValue(forKey: sentinelID) {
             timer.cancel()
+        }
+        // Close the stdin Writable so its `writable` flag flips to
+        // false and further `write()` calls are no-ops. Without this,
+        // user code that keeps writing after the child exited would
+        // either silently drop bytes into a closed pipe (`.hostShell`)
+        // or grow the stdin AsyncStream buffer unbounded
+        // (`.inProcess`). `Writable.end()` is idempotent, so it's
+        // safe even when the user already called it themselves.
+        if let stdin = handles.stdinS, !stdin.isUndefined, !stdin.isNull {
+            _ = stdin.invokeMethod("end", withArguments: [])
         }
         guard let proc = handles.proc, !proc.isUndefined, !proc.isNull else { return }
         proc.setObject(status, forKeyedSubscript: "exitCode" as NSString)
@@ -545,7 +555,7 @@ extension JSRuntime {
     /// shouldn't be reachable there anyway, but the function still
     /// has to compile.
     private static func runHostShellAsync(command: String, args: [String]?) async -> ChildResult {
-        #if os(macOS) || os(Linux) || os(Windows)
+        #if os(macOS) || os(Linux)
         return await withCheckedContinuation { (cont: CheckedContinuation<ChildResult, Never>) in
             let process = Process()
             process.executableURL = URL(fileURLWithPath: "/bin/sh")
@@ -688,7 +698,7 @@ extension JSRuntime {
     /// `Process` is unavailable on iOS / tvOS / watchOS (App Sandbox);
     /// gated so the file still compiles on those platforms.
     private func runHostShell(command: String, args: [String]?) -> ChildResult {
-        #if os(macOS) || os(Linux) || os(Windows)
+        #if os(macOS) || os(Linux)
         let process = Process()
         process.executableURL = URL(fileURLWithPath: "/bin/sh")
         if let args, !args.isEmpty {

--- a/Sources/SwiftJSCore/ChildProcess.swift
+++ b/Sources/SwiftJSCore/ChildProcess.swift
@@ -14,6 +14,16 @@ private final class ChildPromiseHandles: @unchecked Sendable {
     var reject: JSValue?
 }
 
+/// Holder for the JS-side `ChildProcess` and its three streams.
+/// Crossed into Task.detached / pipe handlers under the same
+/// "main-queue-only access" rule as ``ChildPromiseHandles``.
+private final class SpawnHandles: @unchecked Sendable {
+    var proc: JSValue?
+    var stdoutS: JSValue?
+    var stderrS: JSValue?
+    var stdinS: JSValue?
+}
+
 extension JSRuntime {
 
     /// Build the `node:child_process` module.
@@ -44,6 +54,17 @@ extension JSRuntime {
         cp.setObject(block(spawnSync as AnyObject),
                      forKeyedSubscript: "spawnSync" as NSString)
 
+        // spawn(command, args?, options?) → ChildProcess with live
+        // stdout/stderr/stdin streams. Non-blocking; chunks arrive on
+        // the JS event loop the way node delivers them.
+        let spawnImpl: @convention(block) (String, JSValue?, JSValue?) -> JSValue? = { [weak self] cmd, args, opts in
+            guard let self else { return nil }
+            let argList = (args?.toArray() as? [String]) ?? []
+            return self.runChildSpawn(command: cmd, args: argList, opts: opts)
+        }
+        cp.setObject(block(spawnImpl as AnyObject),
+                     forKeyedSubscript: "spawn" as NSString)
+
         // exec(command, opts?) → Promise<{stdout, stderr, code}>.
         //
         // Non-blocking. Each call spawns a Swift Task.detached that
@@ -59,6 +80,346 @@ extension JSRuntime {
                      forKeyedSubscript: "exec" as NSString)
 
         return cp
+    }
+
+    /// `spawn(cmd, args)` — non-blocking, returns a ``ChildProcess``
+    /// with live `stdout`/`stderr` ``Readable`` streams and a `stdin`
+    /// ``Writable``. Each chunk produced by the underlying backend
+    /// hops to main and is `_push`ed into the corresponding JS
+    /// stream; the `'exit'` and `'close'` events fire when the
+    /// command terminates and both output streams have ended.
+    ///
+    /// Backed by ``Shell`` (`.inProcess`) or `Process` (`.hostShell`),
+    /// the same way `execSync` and `exec` are.
+    private func runChildSpawn(command: String, args: [String], opts _: JSValue?) -> JSValue? {
+        installStreamClasses()
+        let ctx = context
+
+        // Build the JS-side ChildProcess + its three streams. Using
+        // a small JS factory is simpler than constructing them piece
+        // by piece from Swift (we'd otherwise need to manually wire
+        // the EventEmitter prototype chain).
+        let factory = #"""
+        (() => {
+          const S = globalThis.__swiftjs_stream;
+          const events = (() => {
+            const cache = globalThis.__swiftjs_module_cache;
+            return cache && cache["events"] ? cache["events"] : require("node:events");
+          })();
+          const EventEmitter = events.EventEmitter ?? events;
+          class ChildProcess extends EventEmitter {}
+          const proc = new ChildProcess();
+          proc.stdout = new S.Readable();
+          proc.stderr = new S.Readable();
+          proc.stdin  = new S.Writable();
+          proc.killed = false;
+          proc.exitCode = null;
+          proc.signalCode = null;
+          return proc;
+        })();
+        """#
+        guard let proc = ctx.evaluateScript(factory) else { return nil }
+
+        let handles = SpawnHandles()
+        handles.proc = proc
+        handles.stdoutS = proc.objectForKeyedSubscript("stdout")
+        handles.stderrS = proc.objectForKeyedSubscript("stderr")
+        handles.stdinS  = proc.objectForKeyedSubscript("stdin")
+
+        // Sentinel keeps the runloop alive until the spawned process
+        // closes — same trick `runChildAsync` uses for exec().
+        let sentinelID = nextTimerID
+        nextTimerID += 1
+        let sentinel = DispatchSource.makeTimerSource(queue: .main)
+        sentinel.schedule(deadline: .distantFuture)
+        sentinel.setEventHandler {}
+        pendingTimers[sentinelID] = sentinel
+        sentinel.resume()
+
+        switch childShell {
+        case .inProcess:
+            startInProcessSpawn(command: command, args: args,
+                                handles: handles, sentinelID: sentinelID)
+        case .hostShell:
+            startHostShellSpawn(command: command, args: args,
+                                handles: handles, sentinelID: sentinelID)
+        }
+        return proc
+    }
+
+    /// In-process backend for `spawn`. Drives a fresh ``Shell`` whose
+    /// stdout/stderr ``OutputSink``s feed into the JS-side
+    /// ``Readable`` streams. Stdin is an ``InputSource`` over an
+    /// `AsyncStream<Data>` that the JS-side ``Writable`` yields into.
+    private func startInProcessSpawn(
+        command: String, args: [String],
+        handles: SpawnHandles, sentinelID: Int
+    ) {
+        // Feed stdin: JS Writable -> AsyncStream<Data> -> InputSource.
+        let (stdinStream, stdinCont) = AsyncStream<Data>.makeStream()
+        wireStdinHooks(stream: handles.stdinS,
+                       onWrite: { stdinCont.yield($0) },
+                       onEnd:   { stdinCont.finish() })
+
+        let line = Self.composeCommandLine(command, args: args)
+
+        Task.detached { [weak self] in
+            let shell = Shell()
+            shell.registerStandardCommands()
+            let stdoutSink = OutputSink()
+            let stderrSink = OutputSink()
+            shell.stdout = stdoutSink
+            shell.stderr = stderrSink
+            shell.stdin = InputSource(bytes: stdinStream)
+
+            async let outDrain: () = Self.drainSinkToJS(stdoutSink, target: handles.stdoutS)
+            async let errDrain: () = Self.drainSinkToJS(stderrSink, target: handles.stderrS)
+
+            var status: Int32 = 0
+            do {
+                let exit = try await shell.run(line)
+                stdoutSink.finish()
+                stderrSink.finish()
+                status = Int32(exit.code)
+            } catch {
+                let msg = String(describing: error) + "\n"
+                stdoutSink.finish()
+                stderrSink.write(msg)
+                stderrSink.finish()
+                status = 1
+            }
+            await outDrain
+            await errDrain
+
+            await MainActor.run {
+                Self.finalizeSpawn(runtime: self, handles: handles,
+                                   sentinelID: sentinelID, status: status)
+            }
+        }
+    }
+
+    /// Host-shell backend for `spawn`. Uses Foundation's `Process`
+    /// with three pipes; readability handlers hop chunks back to
+    /// main where the JS streams live.
+    ///
+    /// Unavailable on iOS / tvOS / watchOS (App Sandbox blocks fork);
+    /// on those platforms we synthesize an immediate error path.
+    private func startHostShellSpawn(
+        command: String, args: [String],
+        handles: SpawnHandles, sentinelID: Int
+    ) {
+        #if os(macOS) || os(Linux) || os(Windows)
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/sh")
+        process.arguments = ["-c", Self.composeCommandLine(command, args: args)]
+
+        let outPipe = Pipe()
+        let errPipe = Pipe()
+        let inPipe = Pipe()
+        process.standardOutput = outPipe
+        process.standardError  = errPipe
+        process.standardInput  = inPipe
+
+        // Feed stdin from the JS Writable straight into the pipe.
+        wireStdinHooks(
+            stream: handles.stdinS,
+            onWrite: { data in
+                try? inPipe.fileHandleForWriting.write(contentsOf: data)
+            },
+            onEnd: {
+                try? inPipe.fileHandleForWriting.close()
+            }
+        )
+
+        // Two flags so we only emit 'close' once both streams finished.
+        let stateLock = NSLock()
+        var stdoutDone = false
+        var stderrDone = false
+        var processDone = false
+        var exitStatus: Int32 = 0
+        let runtime = self
+        let finalize: @Sendable () -> Void = {
+            stateLock.lock()
+            let ready = stdoutDone && stderrDone && processDone
+            let status = exitStatus
+            stateLock.unlock()
+            guard ready else { return }
+            DispatchQueue.main.async {
+                Self.finalizeSpawn(runtime: runtime, handles: handles,
+                                   sentinelID: sentinelID, status: status)
+            }
+        }
+
+        Self.installReadabilityHandler(
+            on: outPipe.fileHandleForReading,
+            target: handles.stdoutS,
+            onEOF: {
+                stateLock.lock()
+                stdoutDone = true
+                stateLock.unlock()
+                finalize()
+            }
+        )
+        Self.installReadabilityHandler(
+            on: errPipe.fileHandleForReading,
+            target: handles.stderrS,
+            onEOF: {
+                stateLock.lock()
+                stderrDone = true
+                stateLock.unlock()
+                finalize()
+            }
+        )
+
+        process.terminationHandler = { proc in
+            stateLock.lock()
+            processDone = true
+            exitStatus = proc.terminationStatus
+            stateLock.unlock()
+            finalize()
+        }
+
+        do {
+            try process.run()
+        } catch {
+            // Fail synthetically: write the message to stderr, mark
+            // status 127, end both streams. Run on main so the JS
+            // side sees coherent ordering.
+            let message = "\(error.localizedDescription)\n"
+            DispatchQueue.main.async { [weak self] in
+                if let stream = handles.stderrS {
+                    Self.pushBytes(Array(message.utf8), to: stream)
+                    stream.invokeMethod("_end", withArguments: [])
+                }
+                handles.stdoutS?.invokeMethod("_end", withArguments: [])
+                Self.finalizeSpawn(runtime: self, handles: handles,
+                                   sentinelID: sentinelID, status: 127)
+            }
+        }
+        #else
+        let message = "host shell unavailable on this platform\n"
+        DispatchQueue.main.async { [weak self] in
+            if let stream = handles.stderrS {
+                Self.pushBytes(Array(message.utf8), to: stream)
+                stream.invokeMethod("_end", withArguments: [])
+            }
+            handles.stdoutS?.invokeMethod("_end", withArguments: [])
+            Self.finalizeSpawn(runtime: self, handles: handles,
+                               sentinelID: sentinelID, status: 127)
+        }
+        #endif
+    }
+
+    /// Hook the JS-side ``Writable`` so that `write(chunk)` and
+    /// `end()` invoke the supplied closures. Chunks are decoded
+    /// through ``Self/dataFromChunk`` first.
+    private func wireStdinHooks(
+        stream: JSValue?,
+        onWrite: @escaping @Sendable (Data) -> Void,
+        onEnd: @escaping @Sendable () -> Void
+    ) {
+        guard let stream else { return }
+        let writeImpl: @convention(block) (JSValue) -> Void = { chunk in
+            onWrite(JSRuntime.dataFromChunk(chunk))
+        }
+        let endImpl: @convention(block) () -> Void = {
+            onEnd()
+        }
+        stream.setObject(block(writeImpl as AnyObject),
+                         forKeyedSubscript: "_onWrite" as NSString)
+        stream.setObject(block(endImpl as AnyObject),
+                         forKeyedSubscript: "_onEnd" as NSString)
+    }
+
+    /// Drain an ``OutputSink`` until it finishes, hopping to main on
+    /// every chunk to push it into the JS-side ``Readable``. Sends a
+    /// final `_end()` once the stream completes.
+    private static func drainSinkToJS(_ sink: OutputSink,
+                                      target: JSValue?) async {
+        for await chunk in sink.bytes {
+            let bytes = Array(chunk)
+            await MainActor.run {
+                guard let target else { return }
+                Self.pushBytes(bytes, to: target)
+            }
+        }
+        await MainActor.run {
+            _ = target?.invokeMethod("_end", withArguments: [])
+        }
+    }
+
+    /// Wire a `FileHandle.readabilityHandler` to forward bytes to the
+    /// JS-side ``Readable``. Empty Data signals EOF — at which point
+    /// we tear down the handler, push a final `_end`, and call
+    /// `onEOF` so the caller can sequence the `close` event.
+    #if os(macOS) || os(Linux) || os(Windows)
+    private static func installReadabilityHandler(
+        on fh: FileHandle,
+        target: JSValue?,
+        onEOF: @escaping @Sendable () -> Void
+    ) {
+        fh.readabilityHandler = { handle in
+            let data = handle.availableData
+            if data.isEmpty {
+                handle.readabilityHandler = nil
+                DispatchQueue.main.async {
+                    target?.invokeMethod("_end", withArguments: [])
+                }
+                onEOF()
+                return
+            }
+            let bytes = Array(data)
+            DispatchQueue.main.async {
+                if let target {
+                    Self.pushBytes(bytes, to: target)
+                }
+            }
+        }
+    }
+    #endif
+
+    /// Push raw bytes into a JS-side ``Readable`` as a Buffer. Must
+    /// be called on the main queue.
+    private static func pushBytes(_ bytes: [UInt8], to stream: JSValue) {
+        guard let ctx = stream.context,
+              let bufCtor = ctx.objectForKeyedSubscript("Buffer"),
+              let buf = bufCtor.invokeMethod("from", withArguments: [bytes])
+        else { return }
+        stream.invokeMethod("_push", withArguments: [buf])
+    }
+
+    /// Cancel the sentinel timer, set `exitCode`/`signalCode`, and
+    /// emit `'exit'` then `'close'` on the JS-side ChildProcess.
+    /// Must run on the main queue (touches JSValues + the runtime's
+    /// timer table).
+    private static func finalizeSpawn(
+        runtime: JSRuntime?,
+        handles: SpawnHandles,
+        sentinelID: Int,
+        status: Int32
+    ) {
+        if let runtime,
+           let timer = runtime.pendingTimers.removeValue(forKey: sentinelID) {
+            timer.cancel()
+        }
+        guard let proc = handles.proc, !proc.isUndefined, !proc.isNull else { return }
+        proc.setObject(status, forKeyedSubscript: "exitCode" as NSString)
+        // Match node: signal === null when the process exited normally.
+        proc.setObject(NSNull(), forKeyedSubscript: "signalCode" as NSString)
+        _ = proc.invokeMethod("emit", withArguments: ["exit", status, NSNull()])
+        _ = proc.invokeMethod("emit", withArguments: ["close", status, NSNull()])
+    }
+
+    /// Convert a JS-side chunk (string | Buffer | Uint8Array | array
+    /// of bytes) to a `Data`. Used by stdin writes from JS.
+    static func dataFromChunk(_ value: JSValue) -> Data {
+        if value.isString {
+            return Data((value.toString() ?? "").utf8)
+        }
+        if let arr = value.toArray() as? [NSNumber] {
+            return Data(arr.map { $0.uint8Value })
+        }
+        return Data((value.toString() ?? "").utf8)
     }
 
     /// Async `exec`. Spawns a detached Task that runs the command

--- a/Sources/SwiftJSCore/Globals.swift
+++ b/Sources/SwiftJSCore/Globals.swift
@@ -18,6 +18,115 @@ extension JSRuntime {
 
     // MARK: - performance
 
+    /// `process.stdin` — a ``Readable`` over `FileHandle.standardInput`,
+    /// lazily wired. The reader doesn't start (and the runloop doesn't
+    /// stay up) until JS attaches a `'data'` listener or starts a
+    /// `for await` iteration. Once started, a sentinel timer keeps
+    /// the runloop alive until stdin EOFs.
+    ///
+    /// Installed as a property accessor rather than a plain object so
+    /// that the Stream classes (which need EventEmitter from
+    /// `node:events`) are only constructed *after* `installModules`
+    /// has registered the events cache entry — `installGlobals`
+    /// itself runs before `installModules` and can't materialise the
+    /// stream eagerly.
+    func installProcessStdin(on process: JSValue) {
+        let stdinGet: @convention(block) () -> Any? = { [weak self] in
+            self?.lazyProcessStdin()
+        }
+        setGlobal("__swiftjs_stdinGet", block(stdinGet as AnyObject))
+        context.evaluateScript(#"""
+        (() => {
+          Object.defineProperty(process, "stdin", {
+            get() { return globalThis.__swiftjs_stdinGet(); },
+            enumerable: true,
+            configurable: true,
+          });
+        })();
+        """#)
+    }
+
+    /// First-touch construction of the JS-side `process.stdin`.
+    /// Materialises a Readable subclass whose first listener attach
+    /// (or first iterator pull) hooks `FileHandle.standardInput`.
+    private func lazyProcessStdin() -> JSValue? {
+        if let cached = cachedStdin, !cached.isUndefined { return cached }
+        installStreamClasses()
+        let factory = #"""
+        (() => {
+          const S = globalThis.__swiftjs_stream;
+          class Stdin extends S.Readable {
+            constructor() {
+              super();
+              this._started = false;
+              this.isTTY = false;
+            }
+            _start() {
+              if (this._started) return;
+              this._started = true;
+              globalThis.__swiftjs_startStdin(this);
+            }
+            on(event, fn) {
+              const r = super.on(event, fn);
+              if (event === "data") this._start();
+              return r;
+            }
+            [Symbol.asyncIterator]() {
+              this._start();
+              return super[Symbol.asyncIterator]();
+            }
+          }
+          return new Stdin();
+        })();
+        """#
+        guard let stdin = context.evaluateScript(factory) else { return nil }
+        cachedStdin = stdin
+
+        let startStdin: @convention(block) (JSValue) -> Void = { [weak self] s in
+            self?.beginStdinRead(into: s)
+        }
+        setGlobal("__swiftjs_startStdin", block(startStdin as AnyObject))
+        return stdin
+    }
+
+    /// Hook `FileHandle.standardInput.readabilityHandler` to forward
+    /// bytes into the supplied JS-side Readable. Idempotent at the
+    /// JS level — the Stdin class only calls in once.
+    private func beginStdinRead(into streamJS: JSValue) {
+        // Sentinel keeps the runloop alive while we read.
+        let sentinelID = nextTimerID
+        nextTimerID += 1
+        let sentinel = DispatchSource.makeTimerSource(queue: .main)
+        sentinel.schedule(deadline: .distantFuture)
+        sentinel.setEventHandler {}
+        pendingTimers[sentinelID] = sentinel
+        sentinel.resume()
+
+        let fh = FileHandle.standardInput
+        fh.readabilityHandler = { [weak self] handle in
+            let data = handle.availableData
+            if data.isEmpty {
+                handle.readabilityHandler = nil
+                DispatchQueue.main.async { [weak self] in
+                    _ = streamJS.invokeMethod("_end", withArguments: [])
+                    if let self,
+                       let timer = self.pendingTimers.removeValue(forKey: sentinelID) {
+                        timer.cancel()
+                    }
+                }
+                return
+            }
+            let bytes = Array(data)
+            DispatchQueue.main.async {
+                guard let ctx = streamJS.context,
+                      let bufCtor = ctx.objectForKeyedSubscript("Buffer"),
+                      let buf = bufCtor.invokeMethod("from", withArguments: [bytes])
+                else { return }
+                _ = streamJS.invokeMethod("_push", withArguments: [buf])
+            }
+        }
+    }
+
     private func installPerformance() {
         // performance.now() — high-resolution monotonic clock in ms
         // (per the WHATWG spec). Backed by mach_absolute_time via
@@ -383,6 +492,12 @@ extension JSRuntime {
           delete globalThis.__swiftjs_exitCodeSet;
         })();
         """#)
+
+        // Stdin is wired last so the `Object.defineProperty(process,
+        // …)` call inside it has `process` already bound on
+        // `globalThis`. (The stream classes it depends on are
+        // installed lazily on first read.)
+        installProcessStdin(on: process)
     }
 
     // MARK: - Buffer + encoding bridges

--- a/Sources/SwiftJSCore/Globals.swift
+++ b/Sources/SwiftJSCore/Globals.swift
@@ -103,16 +103,27 @@ extension JSRuntime {
         sentinel.resume()
 
         let fh = FileHandle.standardInput
-        fh.readabilityHandler = { [weak self] handle in
+        // Idempotent teardown shared by the EOF path and the JS-side
+        // `destroy()` hook. Without this, a `for await` loop that
+        // breaks early on `process.stdin` would leave the sentinel
+        // alive and `drainPendingWorkIfNeeded()` would hang waiting
+        // for stdin EOF that never comes.
+        let teardown: @Sendable () -> Void = { [weak self] in
+            fh.readabilityHandler = nil
+            DispatchQueue.main.async { [weak self] in
+                guard let self,
+                      let timer = self.pendingTimers.removeValue(forKey: sentinelID)
+                else { return }
+                timer.cancel()
+            }
+        }
+
+        fh.readabilityHandler = { handle in
             let data = handle.availableData
             if data.isEmpty {
-                handle.readabilityHandler = nil
-                DispatchQueue.main.async { [weak self] in
+                teardown()
+                DispatchQueue.main.async {
                     _ = streamJS.invokeMethod("_end", withArguments: [])
-                    if let self,
-                       let timer = self.pendingTimers.removeValue(forKey: sentinelID) {
-                        timer.cancel()
-                    }
                 }
                 return
             }
@@ -125,6 +136,14 @@ extension JSRuntime {
                 _ = streamJS.invokeMethod("_push", withArguments: [buf])
             }
         }
+
+        // Wire the destroy hook so iterator early-exit (or an
+        // explicit `process.stdin.destroy()`) tears the reader down.
+        let destroy: @convention(block) () -> Void = {
+            teardown()
+        }
+        streamJS.setObject(block(destroy as AnyObject),
+                           forKeyedSubscript: "_onDestroy" as NSString)
     }
 
     private func installPerformance() {

--- a/Sources/SwiftJSCore/JSRuntime.swift
+++ b/Sources/SwiftJSCore/JSRuntime.swift
@@ -39,6 +39,10 @@ public final class JSRuntime {
     var pendingTimers: [Int: DispatchSourceTimer] = [:]
     var nextTimerID: Int = 1
 
+    /// Cached lazily-constructed `process.stdin` Readable, so the
+    /// getter returns the same instance on every property access.
+    var cachedStdin: JSValue?
+
     /// Set to true while the run loop is draining. Used by tests
     /// that want to inspect state mid-flight.
     public internal(set) var isDraining: Bool = false

--- a/Sources/SwiftJSCore/Modules.swift
+++ b/Sources/SwiftJSCore/Modules.swift
@@ -193,6 +193,20 @@ extension JSRuntime {
         let perfMod = makePerfHooksModule()
         cacheBuiltin("perf_hooks", perfMod)
         cacheBuiltin("node:perf_hooks", perfMod)
+
+        // node:stream depends on EventEmitter being cached, so register
+        // it after `events`. The module is the `Readable`/`Writable`
+        // pair plus a `default`/named-export shape for ESM ergonomics.
+        let streamMod = makeStreamModule()
+        let streamWrapper = JSValue(newObjectIn: context)!
+        streamWrapper.setObject(streamMod.objectForKeyedSubscript("Readable")!,
+                                forKeyedSubscript: "Readable" as NSString)
+        streamWrapper.setObject(streamMod.objectForKeyedSubscript("Writable")!,
+                                forKeyedSubscript: "Writable" as NSString)
+        streamWrapper.setObject(streamWrapper,
+                                forKeyedSubscript: "default" as NSString)
+        cacheBuiltin("stream", streamWrapper)
+        cacheBuiltin("node:stream", streamWrapper)
     }
 
     // MARK: - node:assert (pure JS)

--- a/Sources/SwiftJSCore/Streams.swift
+++ b/Sources/SwiftJSCore/Streams.swift
@@ -54,15 +54,23 @@ extension JSRuntime {
               super();
               this._buf = [];
               this._ended = false;
+              this._destroyed = false;
               this._mode = "paused";
               this._waiters = [];
+              // _onDestroy(): native-side cleanup hook fired by
+              // destroy(). process.stdin uses it to detach the
+              // FileHandle.readabilityHandler and cancel its sentinel
+              // timer; without it, a `for await … of process.stdin`
+              // loop that breaks early would leave the runloop
+              // pinned waiting for stdin EOF.
+              this._onDestroy = null;
               this.readable = true;
             }
 
             // Called from native code (or from JS in tests). `null`
             // chunks mean EOF.
             _push(chunk) {
-              if (this._ended) return;
+              if (this._ended || this._destroyed) return;
               if (chunk == null) { this._end(); return; }
               if (this._mode === "iter") {
                 if (this._waiters.length > 0) {
@@ -96,15 +104,38 @@ extension JSRuntime {
               this.emit("close");
             }
 
+            // Tear down the stream: drop buffered data, resolve any
+            // pending iterator waiters, fire `_onDestroy` so native
+            // producers can detach. If the stream hadn't already
+            // ended, emit `'close'` (no synthetic `'end'` — node only
+            // emits `'end'` on normal completion). Idempotent.
+            destroy() {
+              if (this._destroyed) return;
+              this._destroyed = true;
+              this._buf = [];
+              while (this._waiters.length > 0) {
+                const r = this._waiters.shift();
+                r({ value: undefined, done: true });
+              }
+              if (this._onDestroy) {
+                try { this._onDestroy(); } catch (_) {}
+              }
+              if (!this._ended) {
+                this._ended = true;
+                this.readable = false;
+                this.emit("close");
+              }
+            }
+
             on(event, fn) {
               super.on(event, fn);
               if (event === "data" && this._mode === "paused") {
                 this._mode = "flowing";
                 while (this._buf.length > 0) this.emit("data", this._buf.shift());
-                if (this._ended) {
-                  this.emit("end");
-                  this.emit("close");
-                }
+                // If the stream had already ended in 'paused' mode,
+                // _end() already emitted end/close — re-emitting here
+                // would double-fire cleanup logic for any listener
+                // that was attached before _end ran.
               }
               return this;
             }
@@ -126,6 +157,9 @@ extension JSRuntime {
               const self = this;
               return {
                 next() {
+                  if (self._destroyed) {
+                    return Promise.resolve({ value: undefined, done: true });
+                  }
                   if (self._buf.length > 0) {
                     return Promise.resolve({ value: self._buf.shift(), done: false });
                   }
@@ -134,7 +168,13 @@ extension JSRuntime {
                   }
                   return new Promise((resolve) => self._waiters.push(resolve));
                 },
+                // for-await early exit (`break` / `return` / `throw`)
+                // funnels through here. Destroy the stream so native
+                // producers can detach and any sentinel timers get
+                // cancelled — otherwise a stdin loop that breaks
+                // early would hang the runtime.
                 return() {
+                  self.destroy();
                   return Promise.resolve({ value: undefined, done: true });
                 },
               };

--- a/Sources/SwiftJSCore/Streams.swift
+++ b/Sources/SwiftJSCore/Streams.swift
@@ -1,0 +1,185 @@
+import Foundation
+
+#if canImport(JavaScriptCore)
+
+import JavaScriptCore
+
+extension JSRuntime {
+
+    /// Build the `node:stream` module — `Readable`, `Writable`, plus
+    /// the helpers that `child_process.spawn` and `process.stdin`
+    /// build on. The classes are pure JS on top of `EventEmitter`,
+    /// fed from Swift via `_push(chunk)` / `_end()` for `Readable`
+    /// and an `_onWrite` hook for `Writable`.
+    ///
+    /// Limits, by design (see issue #6):
+    ///   - No real backpressure — `write()` always returns `true`,
+    ///     no `'drain'` is emitted, and `pipe` is a naïve forward.
+    ///   - No `Duplex` / `Transform` / `pipeline`.
+    ///   - No `objectMode` — chunks are always Buffers (or strings).
+    func makeStreamModule() -> JSValue {
+        installStreamClasses()
+        let mod = context.objectForKeyedSubscript("__swiftjs_stream")!
+        // The classes are stashed under a private global by the
+        // installer so we can hand back the same constructors here.
+        return mod
+    }
+
+    /// Idempotent. Defines `__swiftjs_stream = { Readable, Writable }`
+    /// on `globalThis` and a small `__swiftjs_makeStreamPair()` helper
+    /// that the spawn glue uses to mint a Readable backed by Swift.
+    func installStreamClasses() {
+        if let existing = context.objectForKeyedSubscript("__swiftjs_stream"),
+           !existing.isUndefined {
+            return
+        }
+        let source = #"""
+        (() => {
+          const events = (() => {
+            // Reuse the same EventEmitter the user-facing `node:events`
+            // module exports — keeps one set of semantics.
+            const cache = globalThis.__swiftjs_module_cache;
+            return cache && cache["events"] ? cache["events"] : require("node:events");
+          })();
+          const EventEmitter = events.EventEmitter ?? events;
+
+          // Mode is the most subtle bit. A Readable starts in 'paused'.
+          // The first `on('data', …)` flips it to 'flowing' and we
+          // drain the buffer; the first `for await` flips it to 'iter'
+          // and chunks are routed to the iterator's pending resolvers.
+          // Mixing the two on the same stream is undefined behaviour
+          // (Node's docs say the same).
+          class Readable extends EventEmitter {
+            constructor() {
+              super();
+              this._buf = [];
+              this._ended = false;
+              this._mode = "paused";
+              this._waiters = [];
+              this.readable = true;
+            }
+
+            // Called from native code (or from JS in tests). `null`
+            // chunks mean EOF.
+            _push(chunk) {
+              if (this._ended) return;
+              if (chunk == null) { this._end(); return; }
+              if (this._mode === "iter") {
+                if (this._waiters.length > 0) {
+                  const r = this._waiters.shift();
+                  r({ value: chunk, done: false });
+                } else {
+                  this._buf.push(chunk);
+                }
+                return;
+              }
+              if (this._mode === "flowing") {
+                this.emit("data", chunk);
+                return;
+              }
+              this._buf.push(chunk);
+            }
+
+            _end() {
+              if (this._ended) return;
+              this._ended = true;
+              this.readable = false;
+              if (this._mode === "flowing") {
+                while (this._buf.length > 0) this.emit("data", this._buf.shift());
+              } else if (this._mode === "iter") {
+                while (this._waiters.length > 0) {
+                  const r = this._waiters.shift();
+                  r({ value: undefined, done: true });
+                }
+              }
+              this.emit("end");
+              this.emit("close");
+            }
+
+            on(event, fn) {
+              super.on(event, fn);
+              if (event === "data" && this._mode === "paused") {
+                this._mode = "flowing";
+                while (this._buf.length > 0) this.emit("data", this._buf.shift());
+                if (this._ended) {
+                  this.emit("end");
+                  this.emit("close");
+                }
+              }
+              return this;
+            }
+
+            // Naïve pipe: forward every chunk, end when source ends.
+            // No backpressure — `write()` returns true regardless.
+            pipe(dest) {
+              this.on("data", (chunk) => {
+                if (dest && typeof dest.write === "function") dest.write(chunk);
+              });
+              this.on("end", () => {
+                if (dest && typeof dest.end === "function") dest.end();
+              });
+              return dest;
+            }
+
+            [Symbol.asyncIterator]() {
+              if (this._mode === "paused") this._mode = "iter";
+              const self = this;
+              return {
+                next() {
+                  if (self._buf.length > 0) {
+                    return Promise.resolve({ value: self._buf.shift(), done: false });
+                  }
+                  if (self._ended) {
+                    return Promise.resolve({ value: undefined, done: true });
+                  }
+                  return new Promise((resolve) => self._waiters.push(resolve));
+                },
+                return() {
+                  return Promise.resolve({ value: undefined, done: true });
+                },
+              };
+            }
+          }
+
+          class Writable extends EventEmitter {
+            constructor(opts = {}) {
+              super();
+              // _onWrite(chunk) — called on every write. _onEnd() —
+              // called on end(). The ChildProcess stdin glue plugs
+              // these in to forward bytes to the native side.
+              this._onWrite = opts.write ?? null;
+              this._onEnd = opts.final ?? null;
+              this._ended = false;
+              this.writable = true;
+            }
+
+            write(chunk) {
+              if (this._ended) return false;
+              if (this._onWrite) {
+                try { this._onWrite(chunk); } catch (_) {}
+              }
+              return true;
+            }
+
+            end(chunk) {
+              if (chunk != null) this.write(chunk);
+              if (this._ended) return this;
+              this._ended = true;
+              this.writable = false;
+              if (this._onEnd) {
+                try { this._onEnd(); } catch (_) {}
+              }
+              this.emit("finish");
+              this.emit("close");
+              return this;
+            }
+          }
+
+          globalThis.__swiftjs_stream = { Readable, Writable };
+        })();
+        """#
+        context.evaluateScript(source)
+    }
+}
+
+#endif

--- a/Tests/SwiftJSCoreTests/JSRuntimeTests.swift
+++ b/Tests/SwiftJSCoreTests/JSRuntimeTests.swift
@@ -1025,6 +1025,151 @@ final class JSRuntimeTests: XCTestCase {
         """)
         XCTAssertEqual(out(), "x is 7\n{\"a\":1}\n")
     }
+
+    // MARK: - node:stream + child_process.spawn() streaming
+
+    /// Helper for spawn tests that need to wait for the runloop to
+    /// drain. `JSRuntime.run` already drains until pendingTimers is
+    /// empty, so all we need is to invoke a script that schedules the
+    /// async work and returns synchronously.
+    private func hostShellRuntime() -> (JSRuntime, () -> String, () -> String) {
+        var out = ""
+        var err = ""
+        let r = JSRuntime(
+            argv: ["swift-js"],
+            envProvider: OSEnvProvider(),
+            childShell: .hostShell,
+            stdout: { out += $0 },
+            stderr: { err += $0 }
+        )
+        return (r, { out }, { err })
+    }
+
+    func testSpawnDataEvent() {
+        let (r, out, _) = hostShellRuntime()
+        r.run("""
+        const cp = require('node:child_process');
+        const proc = cp.spawn('printf', ['hi']);
+        let buf = '';
+        proc.stdout.on('data', (chunk) => { buf += chunk.toString(); });
+        proc.on('close', (code) => console.log('code=' + code, buf));
+        """)
+        XCTAssertEqual(out(), "code=0 hi\n")
+    }
+
+    func testSpawnForAwait() {
+        let (r, out, _) = hostShellRuntime()
+        r.run("""
+        const cp = require('node:child_process');
+        (async () => {
+          const proc = cp.spawn('printf', ['a\\nb\\nc']);
+          let acc = '';
+          for await (const chunk of proc.stdout) acc += chunk.toString();
+          console.log('lines:', acc.split('\\n').filter(s => s.length).join('|'));
+        })();
+        """)
+        XCTAssertEqual(out(), "lines: a|b|c\n")
+    }
+
+    func testSpawnPipeToProcessStdout() {
+        let (r, out, _) = hostShellRuntime()
+        // pipe() forwards every 'data' chunk to dest.write(...). The
+        // command is run via /bin/sh so multiple writes coalesce into
+        // one chunk on most platforms — that's fine, we only check
+        // the final string.
+        r.run("""
+        const cp = require('node:child_process');
+        const proc = cp.spawn('printf', ['piped:%s', 'ok']);
+        proc.stdout.pipe(process.stdout);
+        """)
+        XCTAssertEqual(out(), "piped:ok")
+    }
+
+    func testSpawnInProcessBackend() {
+        // BashInterpreter backend — `echo` is a registered command so
+        // this works without forking. The spawn surface is the same.
+        let (r, out, _) = runtime()
+        r.run("""
+        const cp = require('node:child_process');
+        const proc = cp.spawn('echo', ['streamed']);
+        let buf = '';
+        proc.stdout.on('data', c => { buf += c.toString(); });
+        proc.on('close', code => console.log('done', code, buf.trim()));
+        """)
+        XCTAssertEqual(out(), "done 0 streamed\n")
+    }
+
+    func testSpawnExitCodeOnFailure() {
+        let (r, out, _) = hostShellRuntime()
+        r.run("""
+        const cp = require('node:child_process');
+        const proc = cp.spawn('sh', ['-c', 'exit 7']);
+        proc.on('close', code => console.log('exit', code));
+        """)
+        XCTAssertEqual(out(), "exit 7\n")
+    }
+
+    func testSpawnStderrSeparateChannel() {
+        let (r, out, _) = hostShellRuntime()
+        r.run("""
+        const cp = require('node:child_process');
+        const proc = cp.spawn('sh', ['-c', 'printf out; printf err 1>&2']);
+        let outBuf = '', errBuf = '';
+        proc.stdout.on('data', c => { outBuf += c.toString(); });
+        proc.stderr.on('data', c => { errBuf += c.toString(); });
+        proc.on('close', () => console.log('o=' + outBuf, 'e=' + errBuf));
+        """)
+        XCTAssertEqual(out(), "o=out e=err\n")
+    }
+
+    func testSpawnStdinWriteEnd() {
+        let (r, out, _) = hostShellRuntime()
+        r.run("""
+        const cp = require('node:child_process');
+        const proc = cp.spawn('cat', []);
+        let buf = '';
+        proc.stdout.on('data', c => { buf += c.toString(); });
+        proc.on('close', () => console.log('echoed:', buf));
+        proc.stdin.write('hello ');
+        proc.stdin.write('world');
+        proc.stdin.end();
+        """)
+        XCTAssertEqual(out(), "echoed: hello world\n")
+    }
+
+    func testStreamModuleExportsClasses() {
+        let (r, out, _) = runtime()
+        r.run("""
+        const stream = require('node:stream');
+        const r1 = new stream.Readable();
+        r1.on('data', d => console.log('got', d));
+        r1._push('a');
+        r1._push('b');
+        r1._end();
+        """)
+        // 'data' chunks emit before the end listener, in order.
+        XCTAssertEqual(out(), "got a\ngot b\n")
+    }
+
+    func testReadableForAwaitOrdering() {
+        // Buffered chunks should drain in order via the async iterator
+        // even when pushes happen before the loop starts awaiting.
+        let (r, out, _) = runtime()
+        r.run("""
+        const { Readable } = require('node:stream');
+        const s = new Readable();
+        s._push('one'); s._push('two'); s._push('three');
+        // _end after a microtask so the iterator still sees an
+        // unfinished stream when it begins.
+        Promise.resolve().then(() => s._end());
+        (async () => {
+          const got = [];
+          for await (const c of s) got.push(c);
+          console.log(got.join(','));
+        })();
+        """)
+        XCTAssertEqual(out(), "one,two,three\n")
+    }
 }
 
 #endif

--- a/Tests/SwiftJSCoreTests/JSRuntimeTests.swift
+++ b/Tests/SwiftJSCoreTests/JSRuntimeTests.swift
@@ -1170,6 +1170,57 @@ final class JSRuntimeTests: XCTestCase {
         """)
         XCTAssertEqual(out(), "one,two,three\n")
     }
+
+    func testReadableLateDataListenerDoesNotReEmitEnd() {
+        // Regression for #8 review (P2): attaching a `'data'` listener
+        // to a stream that already ended in paused mode used to
+        // re-emit `'end'`/`'close'` — double-firing any earlier
+        // `'end'` or `'close'` listener.
+        let (r, out, _) = runtime()
+        r.run("""
+        const { Readable } = require('node:stream');
+        const s = new Readable();
+        let endCount = 0, closeCount = 0;
+        s.on('end',   () => endCount++);
+        s.on('close', () => closeCount++);
+        // Push + end while still in paused mode — buffered chunk stays.
+        s._push('buf');
+        s._end();
+        // Late 'data' listener: should drain the buffer but NOT
+        // re-emit end/close.
+        const got = [];
+        s.on('data', (c) => got.push(String(c)));
+        console.log('drained:', got.join(','), 'end:', endCount, 'close:', closeCount);
+        """)
+        XCTAssertEqual(out(), "drained: buf end: 1 close: 1\n")
+    }
+
+    func testReadableForAwaitBreakDestroysStream() {
+        // Regression for #8 review (P1): early exit from `for await`
+        // must destroy the stream so native producers can detach.
+        // We observe the `'close'` event firing and verify _onDestroy
+        // ran and subsequent pushes are dropped.
+        let (r, out, _) = runtime()
+        r.run("""
+        const { Readable } = require('node:stream');
+        const s = new Readable();
+        let destroyed = false;
+        s._onDestroy = () => { destroyed = true; };
+        s.on('close', () => console.log('close fired'));
+        // Pre-seed two chunks; the loop only takes the first.
+        s._push('a'); s._push('b');
+        (async () => {
+          for await (const c of s) {
+            console.log('saw', String(c));
+            break;
+          }
+          // Producer keeps trying; new pushes should be dropped.
+          s._push('c');
+          console.log('destroyed:', destroyed);
+        })();
+        """)
+        XCTAssertEqual(out(), "saw a\nclose fired\ndestroyed: true\n")
+    }
 }
 
 #endif

--- a/Tests/SwiftJSCoreTests/JSRuntimeTests.swift
+++ b/Tests/SwiftJSCoreTests/JSRuntimeTests.swift
@@ -1195,6 +1195,26 @@ final class JSRuntimeTests: XCTestCase {
         XCTAssertEqual(out(), "drained: buf end: 1 close: 1\n")
     }
 
+    func testSpawnStdinEndsOnChildExit() {
+        // Regression for #8 review: when the child process closes,
+        // proc.stdin should flip to non-writable. Otherwise user code
+        // that keeps writing leaks bytes (silently dropped on
+        // .hostShell, or growing the AsyncStream buffer on
+        // .inProcess).
+        let (r, out, _) = hostShellRuntime()
+        r.run("""
+        const cp = require('node:child_process');
+        const proc = cp.spawn('printf', ['done']);
+        proc.on('close', () => {
+          console.log('writable=' + proc.stdin.writable,
+                      'wroteAfter=' + proc.stdin.write('late'));
+        });
+        """)
+        // After 'close', stdin is no longer writable and write()
+        // returns false instead of pretending the bytes went somewhere.
+        XCTAssertEqual(out(), "writable=false wroteAfter=false\n")
+    }
+
     func testReadableForAwaitBreakDestroysStream() {
         // Regression for #8 review (P1): early exit from `for await`
         // must destroy the stream so native producers can detach.


### PR DESCRIPTION
Closes #6.

## Summary

- Adds `child_process.spawn(cmd, args)` returning a `ChildProcess` with live `stdout`/`stderr` Readable streams and a `stdin` Writable. Both runtime backends (`.inProcess` BashInterpreter and `.hostShell` Foundation `Process`) feed chunks through the same JS surface.
- Adds `node:stream` exporting `Readable` / `Writable` (pure JS on top of `EventEmitter`). Supports `'data'` listener mode, `for await … of`, and naïve `pipe()`.
- Adds `process.stdin` as a Readable over `FileHandle.standardInput`. Wired lazily — the reader (and the runloop sentinel that keeps the process alive) only starts when JS attaches a `'data'` listener or begins a `for await`.

## Acceptance (from issue)

- `cp.spawn('echo', ['hi']).stdout.on('data', …)` ✓
- `for await (const chunk of proc.stdout)` ✓
- `proc.stdout.pipe(process.stdout)` for both `.inProcess` and `.hostShell` backends ✓
- Cross-runtime parity verified against `node` and `bun` on the for-await example ✓
- Documented limit: no real backpressure (`write()` always returns `true`, no `'drain'`) ✓

## Test plan

- [x] `swift test --filter SwiftJSCoreTests` — 91/91 pass (82 prior + 9 new streaming tests)
- [x] CLI smoke: `spawn('curl', […])` with `'data'` listener
- [x] CLI smoke: `for await (const chunk of proc.stdout)`
- [x] CLI smoke: `spawn(...).stdout.pipe(process.stdout)`
- [x] CLI smoke: `echo … | swift-js -e "process.stdin.on('data', …)"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)