### PR TITLE
docs: retarget IO-bridge gate follow-up at SwiftScript#3

### DIFF
--- a/Docs/SwiftScript.md
+++ b/Docs/SwiftScript.md
@@ -151,4 +151,4 @@ to bash and SwiftScript scripts.
   bare `URL`) aren't gated yet — a determined script can reach
   the real filesystem through them. Tracked as the broader
   "inventory + gate every IO-shaped Foundation method"
-  follow-up: issue #13.
+  follow-up: [Cocoanetics/SwiftScript#3](https://github.com/Cocoanetics/SwiftScript/issues/3).


### PR DESCRIPTION
## Summary

- Issue 13 was filed against SwiftBash but every concrete change it lists (generator policy in `BridgeGeneratorTool/main.swift`, auto-generated Foundation bridges, regen script) lives in the SwiftScript repo. Transferred to [Cocoanetics/SwiftScript#3](https://github.com/Cocoanetics/SwiftScript/issues/3).
- This PR updates the cross-reference in `Docs/SwiftScript.md` to point at the new home with a full URL so the link text matches.

## Test plan

- [x] No code changes; docs-only.