### PR TITLE
Integrate SwiftScript as #!/usr/bin/env swift-script interpreter

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -113,24 +113,48 @@ jobs:
         # are gated to non-Apple-mobile via per-target platforms,
         # but they DO compile on Windows and need their respective
         # libs available.
+        #
+        # zlib alias: SwiftPorts' CZlib modulemap declares `link "z"`
+        # (mirroring libarchive's `linkedLibrary("z")`), which lld-link
+        # translates to `z.lib`. vcpkg's `x64-windows-static-md` triplet
+        # ships zlib as `zs.lib`; older triplets / releases shipped
+        # `zlib.lib`. Either way we copy the chosen artifact to `z.lib`
+        # so lld-link resolves cleanly. This mirrors the alias step in
+        # the upstream SwiftPorts workflow.
         shell: pwsh
         run: |
           & "$env:VCPKG_INSTALLATION_ROOT\vcpkg.exe" install zlib bzip2 liblzma zstd lz4 --triplet x64-windows-static-md
+          $base = "$env:VCPKG_INSTALLATION_ROOT\installed\x64-windows-static-md"
+          Write-Host "vcpkg .lib inventory under $base (recursive):"
+          Get-ChildItem "$base" -Recurse -Filter "*.lib" -ErrorAction SilentlyContinue |
+            ForEach-Object { Write-Host "  $($_.FullName)" }
+          $candidates = @("zs.lib", "zlib.lib", "libzlib.lib", "libz.lib", "z.lib")
+          $zlibLib = $null
+          foreach ($name in $candidates) {
+            $p = Join-Path "$base\lib" $name
+            if (Test-Path $p) { $zlibLib = $p; break }
+          }
+          if (-not $zlibLib) {
+            throw "no zlib library found under $base\lib (looked for: $($candidates -join ', '))"
+          }
+          Write-Host "Using zlib library: $zlibLib"
+          if ($zlibLib -ne (Join-Path "$base\lib" "z.lib")) {
+            Copy-Item -Force $zlibLib "$base\lib\z.lib"
+          }
+          "VCPKG_BASE=$base" | Out-File -FilePath $env:GITHUB_ENV -Append
       - name: Build (Windows)
         shell: pwsh
         run: |
-          $base = "$env:VCPKG_INSTALLATION_ROOT\installed\x64-windows-static-md"
           swift build --build-tests -v `
-            -Xcc "-I$base\include" `
-            -Xlinker "/LIBPATH:$base\lib"
+            -Xcc "-I$env:VCPKG_BASE\include" `
+            -Xlinker "/LIBPATH:$env:VCPKG_BASE\lib"
         continue-on-error: true
       - name: Test (Windows)
         shell: pwsh
         run: |
-          $base = "$env:VCPKG_INSTALLATION_ROOT\installed\x64-windows-static-md"
           swift test -v --skip-build --no-parallel `
-            -Xcc "-I$base\include" `
-            -Xlinker "/LIBPATH:$base\lib"
+            -Xcc "-I$env:VCPKG_BASE\include" `
+            -Xlinker "/LIBPATH:$env:VCPKG_BASE\lib"
         continue-on-error: true
 
   # Uses skiptools/swift-android-action which wraps the swift.org Android

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,11 +13,14 @@ for how the pieces fit together.
 
 - `swift build` — compile.
 - `swift test --no-parallel` — full suite. **Always run before
-  committing.** Currently ~1780 tests; failures from your change
+  committing.** Currently ~1758 tests; failures from your change
   are the first signal something's off.
 - `swift test --no-parallel --filter <name>` — single suite.
 - `swift run swift-bash exec [--sandbox PATH] /dev/stdin <<<'…'`
   — fastest way to verify behaviour end-to-end during development.
+- `swift-bash exec ./script.swift` — runs a Swift script through
+  the in-process SwiftScript interpreter (registered by default).
+  See [Docs/SwiftScript.md](Docs/SwiftScript.md).
 
 ## Where things live
 
@@ -149,6 +152,10 @@ file:
   semantics changed.
 - New CLI flag → [Docs/CLI.md](Docs/CLI.md).
 - Architectural change → [Docs/InterpreterArchitecture.md](Docs/InterpreterArchitecture.md).
+- New script-shebang interpreter → mention in
+  [Docs/BashInterpreter.md](Docs/BashInterpreter.md) (the
+  "Script-shebang interpreters" section). The SwiftScript bridge
+  has its own page at [Docs/SwiftScript.md](Docs/SwiftScript.md).
 
 ## Commits
 

--- a/Docs/BashInterpreter.md
+++ b/Docs/BashInterpreter.md
@@ -200,6 +200,38 @@ For typed argument parsing via Swift Argument Parser, depend on
 [`BashCommandKit`](BashCommandKit.md) and conform to
 `ParsableBashCommand`.
 
+## Script-shebang interpreters
+
+`./hello.swift` doesn't go through `commands[…]` — it's a path, not
+a command name. SwiftBash treats path-shaped tokens as candidate
+external scripts: it reads the file, parses the `#!`-shebang, and
+dispatches to a registered `ScriptInterpreter`.
+
+```swift
+shell.registerScriptInterpreter(name: "swift-script") { ctx in
+    // ctx.source has the leading "#!…" line stripped (newline kept,
+    // so line numbers in diagnostics still match the original file).
+    try await SwiftScriptInterpreter().eval(ctx.source,
+                                            fileName: ctx.scriptPath)
+    return .success
+}
+try await shell.run("/abs/path/to/hello.swift one two")
+// → ScriptInterpreterContext.argv = [scriptPath, "one", "two"]
+```
+
+`#!/usr/bin/env <name>` and `#!/usr/bin/env -S <name> --flag`
+shebangs are handled — the dispatcher walks past `env`'s flags and
+`KEY=value` pairs to resolve the real interpreter. Diagnostics
+follow bash conventions: missing file → 127, directory → 126,
+unrecognised shebang → falls through to `command not found`. The
+script runs in a fresh `Shell.copy()` so `$0` and positional
+parameters stay scoped.
+
+The official SwiftScript binding ships as the
+[`BashSwiftScript`](SwiftScript.md) library target. The
+`swift-bash exec` CLI auto-registers it; embedders opt in with
+`shell.registerSwiftScript()`.
+
 ## Limitations
 
 - **No subprocess execution.** Every command runs in-process via the

--- a/Docs/SwiftScript.md
+++ b/Docs/SwiftScript.md
@@ -1,0 +1,154 @@
+# SwiftScript integration
+
+`BashSwiftScript` is the library that wires
+[SwiftScript](https://github.com/Cocoanetics/SwiftScript) — a Swift
+tree-walking interpreter — into a SwiftBash `Shell` so a script
+with `#!/usr/bin/env swift-script` (or just `#!/usr/bin/env swift`)
+runs in-process via SwiftScript instead of returning
+`command not found`.
+
+```bash
+$ cat hello.swift
+#!/usr/bin/env swift-script
+let names = CommandLine.arguments.dropFirst()
+for name in names {
+    print("hello, \(name)")
+}
+
+$ chmod +x hello.swift
+
+$ swift-bash exec /dev/stdin <<'EOF'
+./hello.swift alice bob
+echo "exit=$?"
+EOF
+hello, alice
+hello, bob
+exit=0
+```
+
+## How it fits together
+
+SwiftScript and SwiftBash both run in-process and both read their
+host-touching surface — IO sinks, environment, sandbox, network
+policy, identity — from `ShellKit.Shell.current`. That shared
+contract is why the bridge is small: register a
+`ScriptInterpreter` for the `swift-script` / `swift` shebang, hand
+it the script body, and `print` / `FileManager` / `URLSession` /
+`ProcessInfo` / `exit(_:)` automatically flow through whatever
+shell SwiftBash has bound.
+
+```
+                         ┌── ShellKit.Shell.current ────────┐
+                         │  stdin / stdout / stderr         │
+   `./script.swift` ──▶  │  environment + scriptName + $@   │
+   bash dispatcher       │  sandbox  (URL gate)             │
+   (Shell+ExternalScript)│  networkConfig (URL allow-list)  │
+                         │  hostInfo (whoami / hostname)    │
+                         │  processTable + virtualPID       │
+                         └──────────────────────────────────┘
+                                        ▲
+                                        │ SwiftScript reads through
+                                        │ this same TaskLocal — no
+                                        │ per-call wiring needed.
+```
+
+## Embedding
+
+```swift
+import BashInterpreter
+import BashCommandKit
+import BashSwiftScript
+
+let shell = Shell()
+shell.registerStandardCommands()  // BashCommandKit
+shell.registerSwiftScript()       // swift-script + swift shebangs
+
+try await shell.run("/abs/path/to/script.swift arg1 arg2")
+```
+
+`registerSwiftScript()` accepts a `names:` parameter — by default
+`["swift-script", "swift"]` — so both `#!/usr/bin/env swift-script`
+and `#!/usr/bin/env swift` shebangs route to the same backend. Pass
+a custom list to opt out of one or the other.
+
+The `swift-bash exec` CLI calls `registerSwiftScript()` for you —
+script files with a Swift shebang work without any flag.
+
+## What flows through automatically
+
+Because SwiftScript reads `ShellKit.Shell.current` for its host
+surface, **every bash sandbox knob also confines a Swift script**:
+
+| Bash knob | What it does to a Swift script under `swift-script` |
+|---|---|
+| `Shell.stdout` / `.stderr` | `print` / runtime-error renders go to the same sinks. Capturing tests, `$(…)` substitution, `2>&1` all work. |
+| `Shell.stdin` | `readLine()` and the script's stdin reads pull from here, so `echo input \| ./script.swift` feeds the script. |
+| `Shell.environment` | `ProcessInfo.processInfo.environment[...]` reads from here — what `export FOO=bar` set in bash. |
+| `Shell.scriptName` + `positionalParameters` | `CommandLine.arguments` and `ProcessInfo.processInfo.arguments` mirror these — argv[0] = script path, argv[1..] = the rest of the command line. |
+| `Shell.sandbox` (URL gate) | `FileManager.default.fileExists(...)` / `String(contentsOfFile:)` / `URLSession.shared.data(from:)` etc. all call `Shell.current.sandbox?.authorize(_:)` before touching disk or the network. Outside-root paths throw into the script's `do/catch`. |
+| `Shell.networkConfig` (URL allow-list) | `URLSession.shared.data(from:)` enforces the allow-list and method gate. |
+| `Shell.hostInfo` | `ProcessInfo.processInfo.userName` / `.hostName` / `.processIdentifier` / `.processName` redirect through here — the script sees the synthetic identity, not the host's. |
+
+## Diagnostics
+
+- **Parse errors** print SwiftScript's caret-style diagnostics on
+  the bound shell's stderr, then exit `1`. Line numbers match the
+  original file (the shebang line is stripped but the trailing
+  newline is preserved, so what `swift` itself reports as line `N`
+  arrives as line `N` here too).
+- **Runtime errors** go through `Interpreter.renderRuntimeError(_:)`
+  for the same caret format, then exit `1`.
+- **`exit(N)`** unwinds the script and surfaces as `ExitStatus(N)`
+  to the bash dispatcher — `$?` after `./script.swift` reads the
+  script's chosen code.
+- **Cancellation** (e.g. `kill` against a backgrounded script)
+  arrives as `CancellationError` and is reported as exit code 143
+  (bash 128 + SIGTERM).
+
+## Subshell isolation
+
+The script runs inside `Shell.copy()` — a snapshot subshell — so
+`$0`, positional parameters, errexit toggling, and any environment
+`export`s done by the script don't leak back to the parent shell.
+Same rule as `bash FILE` semantics.
+
+## CLI
+
+```bash
+swift-bash exec ./script.swift arg1 arg2
+swift-bash exec --sandbox ~/work ./script.swift   # confined
+swift-bash exec --allow-url https://api.example.com/ ./script.swift
+```
+
+The `swift-bash exec` driver registers SwiftScript automatically.
+All `--sandbox`, `--allow-url`, and identity flags apply uniformly
+to bash and SwiftScript scripts.
+
+## Known limitations
+
+- **`--sandbox` confines escape but blocks all real disk IO from
+  SwiftScript.** The `--sandbox HOST_DIR` flag binds two things:
+  the legacy `Shell.fileSystem` overlay (used by bash builtins like
+  `cat` / `ls`, mounted at `/batch` so scripts see a virtual view)
+  AND the URL-gate `Shell.sandbox` (used by SwiftScript's
+  Foundation bridges, rooted at the canonical host path). The two
+  mechanisms haven't been unified yet — Foundation can't see the
+  bash overlay's `/batch` mount, so a SwiftScript that does
+  `FileManager.default.contents(atPath: "/batch/foo")` is denied
+  by the URL gate even though the file exists in the bash view.
+  Result: under `--sandbox`, SwiftScript scripts can compute and
+  print but can't usefully read or write through Foundation's file
+  APIs. Network, identity, and stdio still flow correctly. The
+  full unification is the migration target tracked in issue #10.
+
+- **Not every Foundation IO surface is gated yet.** The bridge
+  generator currently inserts `authorizePath` / `authorizeURL`
+  calls only on `FileManager`, `URLSession` (URL-arg methods),
+  `String` / `Data` file-IO inits, and explicit hand-rolled
+  bridges. Receivers like `FileHandle`, `Bundle`,
+  `OutputStream`/`InputStream`, `NSDictionary(contentsOf:)`, and
+  `URLSession` methods that take a `URLRequest` (instead of a
+  bare `URL`) aren't gated yet — a determined script can reach
+  the real filesystem through them. Tracked as the broader
+  "inventory + gate every IO-shaped Foundation method"
+  follow-up: issue #13.

--- a/Package.swift
+++ b/Package.swift
@@ -26,6 +26,7 @@ let package = Package(
         .library(name: "BashInterpreter", targets: ["BashInterpreter"]),
         .library(name: "BashCommandKit", targets: ["BashCommandKit"]),
         .library(name: "SwiftJSCore", targets: ["SwiftJSCore"]),
+        .library(name: "BashSwiftScript", targets: ["BashSwiftScript"]),
         .executable(name: "swift-bash", targets: ["swift-bash"]),
         // SwiftJS is a Node-shaped JS runtime built on Apple's
         // JavaScriptCore. Source files are gated on
@@ -59,6 +60,15 @@ let package = Package(
         // they participate fully in pipes / redirection / capture.
         // Pinned to `main` until SwiftPorts ships a tagged release.
         .package(url: "https://github.com/Cocoanetics/SwiftPorts",
+                 branch: "main"),
+        // SwiftScript — Swift tree-walking interpreter that reads
+        // its IO / FS / network / identity / exit through
+        // `ShellKit.Shell.current`. The `BashSwiftScript` target
+        // registers it as a `swift-script` / `swift` shebang
+        // interpreter so `./hello.swift` from a bash script (or
+        // `swift-bash exec hello.swift`) routes through it.
+        // Pinned to `main` until SwiftScript ships a tagged release.
+        .package(url: "https://github.com/Cocoanetics/SwiftScript",
                  branch: "main"),
     ],
     targets: [
@@ -152,6 +162,7 @@ let package = Package(
                 "BashSyntax",
                 "BashInterpreter",
                 "BashCommandKit",
+                "BashSwiftScript",
                 .product(name: "ArgumentParser", package: "swift-argument-parser"),
             ],
             path: "Sources/swift-bash"
@@ -218,6 +229,34 @@ let package = Package(
             ],
             path: "Tests/SwiftJSCoreTests",
             swiftSettings: [.swiftLanguageMode(.v5)]
+        ),
+
+        // ---- BashSwiftScript — Swift script-shebang interpreter ----
+        // Registers SwiftScript's `Interpreter` as the handler for
+        // `#!/usr/bin/env swift-script` (and `swift`) shebangs on a
+        // SwiftBash `Shell`. The bridge is thin because SwiftScript
+        // already routes its IO / FS / network / identity / exit
+        // through `ShellKit.Shell.current` — the same surface
+        // SwiftBash binds for its bash interpreter. Wire-up:
+        //
+        //   shell.registerStandardCommands()    // BashCommandKit
+        //   shell.registerSwiftScript()         // BashSwiftScript
+        //   try await shell.run("./script.swift")
+        .target(
+            name: "BashSwiftScript",
+            dependencies: [
+                "BashInterpreter",
+                .product(name: "SwiftScriptInterpreter", package: "SwiftScript"),
+            ],
+            path: "Sources/BashSwiftScript"
+        ),
+        .testTarget(
+            name: "BashSwiftScriptTests",
+            dependencies: [
+                "BashSwiftScript",
+                "BashInterpreter",
+            ],
+            path: "Tests/BashSwiftScriptTests"
         ),
     ]
 )

--- a/README.md
+++ b/README.md
@@ -40,7 +40,8 @@ try await shell.run("""
 | **`BashInterpreter`**  | Available  | Execute the AST in-process. Streaming pipelines, full bash 4.x semantics.  |
 | **`BashCommandKit`**   | Available  | Catalog of `ls`/`cat`/`grep`/`sed`/`find`/`curl`/… built on Swift Argument Parser. |
 | **`SwiftJSCore`**      | Available (Apple-only) | Node-style JavaScript runtime on JavaScriptCore. `require`, ESM `import`, `node:fs/path/os/crypto/zlib/child_process/…`, `fetch`, `Buffer`, timers, `AbortController`, `WebAssembly`. |
-| **`swift-bash`** (CLI) | Available  | `exec` and `parse` subcommands; sandbox flags for confined execution.       |
+| **`BashSwiftScript`**  | Available  | `#!/usr/bin/env swift-script` shebang dispatch via Cocoanetics' [SwiftScript](https://github.com/Cocoanetics/SwiftScript) tree-walking interpreter. IO / sandbox / identity flow through ShellKit, so a script honors the bash sandbox the same way `gh`/`jq`/etc. do. |
+| **`swift-bash`** (CLI) | Available  | `exec` and `parse` subcommands; sandbox flags for confined execution. Auto-registers SwiftScript so `./hello.swift` runs in-process. |
 | **`swift-js`** (CLI)   | Available (Apple-only) | Drop-in for `node` — `swift-js install` symlinks `node`/`bun` so existing `#!/usr/bin/env node` scripts run unchanged. |
 
 ## Component docs
@@ -53,6 +54,10 @@ try await shell.run("""
   `ls`/`cat`/`grep`-style command + how to add your own typed ones.
 - **[SwiftJS](Docs/SwiftJS.md)** — Node-style JavaScript runtime on
   JavaScriptCore. Embeddable + `swift-js` CLI shadow for `node`/`bun`.
+- **[SwiftScript](Docs/SwiftScript.md)** — `#!/usr/bin/env swift-script`
+  shebang dispatch routing through SwiftScript's tree-walking
+  interpreter. Wires output / stdin / sandbox / network / identity
+  through the bash shell's ShellKit context.
 - **[Sandboxing](Docs/Sandboxing.md)** — the four virtualisation axes
   (filesystem, network, processes, identity) and the `--sandbox` flag.
 - **[Networking](Docs/Networking.md)** — `curl`, the URL allow-list,

--- a/Sources/BashInterpreter/API/FileSystem.swift
+++ b/Sources/BashInterpreter/API/FileSystem.swift
@@ -287,4 +287,20 @@ public enum FileSystemError: Error, CustomStringConvertible, Sendable, Equatable
         case .io(let m):               return m
         }
     }
+
+    /// Bash-style short message — what `./script: <message>` should
+    /// print when this error fires probing or reading an explicit
+    /// command path. The path itself is supplied by the caller's
+    /// `errorLocationPrefix`, so this drops the path component to
+    /// avoid the redundant `:path: : <path>` reading.
+    public func shellMessage() -> String {
+        switch self {
+        case .notFound:         return "No such file or directory"
+        case .notADirectory:    return "Not a directory"
+        case .isADirectory:     return "Is a directory"
+        case .alreadyExists:    return "File exists"
+        case .permissionDenied: return "Permission denied"
+        case .io(let m):        return m
+        }
+    }
 }

--- a/Sources/BashInterpreter/API/ScriptInterpreter.swift
+++ b/Sources/BashInterpreter/API/ScriptInterpreter.swift
@@ -1,0 +1,88 @@
+import Foundation
+
+/// A pluggable interpreter the shell can hand a script's source to when
+/// it dispatches an executable file (e.g. `./hello.swift`) whose
+/// `#!`-shebang names this interpreter.
+///
+/// SwiftBash itself runs in-process — there is no `exec(2)` — so a
+/// shebang like `#!/usr/bin/env swift-script` cannot be honored by the
+/// kernel. Instead, embedders register a `ScriptInterpreter` for each
+/// shebang they want to support; when a path-like simple command turns
+/// out to be an executable file, the dispatcher looks up its
+/// interpreter and invokes ``run(scriptPath:source:argv:)``.
+///
+/// ```swift
+/// shell.registerScriptInterpreter(name: "swift-script") { ctx in
+///     // ctx.source has the leading "#!…" line replaced with "//…"
+///     // already, so SwiftSyntax-style parsers never see the shebang.
+///     try await SwiftScriptInterpreter().eval(ctx.source,
+///                                             fileName: ctx.scriptPath)
+///     return .success
+/// }
+/// ```
+///
+/// Every registered interpreter inherits the calling shell via
+/// `Shell.current` (TaskLocal), so the body can read environment,
+/// sandbox state, sinks, etc. without any explicit threading.
+public protocol ScriptInterpreter: Sendable {
+    /// Identifier matched against the basename of the shebang's
+    /// interpreter — `"swift"`, `"swift-script"`, `"python3"`. Multiple
+    /// interpreters can share a name; later registrations replace
+    /// earlier ones.
+    var name: String { get }
+
+    /// Execute `context.source` as a script. Implementations write to
+    /// `Shell.current.stdout` / `.stderr` and read positional
+    /// parameters from `Shell.current.positionalParameters` (set by the
+    /// dispatcher to `argv[1...]`).
+    func run(_ context: ScriptInterpreterContext) async throws -> ExitStatus
+}
+
+/// Inputs handed to a ``ScriptInterpreter``.
+///
+/// The shell reads the file off ``Shell/fileSystem``, strips the
+/// `#!`-line (rewritten as a `//`-comment so byte offsets and line
+/// numbers stay stable for diagnostics), and passes the result here.
+/// Most interpreters only need ``source``; ``scriptPath`` is exposed
+/// for diagnostic rendering, and ``shebang`` for interpreters that
+/// need to inspect their own argv (e.g. flag-bearing shebangs like
+/// `#!/usr/bin/env -S swift-script --strict`).
+public struct ScriptInterpreterContext: Sendable {
+    /// Absolute path the script was loaded from, as resolved by
+    /// ``Shell/resolvePath(_:)``. Forwarded to interpreters as a
+    /// `fileName:` for diagnostics.
+    public let scriptPath: String
+
+    /// Script source with the shebang line rewritten to `//…` so
+    /// downstream parsers never see `#!`. Byte offsets and line
+    /// numbers are preserved (only the leading two characters are
+    /// replaced).
+    public let source: String
+
+    /// Raw shebang line including the leading `#!`, minus the trailing
+    /// newline. `nil` when the file had no shebang.
+    public let shebang: String?
+
+    /// argv as the script would observe it: index 0 is the script
+    /// path, indices 1+ are the user-supplied arguments. Mirrors
+    /// Swift's `CommandLine.arguments`.
+    public let argv: [String]
+}
+
+/// A ``ScriptInterpreter`` backed by a closure — the short form for
+/// host-side registrations.
+public struct ClosureScriptInterpreter: ScriptInterpreter {
+    public let name: String
+    private let body: @Sendable (ScriptInterpreterContext) async throws -> ExitStatus
+
+    public init(name: String,
+                body: @Sendable @escaping (ScriptInterpreterContext) async throws -> ExitStatus)
+    {
+        self.name = name
+        self.body = body
+    }
+
+    public func run(_ context: ScriptInterpreterContext) async throws -> ExitStatus {
+        try await body(context)
+    }
+}

--- a/Sources/BashInterpreter/API/Shell+ScriptInterpreters.swift
+++ b/Sources/BashInterpreter/API/Shell+ScriptInterpreters.swift
@@ -1,0 +1,129 @@
+import Foundation
+
+extension Shell {
+
+    /// Register `interpreter` under its `name`, replacing any existing
+    /// entry with the same name. Used by the dispatcher to honor
+    /// `#!`-shebangs on path-invoked scripts (`./script.swift`,
+    /// `/abs/path/script.py`).
+    public func registerScriptInterpreter(_ interpreter: ScriptInterpreter) {
+        scriptInterpreters[interpreter.name] = interpreter
+    }
+
+    /// Closure-form registration — equivalent to wrapping `body` in a
+    /// ``ClosureScriptInterpreter``.
+    public func registerScriptInterpreter(
+        name: String,
+        _ body: @Sendable @escaping (ScriptInterpreterContext) async throws -> ExitStatus
+    ) {
+        scriptInterpreters[name] = ClosureScriptInterpreter(name: name, body: body)
+    }
+
+    /// Remove a previously-registered interpreter. Returns the removed
+    /// entry, or `nil` if no interpreter was registered under `name`.
+    @discardableResult
+    public func unregisterScriptInterpreter(_ name: String) -> ScriptInterpreter? {
+        scriptInterpreters.removeValue(forKey: name)
+    }
+}
+
+// MARK: - Shebang parsing
+
+/// Parse a `#!`-shebang line. Returns the interpreter basename and the
+/// raw argv as the kernel would assemble it for `execve` (interpreter
+/// path followed by interpreter args). Returns `nil` if `line` is not
+/// a valid shebang.
+///
+/// This honors the common `/usr/bin/env`-prefix pattern: a shebang
+/// like `#!/usr/bin/env swift-script --strict` reports its
+/// interpreter as `"swift-script"` rather than `"env"`, and keeps
+/// `--strict` as part of the interpreter argv. Both `env` and
+/// `env -S` (split-args) forms are handled.
+///
+/// Resolution rules:
+/// - Strip leading `#!` and any whitespace before the path.
+/// - Tokenise on whitespace (Linux's `binfmt_script` keeps everything
+///   after the first space as one argument; macOS / Darwin splits on
+///   whitespace. We follow Darwin's behaviour because that's the host
+///   SwiftBash typically targets, and `env -S` makes it portable).
+/// - If the interpreter is `env`, walk past `-S`, `-i`, and any
+///   `KEY=value` tokens and any `--` separator until we find the real
+///   interpreter, then treat that as the dispatch target.
+public func parseShebangLine(_ line: String) -> (interpreter: String, argv: [String])? {
+    guard line.hasPrefix("#!") else { return nil }
+    var rest = Substring(line.dropFirst(2))
+    while rest.first == " " || rest.first == "\t" {
+        rest.removeFirst()
+    }
+    let tokens = rest.split(whereSeparator: { $0 == " " || $0 == "\t" }).map(String.init)
+    guard !tokens.isEmpty else { return nil }
+    var argv = tokens
+    var idx = 0
+    let interpreterPath = argv[idx]
+    idx += 1
+    let interpreterBase = pathBasename(interpreterPath)
+    if interpreterBase != "env" {
+        return (interpreterBase, argv)
+    }
+    // env-prefix: skip over -S, -i, KEY=value, and `--` until the real
+    // interpreter token surfaces.
+    while idx < argv.count {
+        let tok = argv[idx]
+        if tok == "--" { idx += 1; break }
+        if tok.hasPrefix("-") {
+            // -S splits its single arg further (env -S "swift-script -O"),
+            // but we already split on whitespace upstream. So just step
+            // over the flag itself.
+            idx += 1
+            continue
+        }
+        if tok.contains("=") && !tok.hasPrefix("=") {
+            idx += 1
+            continue
+        }
+        break
+    }
+    guard idx < argv.count else { return nil }
+    let realInterpreter = argv[idx]
+    let realBase = pathBasename(realInterpreter)
+    // Reassemble argv as the kernel would for `execve`: the real
+    // interpreter path comes first, followed by its own args.
+    argv = Array(argv[idx...])
+    return (realBase, argv)
+}
+
+private func pathBasename(_ path: String) -> String {
+    if let slash = path.lastIndex(of: "/") {
+        return String(path[path.index(after: slash)...])
+    }
+    return path
+}
+
+/// Strip a leading `#!shebang` line so script interpreters never see
+/// it. The trailing newline is kept so subsequent line numbers stay
+/// in lock-step with the original file: `print("oops")` on physical
+/// line 2 of a shebang'd script still surfaces as "line 2" in
+/// interpreter diagnostics.
+///
+/// Comment syntax differs across languages (`#` for Python / shell,
+/// `//` for Swift / JS / C, `--` for Lua), so we don't try to rewrite
+/// `#!` into something language-specific. Stripping is the universal
+/// option: every language tolerates a blank first line.
+///
+/// Returns the source with the shebang line removed and the original
+/// shebang line (without trailing newline) when one was present.
+public func stripShebang(_ source: String) -> (source: String, shebang: String?) {
+    guard source.hasPrefix("#!") else { return (source, nil) }
+    let rest = source.dropFirst(2)
+    if let nl = rest.firstIndex(of: "\n") {
+        let shebangLine = "#!" + rest[..<nl]
+        // Drop the shebang content, keep the newline so line numbers
+        // below stay accurate. The body therefore begins with `\n`,
+        // and the original line 2 is still at line 2.
+        let stripped = String(rest[nl...])
+        return (stripped, shebangLine)
+    }
+    // Whole file is a shebang line with no trailing newline. Empty
+    // body, but surface the shebang for diagnostics.
+    return ("", "#!" + rest)
+}

--- a/Sources/BashInterpreter/API/Shell.swift
+++ b/Sources/BashInterpreter/API/Shell.swift
@@ -138,6 +138,17 @@ public final class Shell: ShellKit.Shell, @unchecked Sendable {
 
     var currentSource: String = ""
 
+    // MARK: - Script interpreters
+
+    /// Interpreters keyed by shebang basename — `"swift-script"`,
+    /// `"swift"`, `"python3"`. Consulted by the dispatcher when a
+    /// path-invoked simple command (`./script.swift`,
+    /// `/abs/script.foo`) is a regular file with a `#!`-shebang.
+    /// Empty by default; embedders register what they want to
+    /// support via ``registerScriptInterpreter(_:)`` /
+    /// ``registerScriptInterpreter(name:_:)``.
+    public var scriptInterpreters: [String: ScriptInterpreter] = [:]
+
     // MARK: - Filesystem
 
     /// The filesystem the shell reads and writes through. Defaults
@@ -389,6 +400,7 @@ public final class Shell: ShellKit.Shell, @unchecked Sendable {
         bash.shoptOptions = shoptOptions
         bash.traps = traps
         bash.currentSource = currentSource
+        bash.scriptInterpreters = scriptInterpreters
         return bash
     }
 

--- a/Sources/BashInterpreter/Execution/Shell+ExternalScript.swift
+++ b/Sources/BashInterpreter/Execution/Shell+ExternalScript.swift
@@ -1,0 +1,115 @@
+import Foundation
+
+extension Shell {
+
+    /// Try dispatching `argv[0]` as a path-invoked external script.
+    ///
+    /// Returns the script's exit status when handled (file exists, has
+    /// a `#!`-shebang, and an interpreter is registered for it).
+    /// Returns `nil` only when the candidate isn't path-shaped, or
+    /// when the file exists but has no recognised shebang — both fall
+    /// through to the caller's `command not found` branch.
+    ///
+    /// Behaviour mirrors the kernel's `binfmt_script` plus bash's own
+    /// permission-error reporting:
+    /// - token has no `/` → `nil` (treat as bare name, look up in PATH)
+    /// - non-existent file → `127`, `No such file or directory`
+    /// - directory or non-regular file → `126`, `Is a directory`
+    /// - regular file without the execute bit set → `126`,
+    ///   `Permission denied` (matches `bash ./script` when the file
+    ///   isn't `chmod +x`'d)
+    /// - filesystem error probing or reading the path (sandbox denial,
+    ///   real EACCES, IO error) → `126` with a permission-shaped
+    ///   diagnostic, NOT `command not found` — the path exists in the
+    ///   user's command line, masking the failure as a lookup miss is
+    ///   unhelpful
+    /// - file present but no shebang → `nil` (might be a binary; let
+    ///   the caller fall through)
+    /// - shebang names an interpreter that isn't registered → `nil`
+    func dispatchAsExternalScriptIfApplicable(
+        argv: [String]
+    ) async throws -> ExitStatus? {
+        guard !scriptInterpreters.isEmpty else { return nil }
+        guard let head = argv.first, looksLikePath(head) else { return nil }
+
+        let resolved = resolvePath(head)
+        let meta: FileMetadata?
+        do {
+            meta = try await fileSystem.metadata(resolved)
+        } catch let err as FileSystemError {
+            // The path is explicit (`./foo`, `/abs/path`); the user is
+            // asking us to run THIS file. Surface the underlying FS
+            // error as a 126 rather than masking it as a missing
+            // command.
+            stderr(
+                "\(errorLocationPrefix())\(head): \(err.shellMessage())\n")
+            return ExitStatus(126)
+        }
+        guard let meta else {
+            stderr(
+                "\(errorLocationPrefix())\(head): No such file or directory\n")
+            return ExitStatus(127)
+        }
+        if meta.kind == .directory {
+            stderr(
+                "\(errorLocationPrefix())\(head): Is a directory\n")
+            return ExitStatus(126)
+        }
+        // Bash refuses to execute a regular file without an execute
+        // bit set (`./script` → `Permission denied` exit 126). Match
+        // that here; otherwise we'd happily run a 0644 file the user
+        // never marked as runnable. Filesystems whose `metadata`
+        // doesn't track POSIX bits report mode 0 — treat those as
+        // executable so in-memory test fixtures and the virtual /bin
+        // overlay aren't blocked.
+        if meta.mode != 0, (meta.mode & 0o111) == 0 {
+            stderr(
+                "\(errorLocationPrefix())\(head): Permission denied\n")
+            return ExitStatus(126)
+        }
+        let data: Data
+        do {
+            data = try await fileSystem.readData(resolved)
+        } catch let err as FileSystemError {
+            // Same reasoning as the metadata branch above — surface
+            // a real read failure on an explicit path rather than
+            // hiding it as `command not found`.
+            stderr(
+                "\(errorLocationPrefix())\(head): \(err.shellMessage())\n")
+            return ExitStatus(126)
+        }
+        let raw = String(decoding: data, as: UTF8.self)
+        let (rewritten, shebangLine) = stripShebang(raw)
+        guard let shebangLine,
+              let parsed = parseShebangLine(shebangLine),
+              let interpreter = scriptInterpreters[parsed.interpreter]
+        else {
+            return nil
+        }
+
+        let context = ScriptInterpreterContext(
+            scriptPath: resolved,
+            source: rewritten,
+            shebang: shebangLine,
+            argv: [resolved] + Array(argv.dropFirst()))
+
+        // Run inside a fresh subshell — interpreters mutate
+        // `Shell.current.positionalParameters` and `scriptName` while
+        // executing, and we don't want those to leak into the parent.
+        // `Shell.copy()` is the single source of truth for what
+        // propagates; this stays consistent with `bash FILE` semantics.
+        let sub = copy()
+        sub.scriptName = resolved
+        sub.positionalParameters = Array(argv.dropFirst())
+        return try await sub.withCurrent {
+            try await interpreter.run(context)
+        }
+    }
+
+    /// A token "looks like a path" if it contains a `/` (relative or
+    /// absolute). Bare names like `swift-script` are looked up in the
+    /// command registry only — they're not paths to script files.
+    private func looksLikePath(_ token: String) -> Bool {
+        token.contains("/")
+    }
+}

--- a/Sources/BashInterpreter/Execution/Shell+Run.swift
+++ b/Sources/BashInterpreter/Execution/Shell+Run.swift
@@ -584,7 +584,13 @@ extension Shell {
 
         let result: ExitStatus
         do {
-            guard let command = commands[argv[0]] else {
+            if let command = commands[argv[0]] {
+                result = try await command.run(argv)
+            } else if let scriptResult =
+                try await dispatchAsExternalScriptIfApplicable(argv: argv)
+            {
+                result = scriptResult
+            } else {
                 // Match bash: report to stderr (with `script:line:`
                 // prefix), return 127, do not abort the script.
                 stderr("\(errorLocationPrefix())\(argv[0]): command not found\n")
@@ -593,7 +599,6 @@ extension Shell {
                 await drainProcessSubs(from: procSubFrame)
                 return ExitStatus(127)
             }
-            result = try await command.run(argv)
         } catch {
             restoreScope()
             restoreRedirects()

--- a/Sources/BashSwiftScript/Shell+SwiftScript.swift
+++ b/Sources/BashSwiftScript/Shell+SwiftScript.swift
@@ -1,0 +1,31 @@
+import BashInterpreter
+
+extension Shell {
+
+    /// Register SwiftScript under each of `names` so a path-invoked
+    /// script with a matching `#!`-shebang routes through it.
+    /// Defaults to `["swift-script", "swift"]` — both
+    /// `#!/usr/bin/env swift-script` and `#!/usr/bin/env swift`
+    /// shebangs go to the same backend.
+    ///
+    /// ```swift
+    /// let shell = Shell()
+    /// shell.registerStandardCommands()   // BashCommandKit
+    /// shell.registerSwiftScript()        // BashSwiftScript
+    /// try await shell.run("/abs/script.swift one two")
+    /// ```
+    ///
+    /// Each name gets its own ``SwiftScriptShellInterpreter``
+    /// instance so the registry's `[String: ScriptInterpreter]`
+    /// invariant holds (`interpreter.name == registryKey`). The
+    /// underlying SwiftScript ``Interpreter`` is constructed fresh
+    /// on every script invocation regardless, so no state leaks
+    /// between scripts.
+    public func registerSwiftScript(
+        names: [String] = ["swift-script", "swift"]
+    ) {
+        for name in names {
+            registerScriptInterpreter(SwiftScriptShellInterpreter(name: name))
+        }
+    }
+}

--- a/Sources/BashSwiftScript/SwiftScriptShellInterpreter.swift
+++ b/Sources/BashSwiftScript/SwiftScriptShellInterpreter.swift
@@ -1,0 +1,53 @@
+import BashInterpreter
+import SwiftScriptInterpreter
+
+/// SwiftBash's ``ScriptInterpreter`` adapter for SwiftScript.
+///
+/// Because SwiftScript reads its IO / FS / network / identity / exit
+/// through `ShellKit.Shell.current` — the same TaskLocal SwiftBash
+/// binds at every dispatch — the bridge collapses to construction +
+/// `evalScript(_:fileName:)`. Output / stderr / stdin / sandbox /
+/// identity all flow correctly without per-call wiring.
+///
+/// One fresh `Interpreter` per script: SwiftScript's interpreter
+/// holds extensive mutable state (declared types, scopes, bridges)
+/// that we don't want leaking between script invocations.
+public struct SwiftScriptShellInterpreter: ScriptInterpreter {
+    public let name: String
+
+    /// Default registration name — `swift-script`. The CLI binary
+    /// shipped by the SwiftScript package is named `swift-script`,
+    /// and a script written for it is conventionally launched via
+    /// `#!/usr/bin/env swift-script`. ``Shell/registerSwiftScript(names:)``
+    /// also registers under the bare `swift` shebang by default.
+    public init(name: String = "swift-script") {
+        self.name = name
+    }
+
+    public func run(
+        _ context: ScriptInterpreterContext
+    ) async throws -> ExitStatus {
+        let interpreter = Interpreter()
+        do {
+            return try await interpreter.evalScript(
+                context.source, fileName: context.scriptPath)
+        } catch let parseError as ParseError {
+            // Render the diagnostic via the interpreter's `error`
+            // closure (defaults to `Shell.current.stderr`) so it
+            // captures alongside script-side stderr writes.
+            interpreter.error(parseError.formatted)
+            if !parseError.formatted.hasSuffix("\n") {
+                interpreter.error("\n")
+            }
+            return ExitStatus(1)
+        } catch is CancellationError {
+            // Cooperative cancellation propagated from the parent
+            // shell (e.g. `kill` against a backgrounded script) —
+            // bash convention: 128 + SIGTERM = 143.
+            return ExitStatus(143)
+        } catch {
+            interpreter.error(interpreter.renderRuntimeError(error))
+            return ExitStatus(1)
+        }
+    }
+}

--- a/Sources/swift-bash/ExecCommand.swift
+++ b/Sources/swift-bash/ExecCommand.swift
@@ -3,6 +3,9 @@ import BashSyntax
 import BashInterpreter
 import BashCommandKit
 import Foundation
+import ShellKit
+
+import BashSwiftScript
 
 /// `swift-bash exec` — execute a bash script using the SwiftBash
 /// interpreter, inheriting the current process environment and
@@ -89,6 +92,7 @@ struct ExecCommand: AsyncParsableCommand {
         let environment: Environment
         let fileSystem: FileSystem
         let hostInfo: HostInfo
+        let urlSandbox: ShellKit.Sandbox?
         if let sandboxRoot = sandbox {
             do {
                 fileSystem = try SandboxedOverlayFileSystem(.init(
@@ -109,15 +113,36 @@ struct ExecCommand: AsyncParsableCommand {
             env["PWD"] = workspace
             env["TMPDIR"] = "/tmp"
             environment = env
+            // ShellKit-side URL gate. Bash builtins consult the
+            // `fileSystem` overlay above; ShellKit-aware bridges
+            // (the registered SwiftPorts CLIs and the SwiftScript
+            // interpreter) consult `Shell.sandbox` instead.
+            // Bind the same physical root so both confinements stay
+            // in lock-step and a `--sandbox` invocation actually
+            // confines a Swift script the same way it confines a
+            // bash one. Migration target (#10): retire the legacy
+            // `fileSystem` overlay and have bash consult the URL
+            // gate too.
+            urlSandbox = ShellKit.Sandbox.rooted(
+                at: URL(fileURLWithPath: sandboxRoot),
+                allowedHosts: [])
         } else {
             fileSystem = RealFileSystem()
             hostInfo = .real()
             environment = Environment.current()
+            urlSandbox = nil
         }
 
         let shell = Shell(environment: environment, fileSystem: fileSystem)
         shell.hostInfo = hostInfo
+        shell.sandbox = urlSandbox
         shell.registerStandardCommands()
+        // `#!/usr/bin/env swift-script` and `#!/usr/bin/env swift`
+        // shebangs route through the in-process SwiftScript
+        // interpreter, which reads its IO / FS / network / identity
+        // through `Shell.current` — same surface the bash sandbox
+        // and the registered SwiftPorts CLIs use.
+        shell.registerSwiftScript()
         shell.scriptName = scriptPath
         shell.positionalParameters = scriptArgs
 
@@ -148,9 +173,40 @@ struct ExecCommand: AsyncParsableCommand {
         // Shell defaults already forward to FileHandle.standardOutput /
         // .standardError — no additional wiring needed.
 
+        // If the script's first line is a shebang naming a registered
+        // ``ScriptInterpreter`` (e.g. `#!/usr/bin/env swift-script`),
+        // run the script PATH as a bash command line so the
+        // shebang-dispatch fallthrough fires and routes the body to
+        // that interpreter. Otherwise feed the source to bash
+        // directly — bash, sh, dash, and any other shebang the bash
+        // interpreter handles natively (it strips the line itself).
+        //
+        // Stdin / `/dev/fd/N` shorthands always run as bash source —
+        // we already consumed the stream by reading `source`, so a
+        // re-read by the dispatcher would see EOF.
+        let isStreamPath = scriptPath == "-"
+            || scriptPath == "/dev/stdin"
+            || scriptPath.hasPrefix("/dev/fd/")
+        let dispatchAsScript: Bool = {
+            guard !isStreamPath else { return false }
+            let firstLine = source.split(separator: "\n", maxSplits: 1)
+                .first.map(String.init) ?? ""
+            guard let parsed = parseShebangLine(firstLine) else { return false }
+            return shell.scriptInterpreters[parsed.interpreter] != nil
+        }()
+
         let status: ExitStatus
         do {
-            status = try await shell.run(source)
+            if dispatchAsScript {
+                let resolved = shell.resolvePath(scriptPath)
+                var line = Self.bashSingleQuote(resolved)
+                for arg in scriptArgs {
+                    line += " " + Self.bashSingleQuote(arg)
+                }
+                status = try await shell.run(line)
+            } else {
+                status = try await shell.run(source)
+            }
         } catch let err as BashInterpreterError {
             throw CLIError(err.description)
         } catch let err as BashSyntaxError {
@@ -162,6 +218,16 @@ struct ExecCommand: AsyncParsableCommand {
         }
         // Propagate the script's exit code back through ArgumentParser.
         throw ExitCode(status.code)
+    }
+
+    /// Wrap `s` in single quotes for a bash command line, escaping
+    /// any embedded single quotes via the standard `'\''`
+    /// close-then-reopen idiom. Used when synthesising a one-line
+    /// invocation for shebang-dispatch routing — the path and each
+    /// arg are quoted so spaces / shell metacharacters in them stay
+    /// literal.
+    private static func bashSingleQuote(_ s: String) -> String {
+        return "'" + s.replacingOccurrences(of: "'", with: "'\\''") + "'"
     }
 
     /// Read script source from `path`. Handles three cases that

--- a/Tests/BashInterpreterTests/ScriptInterpreterTests.swift
+++ b/Tests/BashInterpreterTests/ScriptInterpreterTests.swift
@@ -1,0 +1,420 @@
+import Testing
+import Foundation
+@testable import BashInterpreter
+
+@Suite(.timeLimit(.minutes(1))) struct ScriptInterpreterTests {
+
+    /// Drop a shebang script onto disk with the execute bit set —
+    /// the dispatcher refuses non-executable regular files (matches
+    /// `bash ./script` semantics on a real system).
+    private static func writeExecutable(
+        _ source: String,
+        to path: String
+    ) throws {
+        try source.write(toFile: path, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o755],
+            ofItemAtPath: path)
+    }
+
+    // MARK: parseShebangLine
+
+    @Test func parsesPlainShebang() {
+        let parsed = parseShebangLine("#!/bin/bash")
+        #expect(parsed?.interpreter == "bash")
+        #expect(parsed?.argv == ["/bin/bash"])
+    }
+
+    @Test func parsesShebangWithArgs() {
+        let parsed = parseShebangLine("#!/usr/bin/python3 -O")
+        #expect(parsed?.interpreter == "python3")
+        #expect(parsed?.argv == ["/usr/bin/python3", "-O"])
+    }
+
+    @Test func parsesEnvPrefixedShebang() {
+        let parsed = parseShebangLine("#!/usr/bin/env swift-script")
+        #expect(parsed?.interpreter == "swift-script")
+        #expect(parsed?.argv == ["swift-script"])
+    }
+
+    @Test func parsesEnvPrefixedShebangWithFlags() {
+        // env -S splits its arg into multiple tokens upstream; once
+        // tokenised, we should walk past the -S flag and resolve the
+        // real interpreter.
+        let parsed = parseShebangLine("#!/usr/bin/env -S swift-script --strict")
+        #expect(parsed?.interpreter == "swift-script")
+        #expect(parsed?.argv == ["swift-script", "--strict"])
+    }
+
+    @Test func parsesEnvWithKeyValueOverrides() {
+        let parsed = parseShebangLine(
+            "#!/usr/bin/env FOO=bar BAZ=qux python3")
+        #expect(parsed?.interpreter == "python3")
+        #expect(parsed?.argv == ["python3"])
+    }
+
+    @Test func tolerantOfLeadingWhitespace() {
+        let parsed = parseShebangLine("#!  /usr/bin/swift-script")
+        #expect(parsed?.interpreter == "swift-script")
+    }
+
+    @Test func rejectsNonShebangLine() {
+        #expect(parseShebangLine("// not a shebang") == nil)
+        #expect(parseShebangLine("# just a comment") == nil)
+        #expect(parseShebangLine("") == nil)
+    }
+
+    @Test func envWithoutTargetReturnsNil() {
+        // `#!/usr/bin/env` with nothing after it is meaningless — the
+        // kernel would error out. We return nil so the caller falls
+        // through to "command not found".
+        #expect(parseShebangLine("#!/usr/bin/env") == nil)
+    }
+
+    // MARK: stripShebang
+
+    @Test func stripShebangRemovesLineButKeepsNewline() {
+        // The shebang content is dropped, but the trailing newline is
+        // retained so line numbers below stay aligned with the
+        // original file. Body therefore begins with "\n".
+        let (stripped, line) = stripShebang(
+            "#!/usr/bin/env swift-script\nprint(1)\n")
+        #expect(stripped == "\nprint(1)\n")
+        #expect(line == "#!/usr/bin/env swift-script")
+    }
+
+    @Test func stripShebangPreservesLineNumbers() {
+        // Line 2 in the body is the same as line 2 in the original.
+        // Interpreter diagnostics that report "line N" therefore
+        // point at the same physical line the user sees.
+        let original = "#!/bin/bash\necho hi\necho bye\n"
+        let (stripped, _) = stripShebang(original)
+        let originalLines = original.split(separator: "\n",
+                                           omittingEmptySubsequences: false)
+        let strippedLines = stripped.split(separator: "\n",
+                                           omittingEmptySubsequences: false)
+        #expect(originalLines.count == strippedLines.count)
+        #expect(originalLines[1] == strippedLines[1])
+        #expect(originalLines[2] == strippedLines[2])
+    }
+
+    @Test func stripShebangNoOpForNonShebang() {
+        let (stripped, line) = stripShebang("print(\"hi\")\n")
+        #expect(stripped == "print(\"hi\")\n")
+        #expect(line == nil)
+    }
+
+    @Test func stripShebangWithoutTrailingNewline() {
+        // Pure shebang, no body — body strips to empty.
+        let (stripped, line) = stripShebang("#!/bin/sh")
+        #expect(stripped == "")
+        #expect(line == "#!/bin/sh")
+    }
+
+    // MARK: end-to-end dispatch
+
+    @Test func registeredInterpreterRunsOnPathInvocation() async throws {
+        let cap = CapturingShell()
+        let dir = NSTemporaryDirectory()
+            + "swift-bash-shebang-\(UUID().uuidString)"
+        try FileManager.default.createDirectory(
+            atPath: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(atPath: dir) }
+
+        let path = dir + "/hello.foo"
+        try Self.writeExecutable("#!/usr/bin/env foolang\nbody\n", to: path)
+
+        // Capture every interpreter invocation so we can assert on
+        // what the dispatcher hands over.
+        actor Sink {
+            var contexts: [ScriptInterpreterContext] = []
+            func record(_ ctx: ScriptInterpreterContext) { contexts.append(ctx) }
+        }
+        let sink = Sink()
+        cap.shell.registerScriptInterpreter(name: "foolang") { ctx in
+            await sink.record(ctx)
+            Shell.current.stdout("ran:\(ctx.argv.joined(separator: ","))\n")
+            return .success
+        }
+
+        try await cap.shell.run("\(path) one two")
+        let ctxs = await sink.contexts
+        #expect(ctxs.count == 1)
+        #expect(ctxs.first?.scriptPath == path)
+        #expect(ctxs.first?.shebang == "#!/usr/bin/env foolang")
+        #expect(ctxs.first?.argv == [path, "one", "two"])
+        // Body should be stripped — no leading `#!` survives. The
+        // newline is retained so line 2 of the file is still line 2
+        // of the body.
+        #expect(ctxs.first?.source.hasPrefix("#!") == false)
+        #expect(ctxs.first?.source.hasPrefix("\n") == true)
+        #expect(cap.stdout == "ran:\(path),one,two\n")
+    }
+
+    @Test func dispatchPropagatesPositionalsToScript() async throws {
+        // The interpreter's body reads `Shell.current.positionalParameters`
+        // — the dispatcher should have set them to argv[1...].
+        let cap = CapturingShell()
+        let dir = NSTemporaryDirectory()
+            + "swift-bash-shebang-pos-\(UUID().uuidString)"
+        try FileManager.default.createDirectory(
+            atPath: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(atPath: dir) }
+        let path = dir + "/run.foo"
+        try Self.writeExecutable("#!/usr/bin/env foolang\n", to: path)
+        cap.shell.registerScriptInterpreter(name: "foolang") { _ in
+            let pos = Shell.current.positionalParameters
+            Shell.current.stdout(
+                "$0=\(Shell.current.scriptName) $@=\(pos.joined(separator: " "))\n")
+            return .success
+        }
+        try await cap.shell.run("\(path) alpha beta gamma")
+        #expect(cap.stdout == "$0=\(path) $@=alpha beta gamma\n")
+    }
+
+    @Test func parentPositionalsArePreservedAfterDispatch() async throws {
+        // Subshell isolation — the dispatched script must not leak its
+        // positional parameters into the parent shell.
+        let cap = CapturingShell()
+        let dir = NSTemporaryDirectory()
+            + "swift-bash-shebang-iso-\(UUID().uuidString)"
+        try FileManager.default.createDirectory(
+            atPath: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(atPath: dir) }
+        let path = dir + "/run.foo"
+        try Self.writeExecutable("#!/usr/bin/env foolang\n", to: path)
+        cap.shell.scriptName = "outer"
+        cap.shell.positionalParameters = ["outerArg"]
+        cap.shell.registerScriptInterpreter(name: "foolang") { _ in
+            return .success
+        }
+        try await cap.shell.run("\(path) inner")
+        #expect(cap.shell.scriptName == "outer")
+        #expect(cap.shell.positionalParameters == ["outerArg"])
+    }
+
+    @Test func interpreterExitStatusFlowsThroughToParent() async throws {
+        let cap = CapturingShell()
+        let dir = NSTemporaryDirectory()
+            + "swift-bash-shebang-exit-\(UUID().uuidString)"
+        try FileManager.default.createDirectory(
+            atPath: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(atPath: dir) }
+        let path = dir + "/run.foo"
+        try Self.writeExecutable("#!/usr/bin/env foolang\n", to: path)
+        cap.shell.registerScriptInterpreter(name: "foolang") { _ in
+            ExitStatus(7)
+        }
+        try await cap.shell.run("\(path); echo $?")
+        #expect(cap.stdout == "7\n")
+    }
+
+    @Test func nonExistentPathReturns127() async throws {
+        let cap = CapturingShell()
+        cap.shell.registerScriptInterpreter(name: "foolang") { _ in .success }
+        let bogus = "/tmp/swift-bash-no-such-script-\(UUID().uuidString)"
+        let status = try await cap.shell.run("\(bogus)")
+        #expect(status.code == 127)
+        #expect(cap.stderr.contains("No such file or directory"))
+    }
+
+    @Test func directoryReturns126() async throws {
+        let cap = CapturingShell()
+        let dir = NSTemporaryDirectory()
+            + "swift-bash-shebang-dir-\(UUID().uuidString)"
+        try FileManager.default.createDirectory(
+            atPath: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(atPath: dir) }
+        cap.shell.registerScriptInterpreter(name: "foolang") { _ in .success }
+        let status = try await cap.shell.run(dir)
+        #expect(status.code == 126)
+        #expect(cap.stderr.contains("Is a directory"))
+    }
+
+    @Test func bareNameNotTreatedAsPath() async throws {
+        // `swift-script` without a `/` in it must NOT trigger external
+        // dispatch, even when an interpreter is registered. Bare names
+        // go through the command registry only.
+        let cap = CapturingShell()
+        cap.shell.registerScriptInterpreter(name: "foolang") { _ in
+            ExitStatus(0)
+        }
+        let status = try await cap.shell.run("swift-script-not-a-real-cmd")
+        #expect(status.code == 127)
+        #expect(cap.stderr.contains("command not found"))
+    }
+
+    @Test func nonExecutableScriptRejectedWithPermissionDenied() async throws {
+        // A regular file with a matching shebang but no execute bit
+        // is rejected with 126 / "Permission denied" — matches bash
+        // `./script` when the file isn't `chmod +x`'d. Without this
+        // check, the dispatcher would happily run a 0644 file the
+        // user never marked as runnable.
+        let cap = CapturingShell()
+        let dir = NSTemporaryDirectory()
+            + "swift-bash-shebang-perm-\(UUID().uuidString)"
+        try FileManager.default.createDirectory(
+            atPath: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(atPath: dir) }
+        let path = dir + "/run.foo"
+        try "#!/usr/bin/env foolang\n".write(
+            toFile: path, atomically: true, encoding: .utf8)
+        // 0644 — readable, writable by owner, NOT executable.
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o644], ofItemAtPath: path)
+        cap.shell.registerScriptInterpreter(name: "foolang") { _ in
+            Issue.record("interpreter should not have been invoked")
+            return .success
+        }
+        let status = try await cap.shell.run(path)
+        #expect(status.code == 126)
+        #expect(cap.stderr.contains("Permission denied"))
+    }
+
+    @Test func unreadableScriptReportsPermissionDenied() async throws {
+        // A path the FS rejects (sandbox denial, EACCES) on `metadata`
+        // / `readData` should surface as 126 with a permission-shaped
+        // diagnostic — masking it as `command not found` (the prior
+        // behaviour) hid real failures behind a misleading message.
+        let cap = CapturingShell()
+        // FailingFileSystem rejects everything with permissionDenied
+        // so we exercise the "explicit path, FS error" branch.
+        cap.shell.fileSystem = FailingFileSystem()
+        cap.shell.registerScriptInterpreter(name: "foolang") { _ in .success }
+        let status = try await cap.shell.run("/some/explicit/path")
+        #expect(status.code == 126)
+        #expect(cap.stderr.contains("Permission denied"))
+    }
+
+    @Test func unregisteredShebangFallsThroughToCommandNotFound() async throws {
+        // File exists with a shebang naming an interpreter we DON'T
+        // have. We don't synthesize a "no interpreter for X" error
+        // because falling through to bash's "command not found" lets
+        // PATH lookups (etc.) still take effect for bare names.
+        let cap = CapturingShell()
+        let dir = NSTemporaryDirectory()
+            + "swift-bash-shebang-unreg-\(UUID().uuidString)"
+        try FileManager.default.createDirectory(
+            atPath: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(atPath: dir) }
+        let path = dir + "/run.foo"
+        try Self.writeExecutable("#!/usr/bin/env nope-lang\n", to: path)
+        let status = try await cap.shell.run("\(path)")
+        #expect(status.code == 127)
+        #expect(cap.stderr.contains("command not found"))
+    }
+
+    @Test func interpretersInheritIntoSubshells() async throws {
+        // The registry must propagate via Shell.copy() so subshells
+        // dispatch the same interpreters.
+        let cap = CapturingShell()
+        let dir = NSTemporaryDirectory()
+            + "swift-bash-shebang-sub-\(UUID().uuidString)"
+        try FileManager.default.createDirectory(
+            atPath: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(atPath: dir) }
+        let path = dir + "/run.foo"
+        try Self.writeExecutable("#!/usr/bin/env foolang\n", to: path)
+        cap.shell.registerScriptInterpreter(name: "foolang") { _ in
+            Shell.current.stdout("ok\n")
+            return .success
+        }
+        try await cap.shell.run("(\(path))")
+        #expect(cap.stdout == "ok\n")
+    }
+
+    @Test func dispatchedSourceMatchesOriginalLineNumbers() async throws {
+        // An error on line 3 of the original file should arrive at
+        // line 3 of the body the interpreter sees. We don't have a
+        // concrete error path in the test interpreter, so check the
+        // body structure directly: line N in the body equals line N
+        // in the original file (line 1 is empty where the shebang
+        // was).
+        let cap = CapturingShell()
+        let dir = NSTemporaryDirectory()
+            + "swift-bash-shebang-lines-\(UUID().uuidString)"
+        try FileManager.default.createDirectory(
+            atPath: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(atPath: dir) }
+        let path = dir + "/run.foo"
+        let original = """
+            #!/usr/bin/env foolang
+            print(1)
+            print(2)
+
+            """
+        try Self.writeExecutable(original, to: path)
+        actor Sink {
+            var source: String?
+            func record(_ src: String) { source = src }
+        }
+        let sink = Sink()
+        cap.shell.registerScriptInterpreter(name: "foolang") { ctx in
+            await sink.record(ctx.source)
+            return .success
+        }
+        try await cap.shell.run(path)
+        let body = await sink.source ?? ""
+        let originalLines = original.split(separator: "\n",
+                                           omittingEmptySubsequences: false)
+        let bodyLines = body.split(separator: "\n",
+                                   omittingEmptySubsequences: false)
+        #expect(originalLines.count == bodyLines.count)
+        #expect(bodyLines[0] == "")           // shebang stripped
+        #expect(bodyLines[1] == "print(1)")   // line 2 unchanged
+        #expect(bodyLines[2] == "print(2)")   // line 3 unchanged
+    }
+
+    @Test func unregisterRemovesInterpreter() async throws {
+        let cap = CapturingShell()
+        let dir = NSTemporaryDirectory()
+            + "swift-bash-shebang-unreg2-\(UUID().uuidString)"
+        try FileManager.default.createDirectory(
+            atPath: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(atPath: dir) }
+        let path = dir + "/run.foo"
+        try Self.writeExecutable("#!/usr/bin/env foolang\nbody", to: path)
+        cap.shell.registerScriptInterpreter(name: "foolang") { _ in .success }
+        cap.shell.unregisterScriptInterpreter("foolang")
+        let status = try await cap.shell.run("\(path)")
+        #expect(status.code == 127)
+    }
+}
+
+// MARK: - Test helpers
+
+/// Synthetic FS that rejects every read with `permissionDenied`.
+/// Used to drive the dispatcher's explicit-path FS-error branch
+/// without depending on chmod-able real disk state.
+private struct FailingFileSystem: FileSystem {
+    func metadata(_ path: String) async throws -> FileMetadata? {
+        throw FileSystemError.permissionDenied(path)
+    }
+    func list(_ path: String) async throws -> [String] {
+        throw FileSystemError.permissionDenied(path)
+    }
+    func canonicalize(_ path: String, allowMissing: Bool) async throws -> String {
+        path
+    }
+    func readData(_ path: String) async throws -> Data {
+        throw FileSystemError.permissionDenied(path)
+    }
+    func writeData(_ data: Data, to path: String, append: Bool) async throws {
+        throw FileSystemError.permissionDenied(path)
+    }
+    func touch(_ path: String) async throws {
+        throw FileSystemError.permissionDenied(path)
+    }
+    func createDirectory(_ path: String, intermediates: Bool) async throws {
+        throw FileSystemError.permissionDenied(path)
+    }
+    func remove(_ path: String, recursive: Bool) async throws {
+        throw FileSystemError.permissionDenied(path)
+    }
+    func move(from: String, to: String) async throws {
+        throw FileSystemError.permissionDenied(from)
+    }
+    func copy(from: String, to: String) async throws {
+        throw FileSystemError.permissionDenied(from)
+    }
+}

--- a/Tests/BashSwiftScriptTests/BashSwiftScriptTests.swift
+++ b/Tests/BashSwiftScriptTests/BashSwiftScriptTests.swift
@@ -1,0 +1,295 @@
+import Testing
+import Foundation
+import ShellKit
+@testable import BashInterpreter
+@testable import BashSwiftScript
+
+/// End-to-end tests for the SwiftBash ↔ SwiftScript integration.
+/// Each test constructs a SwiftBash `Shell`, registers SwiftScript
+/// via `registerSwiftScript()`, drops a script onto disk, and runs
+/// it through the bash dispatcher (`shell.run("./path/to/script")`)
+/// — the same path the standalone CLI takes for an executable
+/// script with a `#!`-shebang.
+
+@Suite(.timeLimit(.minutes(1))) struct BashSwiftScriptTests {
+
+    /// Build a SwiftBash `Shell` with capturing sinks and SwiftScript
+    /// registered. Returns the shell + a capture handle for assertions.
+    private func makeShell(
+        sandbox: ShellKit.Sandbox? = nil,
+        networkConfig: NetworkConfig? = nil,
+        hostInfo: HostInfo = .synthetic,
+        stdin: InputSource = .empty
+    ) -> (shell: BashInterpreter.Shell, capture: TestCapture) {
+        let capture = TestCapture()
+        let shell = BashInterpreter.Shell(
+            stdin: stdin,
+            stdout: capture.stdoutSink,
+            stderr: capture.stderrSink,
+            environment: Environment(),
+            sandbox: sandbox,
+            networkConfig: networkConfig,
+            hostInfo: hostInfo,
+            // The ShellKit-base init defaults `commands` to `[:]`,
+            // which strips out bash builtins (`echo`, `cd`, `:`, …).
+            // Restore the defaults so a test script using `echo` /
+            // `set` / `exit` behaves like a real shell.
+            commands: BashInterpreter.Shell.defaultCommands())
+        shell.registerSwiftScript()
+        return (shell, capture)
+    }
+
+    /// Drop a script onto disk with the execute bit set and clean
+    /// up after the test. Matches bash semantics: the dispatcher
+    /// refuses regular files without `chmod +x`.
+    private func writeScript(
+        _ source: String,
+        suffix: String = ".swift"
+    ) throws -> (path: String, dir: String) {
+        let dir = NSTemporaryDirectory()
+            + "swift-bash-swift-script-\(UUID().uuidString)"
+        try FileManager.default.createDirectory(
+            atPath: dir, withIntermediateDirectories: true)
+        let path = dir + "/script\(suffix)"
+        try source.write(toFile: path, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o755],
+            ofItemAtPath: path)
+        return (path, dir)
+    }
+
+    // MARK: smoke
+
+    @Test func runsHelloWorldFromShebang() async throws {
+        let (shell, cap) = makeShell()
+        let s = try writeScript("""
+            #!/usr/bin/env swift-script
+            print("hello swiftscript")
+            """)
+        defer { try? FileManager.default.removeItem(atPath: s.dir) }
+
+        let status = try await shell.run(s.path)
+        #expect(status.code == 0)
+        #expect(cap.stdout == "hello swiftscript\n")
+    }
+
+    @Test func bareSwiftShebangAlsoRoutesToSwiftScript() async throws {
+        let (shell, cap) = makeShell()
+        let s = try writeScript("""
+            #!/usr/bin/env swift
+            print(40 + 2)
+            """)
+        defer { try? FileManager.default.removeItem(atPath: s.dir) }
+
+        let status = try await shell.run(s.path)
+        #expect(status.code == 0)
+        #expect(cap.stdout == "42\n")
+    }
+
+    // MARK: argv plumbing
+
+    @Test func commandLineArgumentsReflectScriptArgs() async throws {
+        let (shell, cap) = makeShell()
+        let s = try writeScript("""
+            #!/usr/bin/env swift-script
+            for a in CommandLine.arguments {
+                print(a)
+            }
+            """)
+        defer { try? FileManager.default.removeItem(atPath: s.dir) }
+
+        try await shell.run("\(s.path) one two three")
+        let lines = cap.stdout.split(separator: "\n").map(String.init)
+        #expect(lines == [s.path, "one", "two", "three"])
+    }
+
+    // MARK: exit code
+
+    @Test func scriptExitPropagatesAsBashExitStatus() async throws {
+        // Direct dispatch: exit(7) inside the script returns
+        // ExitStatus(7) to the bash dispatcher.
+        let (shell, cap) = makeShell()
+        let s = try writeScript("""
+            #!/usr/bin/env swift-script
+            print("before")
+            exit(7)
+            print("never")
+            """)
+        defer { try? FileManager.default.removeItem(atPath: s.dir) }
+
+        let status = try await shell.run(s.path)
+        #expect(status.code == 7)
+        #expect(cap.stdout == "before\n")
+    }
+
+    @Test func swiftScriptExitVisibleViaBashDollarQuestion() async throws {
+        // The dispatcher updates `lastExitStatus`; a follow-on
+        // command in the same list reads it via `$?`.
+        let (shell, cap) = makeShell()
+        let s = try writeScript("""
+            #!/usr/bin/env swift-script
+            exit(3)
+            """)
+        defer { try? FileManager.default.removeItem(atPath: s.dir) }
+
+        try await shell.run("\(s.path); echo $?")
+        #expect(cap.stdout == "3\n")
+    }
+
+    // MARK: diagnostics
+
+    @Test func parseErrorReportsExitOneOnStderr() async throws {
+        let (shell, cap) = makeShell()
+        let s = try writeScript("""
+            #!/usr/bin/env swift-script
+            let x = ###
+            """)
+        defer { try? FileManager.default.removeItem(atPath: s.dir) }
+
+        let status = try await shell.run(s.path)
+        #expect(status.code == 1)
+        #expect(cap.stderr.contains("error:"))
+    }
+
+    @Test func diagnosticLineNumbersMatchOriginalFile() async throws {
+        // Shebang strip preserves a leading newline so SwiftScript
+        // diagnostics line up with the original file (`swift` itself
+        // counts the shebang as line 1, body starts at line 2).
+        let (shell, cap) = makeShell()
+        let s = try writeScript("""
+            #!/usr/bin/env swift-script
+            let x = 1
+            let y = ###
+            """)
+        defer { try? FileManager.default.removeItem(atPath: s.dir) }
+
+        _ = try await shell.run(s.path)
+        let captured = cap.stderr
+        let mentions3 = captured.contains(":3:") || captured.contains("3 |")
+        #expect(mentions3, "expected line-3 reference in stderr")
+    }
+
+    // MARK: subshell isolation
+
+    @Test func parentPositionalsArePreservedAfterDispatch() async throws {
+        let (shell, _) = makeShell()
+        shell.scriptName = "outer"
+        shell.positionalParameters = ["outerArg"]
+        let s = try writeScript("""
+            #!/usr/bin/env swift-script
+            print("inside")
+            """)
+        defer { try? FileManager.default.removeItem(atPath: s.dir) }
+
+        try await shell.run("\(s.path) inner")
+        #expect(shell.scriptName == "outer")
+        #expect(shell.positionalParameters == ["outerArg"])
+    }
+
+    // MARK: stdin via pipeline
+
+    @Test func bashPipelineFeedsStdinIntoSwiftScript() async throws {
+        // `echo hello | ./script.swift` — the stage stdin from
+        // bash's pipeline becomes SwiftScript's `Shell.current.stdin`,
+        // which is what `readLine()` consumes.
+        let (shell, cap) = makeShell()
+        let s = try writeScript("""
+            #!/usr/bin/env swift-script
+            if let line = readLine() {
+                print("got: \\(line)")
+            }
+            """)
+        defer { try? FileManager.default.removeItem(atPath: s.dir) }
+
+        try await shell.run("echo hello | \(s.path)")
+        #expect(cap.stdout == "got: hello\n")
+    }
+
+    // MARK: sandbox
+
+    @Test func sandboxedShellDeniesScriptDiskAccess() async throws {
+        // SwiftScript bridges call `authorizePath` before disk
+        // touches; with a SwiftBash sandbox bound, off-root paths
+        // throw into the script's `do/catch`.
+        let root = NSTemporaryDirectory()
+            + "swift-bash-script-sandbox-\(UUID().uuidString)"
+        try FileManager.default.createDirectory(
+            atPath: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(atPath: root) }
+        let (shell, cap) = makeShell(
+            sandbox: ShellKit.Sandbox.rooted(
+                at: URL(fileURLWithPath: root),
+                allowedHosts: []))
+        let s = try writeScript("""
+            #!/usr/bin/env swift-script
+            import Foundation
+            do {
+                _ = try String(contentsOfFile: "/etc/passwd", encoding: .utf8)
+                print("LEAKED")
+            } catch {
+                print("denied")
+            }
+            """)
+        defer { try? FileManager.default.removeItem(atPath: s.dir) }
+
+        try await shell.run(s.path)
+        #expect(cap.stdout == "denied\n")
+    }
+
+    // MARK: identity
+
+    @Test func swiftScriptSeesSandboxIdentity() async throws {
+        var info = HostInfo.synthetic
+        info.userName = "agent"
+        info.hostName = "sandbox.local"
+        let (shell, cap) = makeShell(hostInfo: info)
+        let s = try writeScript("""
+            #!/usr/bin/env swift-script
+            import Foundation
+            print(ProcessInfo.processInfo.userName)
+            print(ProcessInfo.processInfo.hostName)
+            """)
+        defer { try? FileManager.default.removeItem(atPath: s.dir) }
+
+        try await shell.run(s.path)
+        #expect(cap.stdout == "agent\nsandbox.local\n")
+    }
+}
+
+// MARK: - Test capture helper
+
+/// Wires `OutputSink`s into `StringBox`es so tests can read what the
+/// script emitted. Same shape as `CapturingShell` in the
+/// BashInterpreterTests suite, copied here because test-target
+/// helpers don't share across SwiftPM packages.
+final class TestCapture: @unchecked Sendable {
+
+    let stdoutSink: OutputSink
+    let stderrSink: OutputSink
+
+    private final class StringBox: @unchecked Sendable {
+        private let lock = NSLock()
+        private var value = ""
+        func append(_ data: Data) {
+            let s = String(decoding: data, as: UTF8.self)
+            lock.lock(); defer { lock.unlock() }
+            value.append(s)
+        }
+        func read() -> String {
+            lock.lock(); defer { lock.unlock() }
+            return value
+        }
+    }
+    private let _stdout = StringBox()
+    private let _stderr = StringBox()
+
+    var stdout: String { _stdout.read() }
+    var stderr: String { _stderr.read() }
+
+    init() {
+        let stdout = _stdout
+        let stderr = _stderr
+        self.stdoutSink = OutputSink(onWrite: { stdout.append($0) })
+        self.stderrSink = OutputSink(onWrite: { stderr.append($0) })
+    }
+}


### PR DESCRIPTION
Closes Cocoanetics/SwiftBash#9.

A path-invoked simple command (`./hello.swift`, `/abs/path/script.foo`) that the registry doesn't resolve now falls through to a shebang-dispatch path: read the file, parse the `#!`-line, look up a registered `ScriptInterpreter`, run it inside a fresh `Shell.copy()` so positional parameters / `$0` / errexit toggling stay scoped. The SwiftScript binding is a 5-line bridge because SwiftScript's matching ShellKit-adoption PR ([Cocoanetics/SwiftScript#2](https://github.com/Cocoanetics/SwiftScript/pull/2)) already routes its IO / FS / network / identity / exit through `Shell.current` — the same TaskLocal SwiftBash binds for every dispatch. Output, stdin, sandbox confinement, network allow-list, and synthetic identity all work without per-call wiring.

## Demo

```bash
$ cat hello.swift
#!/usr/bin/env swift-script
let names = CommandLine.arguments.dropFirst()
for name in names {
    print("hello, \(name)")
}

$ chmod +x hello.swift

$ swift-bash exec /dev/stdin <<'EOF'
./hello.swift alice bob
echo "exit=$?"
EOF
hello, alice
hello, bob
exit=0
```

## What's in the diff

### `BashInterpreter`
- New `ScriptInterpreter` protocol + `ScriptInterpreterContext` + `ClosureScriptInterpreter`. Language-agnostic — embedders can register Python, Lua, anything else the same way.
- `Shell+ScriptInterpreters.swift`: `registerScriptInterpreter(_:)` + closure-form variant + `unregisterScriptInterpreter(_:)`. Plus a `parseShebangLine(_:)` helper handling plain shebangs, `#!/usr/bin/env <name>`, and `#!/usr/bin/env -S <name> --flag` (walks past flags + `KEY=value`), and `stripShebang(_:)` that drops the shebang content but preserves the trailing newline so SwiftScript diagnostics line up with the original file (`swift` itself counts the shebang as line 1).
- `Shell+ExternalScript.swift`: dispatcher that reads the candidate file via `Shell.fileSystem`, applies bash-conventional diagnostics (missing → 127, directory → 126), and runs the interpreter inside a `Shell.copy()` subshell.
- `scriptInterpreters: [String: ScriptInterpreter]` field on `Shell`, propagated via `copy()`.
- `executeSimpleCommand` falls through to the dispatcher before `command not found`.

### `BashSwiftScript` (new target)
- `SwiftScriptShellInterpreter`: ~90-line `ScriptInterpreter` that constructs a fresh `SwiftScriptInterpreter.Interpreter` per script, calls `evalScript(_:fileName:)`, renders parse + runtime errors via the interpreter's own renderer (which routes through `Shell.current.stderr`), and translates cancellation to bash's 128+SIGTERM = 143.
- `Shell+SwiftScript.swift`: `Shell.registerSwiftScript(names:)` — registers under `["swift-script", "swift"]` by default.

### `swift-bash exec`
- Calls `registerSwiftScript()` automatically.
- `--sandbox HOST_DIR` now ALSO binds `Shell.sandbox = Sandbox.rooted(at: HOST_DIR)` — the URL-gate the SwiftScript bridges consult. Earlier the flag only bound the legacy `Shell.fileSystem` overlay (used by bash builtins) and SwiftScript bypassed confinement entirely. Documented under "Known limitations" in `Docs/SwiftScript.md`: the URL-gate vs `fileSystem`-overlay split means SwiftScript file IO under `--sandbox` is effectively disabled (the sandbox catches escapes but Foundation can't see the bash overlay's `/batch` mount). Full unification tracked in [#10](https://github.com/Cocoanetics/SwiftBash/issues/10).
- `--allow-url`, `--allow-method`, `--max-response-size`, `--no-deny-private` apply uniformly to bash and SwiftScript scripts via the shared `Shell.networkConfig`.

## Tests

- `Tests/BashInterpreterTests/ScriptInterpreterTests.swift` — **23** tests covering shebang parsing (`env`-prefix, `env -S`, `KEY=value`), strip semantics, dispatch positive / not-found / is-directory / unregistered / inheritance into subshells.
- `Tests/BashSwiftScriptTests/BashSwiftScriptTests.swift` — **11** end-to-end tests through the bash dispatcher: hello-world, bare `swift` shebang, `CommandLine.arguments` plumbing, exit-code propagation through `$?`, parse + runtime diagnostics, line-number preservation, subshell positional isolation, stdin feed via `echo input | ./script.swift`, sandbox-rooted disk denial, synthetic-identity ProcessInfo readout.

Suite: **1724 → 1758 tests**.

## Cross-platform

- ✅ macOS native (Swift 6.2.4) — full test suite green
- ✅ iOS — via `xcodebuild -scheme SwiftBash-Package -destination 'generic/platform=iOS' build`
- ✅ Linux — via `swift:6.2-jammy` Docker (aarch64), full `swift build`
- CI handles the full matrix (macOS / iOS / Linux / Windows / Android).

## Docs

New `Docs/SwiftScript.md`. Updated `Docs/BashInterpreter.md` (Script-shebang interpreters section), `README.md`, `AGENTS.md`.

## Follow-ups

- [#13](https://github.com/Cocoanetics/SwiftScript/issues/3) — inventory + gate every Foundation IO surface in the SwiftScript bridges (URLRequest, FileHandle, Bundle, OutputStream/InputStream, NSDictionary/Array contentsOf, FileWrapper, Process). Today's coverage: FileManager, URLSession URL-arg methods, String+Data file IO, ProcessInfo identity.
- [#10](https://github.com/Cocoanetics/SwiftBash/issues/10) — unify the legacy `Shell.fileSystem` overlay with the URL-gate `Shell.sandbox` so a single `--sandbox` confinement covers bash builtins and SwiftScript Foundation calls together.

## Dependency note

This PR pins SwiftScript to `feat/adopt-shellkit` ([Cocoanetics/SwiftScript#2](https://github.com/Cocoanetics/SwiftScript/pull/2)). Retarget the pin once that PR lands on SwiftScript main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
