### PR TITLE
SwiftJSCore: gate host-touching JS surfaces on Shell.current (#17)

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -92,9 +92,11 @@ jobs:
         run: swift test -v --skip-build --no-parallel
 
   build-windows:
-    # Investigation job: Windows support is not yet a committed
-    # compatibility target, so collect compiler/test failures without
-    # blocking existing macOS / iOS / Linux CI.
+    # Windows is a committed compatibility target — the build and
+    # test steps fail the job on regression, same as the other
+    # platforms. Tests that don't map to Windows (POSIX execute bit,
+    # `bash FILE` with non-quoted host paths, etc.) carry their own
+    # `#if !os(Windows)` gates at the source level.
     runs-on: windows-latest
     timeout-minutes: 45
     steps:
@@ -148,14 +150,12 @@ jobs:
           swift build --build-tests -v `
             -Xcc "-I$env:VCPKG_BASE\include" `
             -Xlinker "/LIBPATH:$env:VCPKG_BASE\lib"
-        continue-on-error: true
       - name: Test (Windows)
         shell: pwsh
         run: |
           swift test -v --skip-build --no-parallel `
             -Xcc "-I$env:VCPKG_BASE\include" `
             -Xlinker "/LIBPATH:$env:VCPKG_BASE\lib"
-        continue-on-error: true
 
   # Uses skiptools/swift-android-action which wraps the swift.org Android
   # SDK setup AND runs the SwiftPM tests on an x86_64 Android emulator.

--- a/Sources/BashInterpreter/API/Shell+Path.swift
+++ b/Sources/BashInterpreter/API/Shell+Path.swift
@@ -12,10 +12,15 @@ extension Shell {
     ///
     /// The result is *not* symlink-resolved — call
     /// ``FileSystem/canonicalize(_:allowMissing:)`` for that.
+    ///
+    /// On Windows, drive-letter paths (`C:\foo`, `c:/foo`) and UNC
+    /// paths (`\\server\share`) count as absolute. The result uses
+    /// forward-slash separators throughout — Windows file APIs
+    /// accept both, and our split-on-`/` normalisation expects them.
     public func resolvePath(_ path: String) -> String {
         let expanded = expandTilde(path)
         let absolute: String
-        if expanded.hasPrefix("/") {
+        if Self.isAbsolutePath(expanded) {
             absolute = expanded
         } else {
             // Pure-Swift join — `NSString.appendingPathComponent`
@@ -29,6 +34,27 @@ extension Shell {
         return Self.normalizePath(absolute)
     }
 
+    /// True for paths that don't need to be joined with the working
+    /// directory: `/foo` everywhere, plus `C:\foo` / `C:/foo` / UNC
+    /// (`\\server\share`) on Windows.
+    static func isAbsolutePath(_ p: String) -> Bool {
+        if p.hasPrefix("/") { return true }
+        #if os(Windows)
+        // Drive letter: `C:\…` or `C:/…`.
+        let chars = Array(p)
+        if chars.count >= 3,
+           chars[0].isLetter,
+           chars[1] == ":",
+           chars[2] == "/" || chars[2] == "\\"
+        {
+            return true
+        }
+        // UNC roots: `\\server\share\…` or `//server/share/…`.
+        if p.hasPrefix("\\\\") || p.hasPrefix("//") { return true }
+        #endif
+        return false
+    }
+
     /// Lexical path normalisation — collapses `.` / `..` / repeated
     /// `/` purely as text, never touching the filesystem. **Does not
     /// resolve symlinks** (that's what `cd -L` / `pwd -L` semantics
@@ -39,29 +65,63 @@ extension Shell {
     /// supposed to be lexical but on swift-corelibs-foundation
     /// (Linux) follows symlinks too — making `cd -L /var` set `$PWD`
     /// to `/private/var` instead of preserving `/var`.
+    ///
+    /// On Windows, backslashes are normalised to forward slashes
+    /// up front (Win32 path APIs accept both). Drive-letter paths
+    /// keep their `C:` prefix as the root segment so the result is
+    /// still a valid Windows path: `C:\Users\foo\..\bar` → `C:/Users/bar`.
     static func normalizePath(_ path: String) -> String {
         guard !path.isEmpty else { return "" }
-        let isAbsolute = path.hasPrefix("/")
+        #if os(Windows)
+        let normalized = path.replacingOccurrences(of: "\\", with: "/")
+        #else
+        let normalized = path
+        #endif
+        // Split on `/`, tracking whether the path is anchored at the
+        // root (Unix `/foo`) or at a drive (Windows `C:/foo`). For a
+        // drive-letter path we keep the `C:` segment in the stack so
+        // the rebuilt string still stems from that drive.
+        let isUnixAbsolute = normalized.hasPrefix("/")
         var stack: [String] = []
-        for seg in path.split(separator: "/", omittingEmptySubsequences: true) {
+        var driveRoot: String? = nil
+        var saw: [Substring] = normalized.split(
+            separator: "/", omittingEmptySubsequences: true)
+        #if os(Windows)
+        // Detect a leading `C:` segment (drive root). After we
+        // record it, the rest of the segments are walked as if the
+        // path were absolute beneath that drive.
+        if let first = saw.first,
+           first.count == 2,
+           let firstChar = first.first, firstChar.isLetter,
+           first.last == ":"
+        {
+            driveRoot = String(first)
+            saw = Array(saw.dropFirst())
+        }
+        #endif
+        let anchored = isUnixAbsolute || driveRoot != nil
+        for seg in saw {
             switch seg {
             case ".":
                 continue
             case "..":
-                // For absolute paths, `..` at the root stays at the
+                // For anchored paths, `..` at the root stays at the
                 // root. For relative paths we let `..` underflow as
                 // a literal segment so callers can preserve the
                 // user's intent (rare in practice).
                 if !stack.isEmpty, stack.last != ".." {
                     stack.removeLast()
-                } else if !isAbsolute {
+                } else if !anchored {
                     stack.append("..")
                 }
             default:
                 stack.append(String(seg))
             }
         }
-        if isAbsolute {
+        if let driveRoot {
+            return driveRoot + "/" + stack.joined(separator: "/")
+        }
+        if isUnixAbsolute {
             return "/" + stack.joined(separator: "/")
         }
         return stack.isEmpty ? "." : stack.joined(separator: "/")

--- a/Sources/BashInterpreter/Execution/Shell+ExternalScript.swift
+++ b/Sources/BashInterpreter/Execution/Shell+ExternalScript.swift
@@ -109,7 +109,16 @@ extension Shell {
     /// A token "looks like a path" if it contains a `/` (relative or
     /// absolute). Bare names like `swift-script` are looked up in the
     /// command registry only — they're not paths to script files.
+    ///
+    /// On Windows, `\` is also accepted because `NSTemporaryDirectory()`
+    /// and friends return paths like `C:\Users\…\run.foo`. Without
+    /// this, every Windows-shaped temp path falls through to
+    /// `command not found`.
     private func looksLikePath(_ token: String) -> Bool {
-        token.contains("/")
+        #if os(Windows)
+        return token.contains("/") || token.contains("\\")
+        #else
+        return token.contains("/")
+        #endif
     }
 }

--- a/Sources/BashInterpreter/Execution/Shell+ExternalScript.swift
+++ b/Sources/BashInterpreter/Execution/Shell+ExternalScript.swift
@@ -62,11 +62,19 @@ extension Shell {
         // doesn't track POSIX bits report mode 0 — treat those as
         // executable so in-memory test fixtures and the virtual /bin
         // overlay aren't blocked.
+        //
+        // Windows has no POSIX execute bit, so `RealFileSystem`'s
+        // `windowsMetadata` reports `0o644` for every regular file —
+        // applying the check there would block every script. Skip
+        // the gate on Windows; if a script runs at all, the file
+        // already exists and the OS handles the rest.
+        #if !os(Windows)
         if meta.mode != 0, (meta.mode & 0o111) == 0 {
             stderr(
                 "\(errorLocationPrefix())\(head): Permission denied\n")
             return ExitStatus(126)
         }
+        #endif
         let data: Data
         do {
             data = try await fileSystem.readData(resolved)

--- a/Sources/SwiftJSCore/ChildProcess.swift
+++ b/Sources/SwiftJSCore/ChildProcess.swift
@@ -40,6 +40,11 @@ extension JSRuntime {
         // execSync(command, options?) → string | Buffer
         let execSync: @convention(block) (String, JSValue?) -> Any? = { [weak self] cmd, opts in
             guard let self else { return nil }
+            do {
+                try denyProcessIfSandboxed(cmd)
+            } catch {
+                return self.throwSandboxDenial(error, syscall: "spawn")
+            }
             return self.runChildSync(command: cmd, args: nil, opts: opts)
         }
         cp.setObject(block(execSync as AnyObject),
@@ -48,6 +53,11 @@ extension JSRuntime {
         // spawnSync(command, args?, options?) → { status, stdout, stderr, ... }
         let spawnSync: @convention(block) (String, JSValue?, JSValue?) -> Any? = { [weak self] cmd, args, opts in
             guard let self else { return nil }
+            do {
+                try denyProcessIfSandboxed(cmd)
+            } catch {
+                return self.throwSandboxDenial(error, syscall: "spawn")
+            }
             let argList = (args?.toArray() as? [String]) ?? []
             return self.spawnChildSync(command: cmd, args: argList, opts: opts)
         }
@@ -59,6 +69,11 @@ extension JSRuntime {
         // the JS event loop the way node delivers them.
         let spawnImpl: @convention(block) (String, JSValue?, JSValue?) -> JSValue? = { [weak self] cmd, args, opts in
             guard let self else { return nil }
+            do {
+                try denyProcessIfSandboxed(cmd)
+            } catch {
+                return self.throwSandboxDenial(error, syscall: "spawn")
+            }
             let argList = (args?.toArray() as? [String]) ?? []
             return self.runChildSpawn(command: cmd, args: argList, opts: opts)
         }
@@ -74,6 +89,11 @@ extension JSRuntime {
         // ~0.1s, not ~0.3s.
         let exec: @convention(block) (String, JSValue?) -> JSValue? = { [weak self] cmd, opts in
             guard let self else { return nil }
+            do {
+                try denyProcessIfSandboxed(cmd)
+            } catch {
+                return self.throwSandboxDenial(error, syscall: "spawn")
+            }
             return self.runChildAsync(command: cmd, opts: opts)
         }
         cp.setObject(block(exec as AnyObject),

--- a/Sources/SwiftJSCore/Globals.swift
+++ b/Sources/SwiftJSCore/Globals.swift
@@ -511,21 +511,25 @@ extension JSRuntime {
         process.setObject(block(cwd as AnyObject), forKeyedSubscript: "cwd" as NSString)
 
         let chdir: @convention(block) (String) -> Void = { [weak self] path in
+            // Resolve relative `path` against the current shell-CWD
+            // first — Node accepts `process.chdir("./sub")` and
+            // expects it to compose with the prior cwd. Storing the
+            // raw relative string here would leave the bound CWD
+            // unusable for subsequent `fs.*` ops.
+            let resolved = resolveAgainstShellCWD(path)
             // Sandbox gate: chdir into a denied region is a write —
             // it would let a script position subsequent relative-path
             // ops anywhere. Surface as a Node-style EACCES.
             do {
-                try self?.awaitSync { try await authorizePath(path, for: .write) }
+                try self?.awaitSync { try await authorizePath(resolved, for: .write) }
             } catch {
                 _ = self?.throwSandboxDenial(error, syscall: "chdir", path: path)
                 return
             }
             if Shell.current === Shell.processDefault {
-                FileManager.default.changeCurrentDirectoryPath(path)
-                Shell.current.environment.workingDirectory = path
-            } else {
-                Shell.current.environment.workingDirectory = path
+                FileManager.default.changeCurrentDirectoryPath(resolved)
             }
+            Shell.current.environment.workingDirectory = resolved
         }
         process.setObject(block(chdir as AnyObject), forKeyedSubscript: "chdir" as NSString)
 

--- a/Sources/SwiftJSCore/Globals.swift
+++ b/Sources/SwiftJSCore/Globals.swift
@@ -1,4 +1,5 @@
 import Foundation
+import BashInterpreter
 
 #if canImport(JavaScriptCore)
 
@@ -361,10 +362,29 @@ extension JSRuntime {
         // through the EnvProvider. Setting `process.env.X = "y"`
         // calls envProvider.set(...), which for OSEnvProvider also
         // propagates to setenv() so child processes see the change.
+        //
+        // Identity redirect: when an embedder has bound a non-default
+        // Shell (i.e. there's confinement in play), reads and writes
+        // route through `Shell.current.environment.variables` instead
+        // — so a sandboxed JS script sees the bound shell's env, not
+        // the host's. Under `Shell.processDefault` (standalone CLI)
+        // we keep the legacy `OSEnvProvider`-via-`setenv` behaviour
+        // so child processes spawned by the host still see writes.
         let envGet: @convention(block) (String) -> Any? = { [weak self] key in
-            self?.envProvider.get(key)
+            if Shell.current !== Shell.processDefault {
+                return Shell.current.environment.variables[key]
+            }
+            return self?.envProvider.get(key)
         }
         let envSet: @convention(block) (String, JSValue) -> Bool = { [weak self] key, value in
+            if Shell.current !== Shell.processDefault {
+                if value.isNull || value.isUndefined {
+                    Shell.current.environment.variables.removeValue(forKey: key)
+                } else {
+                    Shell.current.environment.variables[key] = value.toString() ?? ""
+                }
+                return true
+            }
             if value.isNull || value.isUndefined {
                 self?.envProvider.set(key, nil)
             } else {
@@ -373,12 +393,22 @@ extension JSRuntime {
             return true
         }
         let envHas: @convention(block) (String) -> Bool = { [weak self] key in
-            self?.envProvider.get(key) != nil
+            if Shell.current !== Shell.processDefault {
+                return Shell.current.environment.variables[key] != nil
+            }
+            return self?.envProvider.get(key) != nil
         }
         let envKeys: @convention(block) () -> [String] = { [weak self] in
-            self?.envProvider.allKeys ?? []
+            if Shell.current !== Shell.processDefault {
+                return Array(Shell.current.environment.variables.keys)
+            }
+            return self?.envProvider.allKeys ?? []
         }
         let envDel: @convention(block) (String) -> Bool = { [weak self] key in
+            if Shell.current !== Shell.processDefault {
+                Shell.current.environment.variables.removeValue(forKey: key)
+                return true
+            }
             self?.envProvider.set(key, nil)
             return true
         }
@@ -421,8 +451,44 @@ extension JSRuntime {
         #endif
 
         process.setObject("v22.0.0-swiftjs", forKeyedSubscript: "version" as NSString)
-        process.setObject(Int(getpid()), forKeyedSubscript: "pid" as NSString)
-        process.setObject(Int(getppid()), forKeyedSubscript: "ppid" as NSString)
+
+        // process.pid / process.ppid: under a bound Shell, return
+        // ``Shell.virtualPID`` (synthetic — defaults to 1) so a
+        // sandboxed script never sees the embedder's real PID. Under
+        // ``Shell.processDefault`` we keep `getpid()` / `getppid()`
+        // so the standalone `swift-js` CLI behaves unchanged.
+        // Defined as Proxy-backed accessors via JS Object.defineProperty
+        // because the value has to be re-read at access time — pid is a
+        // task-local quantity, baking it in at init would freeze the
+        // standalone-mode value into a Shell-bound run.
+        let pidGetter: @convention(block) () -> Int = {
+            if Shell.current === Shell.processDefault {
+                return Int(getpid())
+            }
+            return Int(Shell.current.virtualPID)
+        }
+        let ppidGetter: @convention(block) () -> Int = {
+            if Shell.current === Shell.processDefault {
+                return Int(getppid())
+            }
+            // No virtualPPID concept in ShellKit yet; mirror SwiftScript
+            // and return the same virtualPID (parent of `1` is `1`
+            // under embedded init-style semantics).
+            return Int(Shell.current.virtualPID)
+        }
+        // Bind getters on the local `process` JSValue directly —
+        // `globalThis.process` isn't set until the bottom of this
+        // method, so a getter that reads from globalThis would fire
+        // too early.
+        let pidGetterJS = JSValue(object: block(pidGetter as AnyObject), in: context)!
+        let ppidGetterJS = JSValue(object: block(ppidGetter as AnyObject), in: context)!
+        let installPidProps = context.evaluateScript(#"""
+        (function (process, getPid, getPpid) {
+          Object.defineProperty(process, "pid",  { get: getPid,  enumerable: true, configurable: true });
+          Object.defineProperty(process, "ppid", { get: getPpid, enumerable: true, configurable: true });
+        })
+        """#)!
+        installPidProps.call(withArguments: [process, pidGetterJS, ppidGetterJS])
 
         let exit: @convention(block) (Int32) -> Void = { [weak self] code in
             guard let self else { return }
@@ -437,12 +503,29 @@ extension JSRuntime {
         process.setObject(block(exit as AnyObject), forKeyedSubscript: "exit" as NSString)
 
         let cwd: @convention(block) () -> String = {
-            FileManager.default.currentDirectoryPath
+            if Shell.current === Shell.processDefault {
+                return FileManager.default.currentDirectoryPath
+            }
+            return Shell.current.environment.workingDirectory
         }
         process.setObject(block(cwd as AnyObject), forKeyedSubscript: "cwd" as NSString)
 
-        let chdir: @convention(block) (String) -> Void = { path in
-            FileManager.default.changeCurrentDirectoryPath(path)
+        let chdir: @convention(block) (String) -> Void = { [weak self] path in
+            // Sandbox gate: chdir into a denied region is a write —
+            // it would let a script position subsequent relative-path
+            // ops anywhere. Surface as a Node-style EACCES.
+            do {
+                try self?.awaitSync { try await authorizePath(path, for: .write) }
+            } catch {
+                _ = self?.throwSandboxDenial(error, syscall: "chdir", path: path)
+                return
+            }
+            if Shell.current === Shell.processDefault {
+                FileManager.default.changeCurrentDirectoryPath(path)
+                Shell.current.environment.workingDirectory = path
+            } else {
+                Shell.current.environment.workingDirectory = path
+            }
         }
         process.setObject(block(chdir as AnyObject), forKeyedSubscript: "chdir" as NSString)
 

--- a/Sources/SwiftJSCore/Modules.swift
+++ b/Sources/SwiftJSCore/Modules.swift
@@ -59,8 +59,15 @@ extension JSRuntime {
     }
 
     private func loadFileModule(_ spec: String) -> Any? {
+        // `require("./x")` with no calling-module context (entry-point
+        // script reading via `vm.runInThisContext` etc.) falls back to
+        // CWD. Use the bound shell's logical CWD, not the host process
+        // CWD, so this stays consistent with `process.cwd()` and with
+        // the `fs.*` resolver that follows.
         let basePath = (currentScriptPath as NSString?)?.deletingLastPathComponent
-            ?? FileManager.default.currentDirectoryPath
+            ?? (Shell.current === Shell.processDefault
+                ? FileManager.default.currentDirectoryPath
+                : Shell.current.environment.workingDirectory)
         var resolved = (spec as NSString).hasPrefix("/")
             ? spec
             : (basePath as NSString).appendingPathComponent(spec)
@@ -438,13 +445,14 @@ extension JSRuntime {
         let readFileSync: @convention(block) (String) -> Any? = { [weak self] path in
             guard let self else { return nil }
             let opts = (JSContext.currentArguments()?.dropFirst().first as? JSValue)
+            let resolved = resolveAgainstShellCWD(path)
             do {
-                try self.awaitSync { try await authorizePath(path, for: .read) }
+                try self.awaitSync { try await authorizePath(resolved, for: .read) }
             } catch {
                 return self.throwSandboxDenial(error, syscall: "open", path: path)
             }
             do {
-                let data = try Data(contentsOf: URL(fileURLWithPath: path))
+                let data = try Data(contentsOf: URL(fileURLWithPath: resolved))
                 let encoding = Self.encodingArg(from: opts)
                 if let encoding {
                     return Self.decode(data, encoding: encoding)
@@ -464,15 +472,16 @@ extension JSRuntime {
         // the JS caller omits trailing optional args.
         let writeFileSync: @convention(block) (String, JSValue) -> Bool = { [weak self] path, value in
             guard let self else { return false }
+            let resolved = resolveAgainstShellCWD(path)
             do {
-                try self.awaitSync { try await authorizePath(path, for: .write) }
+                try self.awaitSync { try await authorizePath(resolved, for: .write) }
             } catch {
                 _ = self.throwSandboxDenial(error, syscall: "open", path: path)
                 return false
             }
             do {
                 let data = Self.dataForWrite(value)
-                try data.write(to: URL(fileURLWithPath: path))
+                try data.write(to: URL(fileURLWithPath: resolved))
                 return true
             } catch {
                 _ = self.throwSystemError(error, syscall: "open", path: path)
@@ -484,16 +493,17 @@ extension JSRuntime {
 
         let appendFileSync: @convention(block) (String, JSValue) -> Bool = { [weak self] path, value in
             guard let self else { return false }
+            let resolved = resolveAgainstShellCWD(path)
             do {
-                try self.awaitSync { try await authorizePath(path, for: .write) }
+                try self.awaitSync { try await authorizePath(resolved, for: .write) }
             } catch {
                 _ = self.throwSandboxDenial(error, syscall: "open", path: path)
                 return false
             }
             let data = Self.dataForWrite(value)
-            let url = URL(fileURLWithPath: path)
+            let url = URL(fileURLWithPath: resolved)
             do {
-                if FileManager.default.fileExists(atPath: path) {
+                if FileManager.default.fileExists(atPath: resolved) {
                     let handle = try FileHandle(forWritingTo: url)
                     defer { try? handle.close() }
                     handle.seekToEndOfFile()
@@ -515,25 +525,27 @@ extension JSRuntime {
             // for a path it can't stat. Mirror that behaviour for a
             // sandbox denial: the script learns nothing about whether
             // the path exists, only that it can't see it.
+            let resolved = resolveAgainstShellCWD(path)
             do {
-                try self?.awaitSync { try await authorizePath(path, for: .read) }
+                try self?.awaitSync { try await authorizePath(resolved, for: .read) }
             } catch {
                 return false
             }
-            return FileManager.default.fileExists(atPath: path)
+            return FileManager.default.fileExists(atPath: resolved)
         }
         fs.setObject(block(existsSync as AnyObject),
                      forKeyedSubscript: "existsSync" as NSString)
 
         let readdirSync: @convention(block) (String) -> Any? = { [weak self] path in
             guard let self else { return nil }
+            let resolved = resolveAgainstShellCWD(path)
             do {
-                try self.awaitSync { try await authorizePath(path, for: .read) }
+                try self.awaitSync { try await authorizePath(resolved, for: .read) }
             } catch {
                 return self.throwSandboxDenial(error, syscall: "scandir", path: path)
             }
             do {
-                return try FileManager.default.contentsOfDirectory(atPath: path)
+                return try FileManager.default.contentsOfDirectory(atPath: resolved)
             } catch {
                 _ = self.throwSystemError(error, syscall: "scandir", path: path)
                 return nil
@@ -550,15 +562,16 @@ extension JSRuntime {
             guard let self else { return false }
             let opts = (JSContext.currentArguments()?.dropFirst().first as? JSValue)
             let recursive = opts?.objectForKeyedSubscript("recursive")?.toBool() ?? false
+            let resolved = resolveAgainstShellCWD(path)
             do {
-                try self.awaitSync { try await authorizePath(path, for: .write) }
+                try self.awaitSync { try await authorizePath(resolved, for: .write) }
             } catch {
                 _ = self.throwSandboxDenial(error, syscall: "mkdir", path: path)
                 return false
             }
             do {
                 try FileManager.default.createDirectory(
-                    atPath: path,
+                    atPath: resolved,
                     withIntermediateDirectories: recursive
                 )
                 return true
@@ -574,8 +587,9 @@ extension JSRuntime {
             guard let self else { return false }
             let opts = (JSContext.currentArguments()?.dropFirst().first as? JSValue)
             let force = opts?.objectForKeyedSubscript("force")?.toBool() ?? false
+            let resolved = resolveAgainstShellCWD(path)
             do {
-                try self.awaitSync { try await authorizePath(path, for: .delete) }
+                try self.awaitSync { try await authorizePath(resolved, for: .delete) }
             } catch {
                 // `force: true` would normally swallow ENOENT — but a
                 // sandbox denial is policy, not a missing file, so
@@ -584,7 +598,7 @@ extension JSRuntime {
                 return false
             }
             do {
-                try FileManager.default.removeItem(atPath: path)
+                try FileManager.default.removeItem(atPath: resolved)
                 return true
             } catch {
                 if !force {
@@ -600,14 +614,15 @@ extension JSRuntime {
 
         let statSync: @convention(block) (String) -> Any? = { [weak self] path in
             guard let self else { return nil }
+            let resolved = resolveAgainstShellCWD(path)
             do {
-                try self.awaitSync { try await authorizePath(path, for: .read) }
+                try self.awaitSync { try await authorizePath(resolved, for: .read) }
             } catch {
                 return self.throwSandboxDenial(error, syscall: "stat", path: path)
             }
             let fm = FileManager.default
             var isDir: ObjCBool = false
-            guard fm.fileExists(atPath: path, isDirectory: &isDir) else {
+            guard fm.fileExists(atPath: resolved, isDirectory: &isDir) else {
                 return self.throwJSError(
                     "ENOENT: no such file or directory, stat '\(path)'",
                     code: "ENOENT",
@@ -618,7 +633,7 @@ extension JSRuntime {
                     ]
                 )
             }
-            let attrs = (try? fm.attributesOfItem(atPath: path)) ?? [:]
+            let attrs = (try? fm.attributesOfItem(atPath: resolved)) ?? [:]
             let size = (attrs[.size] as? NSNumber)?.intValue ?? 0
             let mtime = (attrs[.modificationDate] as? Date)?.timeIntervalSince1970 ?? 0
             let isDirectory = isDir.boolValue

--- a/Sources/SwiftJSCore/Modules.swift
+++ b/Sources/SwiftJSCore/Modules.swift
@@ -1,4 +1,5 @@
 import Foundation
+import BashInterpreter
 
 #if canImport(JavaScriptCore)
 
@@ -81,6 +82,16 @@ extension JSRuntime {
             .objectForKeyedSubscript(resolved)),
            !cached.isUndefined, !cached.isNull {
             return cached
+        }
+
+        // Sandbox gate: a `require('./secret')` is a read; route the
+        // resolved path through the bound shell's sandbox before we
+        // touch disk.
+        let gatedPath = resolved
+        do {
+            try awaitSync { try await authorizePath(gatedPath, for: .read) }
+        } catch {
+            return throwSandboxDenial(error, syscall: "open", path: gatedPath)
         }
 
         guard let source = try? String(contentsOfFile: resolved, encoding: .utf8) else {
@@ -428,6 +439,11 @@ extension JSRuntime {
             guard let self else { return nil }
             let opts = (JSContext.currentArguments()?.dropFirst().first as? JSValue)
             do {
+                try self.awaitSync { try await authorizePath(path, for: .read) }
+            } catch {
+                return self.throwSandboxDenial(error, syscall: "open", path: path)
+            }
+            do {
                 let data = try Data(contentsOf: URL(fileURLWithPath: path))
                 let encoding = Self.encodingArg(from: opts)
                 if let encoding {
@@ -449,6 +465,12 @@ extension JSRuntime {
         let writeFileSync: @convention(block) (String, JSValue) -> Bool = { [weak self] path, value in
             guard let self else { return false }
             do {
+                try self.awaitSync { try await authorizePath(path, for: .write) }
+            } catch {
+                _ = self.throwSandboxDenial(error, syscall: "open", path: path)
+                return false
+            }
+            do {
                 let data = Self.dataForWrite(value)
                 try data.write(to: URL(fileURLWithPath: path))
                 return true
@@ -462,6 +484,12 @@ extension JSRuntime {
 
         let appendFileSync: @convention(block) (String, JSValue) -> Bool = { [weak self] path, value in
             guard let self else { return false }
+            do {
+                try self.awaitSync { try await authorizePath(path, for: .write) }
+            } catch {
+                _ = self.throwSandboxDenial(error, syscall: "open", path: path)
+                return false
+            }
             let data = Self.dataForWrite(value)
             let url = URL(fileURLWithPath: path)
             do {
@@ -482,14 +510,28 @@ extension JSRuntime {
         fs.setObject(block(appendFileSync as AnyObject),
                      forKeyedSubscript: "appendFileSync" as NSString)
 
-        let existsSync: @convention(block) (String) -> Bool = { path in
-            FileManager.default.fileExists(atPath: path)
+        let existsSync: @convention(block) (String) -> Bool = { [weak self] path in
+            // existsSync swallows errors by spec — Node returns `false`
+            // for a path it can't stat. Mirror that behaviour for a
+            // sandbox denial: the script learns nothing about whether
+            // the path exists, only that it can't see it.
+            do {
+                try self?.awaitSync { try await authorizePath(path, for: .read) }
+            } catch {
+                return false
+            }
+            return FileManager.default.fileExists(atPath: path)
         }
         fs.setObject(block(existsSync as AnyObject),
                      forKeyedSubscript: "existsSync" as NSString)
 
         let readdirSync: @convention(block) (String) -> Any? = { [weak self] path in
             guard let self else { return nil }
+            do {
+                try self.awaitSync { try await authorizePath(path, for: .read) }
+            } catch {
+                return self.throwSandboxDenial(error, syscall: "scandir", path: path)
+            }
             do {
                 return try FileManager.default.contentsOfDirectory(atPath: path)
             } catch {
@@ -509,6 +551,12 @@ extension JSRuntime {
             let opts = (JSContext.currentArguments()?.dropFirst().first as? JSValue)
             let recursive = opts?.objectForKeyedSubscript("recursive")?.toBool() ?? false
             do {
+                try self.awaitSync { try await authorizePath(path, for: .write) }
+            } catch {
+                _ = self.throwSandboxDenial(error, syscall: "mkdir", path: path)
+                return false
+            }
+            do {
                 try FileManager.default.createDirectory(
                     atPath: path,
                     withIntermediateDirectories: recursive
@@ -527,6 +575,15 @@ extension JSRuntime {
             let opts = (JSContext.currentArguments()?.dropFirst().first as? JSValue)
             let force = opts?.objectForKeyedSubscript("force")?.toBool() ?? false
             do {
+                try self.awaitSync { try await authorizePath(path, for: .delete) }
+            } catch {
+                // `force: true` would normally swallow ENOENT — but a
+                // sandbox denial is policy, not a missing file, so
+                // surface it regardless.
+                _ = self.throwSandboxDenial(error, syscall: "unlink", path: path)
+                return false
+            }
+            do {
                 try FileManager.default.removeItem(atPath: path)
                 return true
             } catch {
@@ -543,6 +600,11 @@ extension JSRuntime {
 
         let statSync: @convention(block) (String) -> Any? = { [weak self] path in
             guard let self else { return nil }
+            do {
+                try self.awaitSync { try await authorizePath(path, for: .read) }
+            } catch {
+                return self.throwSandboxDenial(error, syscall: "stat", path: path)
+            }
             let fm = FileManager.default
             var isDir: ObjCBool = false
             guard fm.fileExists(atPath: path, isDirectory: &isDir) else {
@@ -674,16 +736,40 @@ extension JSRuntime {
     private func makeOsModule() -> JSValue {
         let os = JSValue(newObjectIn: context)!
 
-        let homedir: @convention(block) () -> String = { NSHomeDirectory() }
+        // Identity redirects: when an embedder has bound a non-default
+        // Shell, route through `Shell.current` so a sandboxed script
+        // sees the synthetic identity rather than the host's. Under
+        // `Shell.processDefault` (standalone `swift-js` CLI) we keep
+        // the legacy host-API answers.
+        let homedir: @convention(block) () -> String = {
+            if Shell.current === Shell.processDefault {
+                return NSHomeDirectory()
+            }
+            if let sandboxHome = Shell.current.sandbox?.homeDirectory.path {
+                return sandboxHome
+            }
+            return Shell.current.environment.variables["HOME"] ?? NSHomeDirectory()
+        }
         os.setObject(block(homedir as AnyObject),
                      forKeyedSubscript: "homedir" as NSString)
 
-        let tmpdir: @convention(block) () -> String = { NSTemporaryDirectory() }
+        let tmpdir: @convention(block) () -> String = {
+            if Shell.current === Shell.processDefault {
+                return NSTemporaryDirectory()
+            }
+            if let sandboxTmp = Shell.current.sandbox?.temporaryDirectory.path {
+                return sandboxTmp
+            }
+            return NSTemporaryDirectory()
+        }
         os.setObject(block(tmpdir as AnyObject),
                      forKeyedSubscript: "tmpdir" as NSString)
 
         let hostname: @convention(block) () -> String = {
-            ProcessInfo.processInfo.hostName
+            if Shell.current === Shell.processDefault {
+                return ProcessInfo.processInfo.hostName
+            }
+            return Shell.current.hostInfo.hostName
         }
         os.setObject(block(hostname as AnyObject),
                      forKeyedSubscript: "hostname" as NSString)

--- a/Sources/SwiftJSCore/Network.swift
+++ b/Sources/SwiftJSCore/Network.swift
@@ -1,4 +1,5 @@
 import Foundation
+import BashInterpreter
 
 #if canImport(JavaScriptCore)
 
@@ -98,9 +99,11 @@ extension JSRuntime {
 
         var request = URLRequest(url: url)
         var abortSignal: JSValue?
+        var method = "GET"
         if let initVal, initVal.isObject {
             if let m = initVal.objectForKeyedSubscript("method"), m.isString {
                 request.httpMethod = m.toString()
+                method = m.toString() ?? "GET"
             }
             if let h = initVal.objectForKeyedSubscript("headers"), h.isObject {
                 if let dict = h.toDictionary() as? [String: Any] {
@@ -132,6 +135,23 @@ extension JSRuntime {
                     return promise
                 }
             }
+        }
+
+        // Sandbox + network-allow-list gate. Run the async gate
+        // synchronously so a denial rejects the Promise before we
+        // open a socket. The gate is pure policy (URL allow-list +
+        // method gate), no DNS, no TLS — sub-millisecond — so
+        // blocking the JSC thread for it is fine.
+        let gateMethod = method
+        do {
+            try awaitSync {
+                try await authorizeURL(url, method: gateMethod)
+            }
+        } catch {
+            box.reject?.call(withArguments: [
+                makeNetworkDenialError(error, in: ctx, url: urlString)
+            ])
+            return promise
         }
 
         // Add a sentinel timer so `drainPendingWorkIfNeeded` keeps

--- a/Sources/SwiftJSCore/SandboxBridge.swift
+++ b/Sources/SwiftJSCore/SandboxBridge.swift
@@ -1,0 +1,201 @@
+import Foundation
+import BashInterpreter
+
+#if canImport(JavaScriptCore)
+
+import JavaScriptCore
+
+// MARK: - Host hooks (sandbox / network / identity gating)
+//
+// Sibling to SwiftScript's `HostHooks.swift`. Every host-touching JS
+// builtin (`fs.readFileSync`, `fetch`, `child_process.spawn`, …) calls
+// one of these helpers before its Foundation hop. Each helper reads
+// `ShellKit.Shell.current` directly: under `Shell.processDefault` the
+// gates are no-ops and the standalone `swift-js` CLI behaves exactly
+// as it always has.
+
+/// Why a path is being authorized. Mirrors SwiftScript's
+/// `PathAccessIntent` so the JS bridge sites read the same way.
+enum PathAccessIntent: Sendable {
+    case read
+    case write
+    case delete
+}
+
+/// Authorize a filesystem access against the bound shell's sandbox.
+/// Throws ``ShellKit.Sandbox.Denial`` when the bound sandbox rejects
+/// the path; returns silently when no sandbox is bound.
+func authorizePath(
+    _ path: String,
+    for intent: PathAccessIntent = .read
+) async throws {
+    _ = intent  // reserved for future per-intent rules
+    guard let sandbox = Shell.current.sandbox else { return }
+    try await sandbox.authorize(URL(fileURLWithPath: path))
+}
+
+/// URL-form variant for bridges that already hold a `URL`. Same
+/// semantics as the path-string overload.
+func authorizePath(
+    _ url: URL,
+    for intent: PathAccessIntent = .read
+) async throws {
+    _ = intent
+    guard let sandbox = Shell.current.sandbox else { return }
+    try await sandbox.authorize(url)
+}
+
+/// Authorize a network access against the bound shell's `sandbox`
+/// host gate and `networkConfig` allow-list. Returns silently when
+/// neither is configured.
+func authorizeURL(
+    _ url: URL,
+    method: String = "GET"
+) async throws {
+    if let sandbox = Shell.current.sandbox {
+        try await sandbox.authorize(url)
+    }
+    if let config = Shell.current.networkConfig {
+        try checkNetworkAllowed(config: config, url: url, method: method)
+    }
+}
+
+/// Thrown by ``denyProcessIfSandboxed()`` and the JS-side
+/// `child_process.*` entry points when a sandbox is bound. JS
+/// callers see this surfaced as an `EPERM`-coded `Error`.
+struct ProcessDeniedBySandbox: Error, CustomStringConvertible {
+    let command: String
+    var description: String {
+        "spawn \(command) EPERM: process spawn denied by sandbox policy"
+    }
+}
+
+/// Sync deny gate for `child_process.{exec,execSync,spawn,spawnSync}`.
+/// SwiftBash's virtual process table doesn't yet route JS-side spawns,
+/// so the right default under a sandbox is to refuse — otherwise
+/// `spawn('cat', ['/etc/passwd'])` would round-trip the read through
+/// a subprocess and bypass every `fs.*` gate.
+func denyProcessIfSandboxed(_ command: String) throws {
+    if Shell.current.sandbox != nil {
+        throw ProcessDeniedBySandbox(command: command)
+    }
+}
+
+/// Local copy of SwiftScript's `NetworkConfig.checkAllowed` —
+/// pulled in here so SwiftJSCore doesn't take a SwiftScript dep
+/// just for the same six lines of allow-list logic.
+func checkNetworkAllowed(
+    config: NetworkConfig,
+    url: URL,
+    method: String
+) throws {
+    if config.dangerouslyAllowFullInternetAccess { return }
+    let normalised = method.uppercased()
+    let knownMethod = HTTPMethod(rawValue: normalised) ?? .GET
+    if !config.allowedMethods.contains(knownMethod) {
+        throw NetworkAccessDenied(
+            url: url,
+            reason: "HTTP method \(normalised) not in allow-list")
+    }
+    let allowed = URLAllowList.isAllowed(
+        url.absoluteString,
+        entries: config.allowedURLPrefixes)
+    guard allowed else {
+        throw NetworkAccessDenied(url: url, reason: "URL not in allow-list")
+    }
+}
+
+struct NetworkAccessDenied: Error, CustomStringConvertible {
+    let url: URL
+    let reason: String
+    var description: String {
+        "Network access denied: \(reason): \(url.absoluteString)"
+    }
+}
+
+extension JSRuntime {
+
+    /// Run an `async throws` operation synchronously by parking the
+    /// caller on a semaphore. Used by sync-shaped JS builtins
+    /// (`fs.readFileSync`, `fs.writeFileSync`, …) so they can call
+    /// the async `authorizePath` / `authorizeURL` gates without
+    /// breaking Node's sync contract.
+    ///
+    /// The current `Shell` binding is captured and re-bound inside
+    /// the spawned task — `@TaskLocal` doesn't propagate to detached
+    /// tasks, so without the rebind `Shell.current` would resolve to
+    /// `processDefault` inside the gate body, defeating the point.
+    ///
+    /// Must not be called from a queue the spawned task awaits on.
+    /// JavaScriptCore's evaluation thread is the intended caller; the
+    /// gate body never hops back to it, so there's no deadlock risk.
+    func awaitSync<T>(
+        _ work: @escaping @Sendable () async throws -> T
+    ) throws -> T {
+        let captured = Shell.current
+        let sem = DispatchSemaphore(value: 0)
+        nonisolated(unsafe) var result: Result<T, any Error>!
+        Task.detached {
+            do {
+                let v = try await captured.withCurrent { try await work() }
+                result = .success(v)
+            } catch {
+                result = .failure(error)
+            }
+            sem.signal()
+        }
+        sem.wait()
+        return try result.get()
+    }
+
+    /// Throw a Node-shaped `EACCES` JS Error from a `Sandbox.Denial`
+    /// or other gate-deny error. Returns the exception so callers can
+    /// `return` it from `Any?`-typed bridge blocks.
+    @discardableResult
+    func throwSandboxDenial(
+        _ error: Error,
+        syscall: String,
+        path: String? = nil
+    ) -> JSValue? {
+        let reason: String
+        if let denial = error as? Sandbox.Denial {
+            reason = denial.reason
+        } else {
+            reason = String(describing: error)
+        }
+        let pathPart = path.map { ", \(syscall) '\($0)'" } ?? ""
+        let msg = "EACCES: permission denied (\(reason))\(pathPart)"
+        var extras: [String: Any] = [
+            "errno": Int(-EACCES),
+            "syscall": syscall,
+        ]
+        if let path { extras["path"] = path }
+        return throwJSError(msg, code: "EACCES", extras: extras)
+    }
+
+    /// Build (don't throw) a Node-shaped network-deny JS Error for
+    /// async paths that need to reject a Promise rather than set
+    /// `ctx.exception`.
+    func makeNetworkDenialError(
+        _ error: Error,
+        in ctx: JSContext,
+        url: String
+    ) -> JSValue {
+        let msg: String
+        if let denial = error as? Sandbox.Denial {
+            msg = "fetch denied: \(denial.reason): \(url)"
+        } else if let netDeny = error as? NetworkAccessDenied {
+            msg = String(describing: netDeny)
+        } else {
+            msg = "fetch denied: \(error): \(url)"
+        }
+        return makeJSError(
+            msg,
+            in: ctx,
+            code: "EACCES",
+            extras: ["url": url]
+        )
+    }
+}
+
+#endif

--- a/Sources/SwiftJSCore/SandboxBridge.swift
+++ b/Sources/SwiftJSCore/SandboxBridge.swift
@@ -22,6 +22,42 @@ enum PathAccessIntent: Sendable {
     case delete
 }
 
+/// Resolve a JS-side path against the bound shell's logical CWD when
+/// it's relative. Mirrors Node's `process.chdir` semantics: after
+/// `process.chdir("/work")`, `readFileSync("./x")` opens `/work/x`.
+///
+/// Why this matters for sandbox correctness: under a non-default
+/// `Shell`, `process.chdir(...)` updates `Shell.current.environment
+/// .workingDirectory` but doesn't touch the host process CWD (we
+/// can't, the host is shared with the embedder). Without this
+/// resolver, every relative-path `fs.*` call would resolve against
+/// the host CWD via `URL(fileURLWithPath:)` — so `process.cwd()`
+/// would diverge from where `readFileSync("./x")` actually reads,
+/// and the gate would authorize the wrong path. Pre-resolving here
+/// means the gate sees what the script intended, and the Foundation
+/// hop that follows opens the same file.
+///
+/// Under `Shell.processDefault` the bound CWD mirrors the host
+/// process CWD, so the result is identical to plain
+/// `URL(fileURLWithPath: path).path` — the standalone `swift-js` CLI
+/// behaviour is unchanged.
+func resolveAgainstShellCWD(_ path: String) -> String {
+    let raw: String
+    if (path as NSString).isAbsolutePath {
+        raw = path
+    } else {
+        let cwd = Shell.current === Shell.processDefault
+            ? FileManager.default.currentDirectoryPath
+            : Shell.current.environment.workingDirectory
+        raw = (cwd as NSString).appendingPathComponent(path)
+    }
+    // Collapse `./` and `../` segments so the gate sees a canonical
+    // form. NSString's `standardizingPath` only resolves symlinks
+    // when doing so doesn't alter intermediate path components, so
+    // sandbox prefix matching stays predictable.
+    return (raw as NSString).standardizingPath
+}
+
 /// Authorize a filesystem access against the bound shell's sandbox.
 /// Throws ``ShellKit.Sandbox.Denial`` when the bound sandbox rejects
 /// the path; returns silently when no sandbox is bound.
@@ -91,7 +127,16 @@ func checkNetworkAllowed(
 ) throws {
     if config.dangerouslyAllowFullInternetAccess { return }
     let normalised = method.uppercased()
-    let knownMethod = HTTPMethod(rawValue: normalised) ?? .GET
+    // Unknown verbs (LINK, UNLINK, custom WebDAV, …) must be rejected
+    // outright — falling back to `.GET` would silently grant a method
+    // the embedder never approved, since `fetch(url, { method: "FOO" })`
+    // would be evaluated against GET permissions while the actual
+    // request method stayed `FOO`.
+    guard let knownMethod = HTTPMethod(rawValue: normalised) else {
+        throw NetworkAccessDenied(
+            url: url,
+            reason: "HTTP method \(normalised) not supported by network gate")
+    }
     if !config.allowedMethods.contains(knownMethod) {
         throw NetworkAccessDenied(
             url: url,

--- a/Tests/BashInterpreterTests/ScriptInterpreterTests.swift
+++ b/Tests/BashInterpreterTests/ScriptInterpreterTests.swift
@@ -257,12 +257,19 @@ import Foundation
         #expect(cap.stderr.contains("command not found"))
     }
 
+    #if !os(Windows)
     @Test func nonExecutableScriptRejectedWithPermissionDenied() async throws {
         // A regular file with a matching shebang but no execute bit
         // is rejected with 126 / "Permission denied" — matches bash
         // `./script` when the file isn't `chmod +x`'d. Without this
         // check, the dispatcher would happily run a 0644 file the
         // user never marked as runnable.
+        //
+        // Skipped on Windows: there's no POSIX execute bit there, so
+        // `setAttributes(posixPermissions:)` is a no-op and the
+        // dispatcher's executable-bit check is disabled (see
+        // `Shell+ExternalScript.swift`). The test concept doesn't
+        // map to the platform.
         let cap = CapturingShell()
         let dir = NSTemporaryDirectory()
             + "swift-bash-shebang-perm-\(UUID().uuidString)"
@@ -283,6 +290,7 @@ import Foundation
         #expect(status.code == 126)
         #expect(cap.stderr.contains("Permission denied"))
     }
+    #endif
 
     @Test func unreadableScriptReportsPermissionDenied() async throws {
         // A path the FS rejects (sandbox denial, EACCES) on `metadata`

--- a/Tests/BashInterpreterTests/ScriptInterpreterTests.swift
+++ b/Tests/BashInterpreterTests/ScriptInterpreterTests.swift
@@ -153,15 +153,20 @@ import Foundation
         try await cap.shell.run("\(Self.bashQuote(path)) one two")
         let ctxs = await sink.contexts
         #expect(ctxs.count == 1)
-        #expect(ctxs.first?.scriptPath == path)
+        // The dispatcher hands over the *resolved* path (drive-letter
+        // forward-slash form on Windows; identity on Unix). Compute
+        // the expected form via the same `resolvePath` so the
+        // assertion stays platform-independent.
+        let resolvedPath = cap.shell.resolvePath(path)
+        #expect(ctxs.first?.scriptPath == resolvedPath)
         #expect(ctxs.first?.shebang == "#!/usr/bin/env foolang")
-        #expect(ctxs.first?.argv == [path, "one", "two"])
+        #expect(ctxs.first?.argv == [resolvedPath, "one", "two"])
         // Body should be stripped — no leading `#!` survives. The
         // newline is retained so line 2 of the file is still line 2
         // of the body.
         #expect(ctxs.first?.source.hasPrefix("#!") == false)
         #expect(ctxs.first?.source.hasPrefix("\n") == true)
-        #expect(cap.stdout == "ran:\(path),one,two\n")
+        #expect(cap.stdout == "ran:\(resolvedPath),one,two\n")
     }
 
     @Test func dispatchPropagatesPositionalsToScript() async throws {
@@ -182,7 +187,8 @@ import Foundation
             return .success
         }
         try await cap.shell.run("\(Self.bashQuote(path)) alpha beta gamma")
-        #expect(cap.stdout == "$0=\(path) $@=alpha beta gamma\n")
+        let resolvedPath = cap.shell.resolvePath(path)
+        #expect(cap.stdout == "$0=\(resolvedPath) $@=alpha beta gamma\n")
     }
 
     @Test func parentPositionalsArePreservedAfterDispatch() async throws {

--- a/Tests/BashInterpreterTests/ScriptInterpreterTests.swift
+++ b/Tests/BashInterpreterTests/ScriptInterpreterTests.swift
@@ -17,6 +17,19 @@ import Foundation
             ofItemAtPath: path)
     }
 
+    /// POSIX-style single-quote a path so it survives bash's word-
+    /// expansion intact. Critical on Windows: `NSTemporaryDirectory()`
+    /// returns paths with `\` separators, and unquoted `\X` is a bash
+    /// escape — the path makes it to `cap.shell.run(...)` with every
+    /// backslash already eaten, so the dispatcher never sees a
+    /// `/`-bearing token and falls through to `command not found`.
+    /// Embedded single quotes are encoded as `'\''` (the standard
+    /// POSIX trick); UUID-bearing test paths don't contain quotes,
+    /// but the helper is correct in general.
+    private static func bashQuote(_ s: String) -> String {
+        "'" + s.replacingOccurrences(of: "'", with: "'\\''") + "'"
+    }
+
     // MARK: parseShebangLine
 
     @Test func parsesPlainShebang() {
@@ -137,7 +150,7 @@ import Foundation
             return .success
         }
 
-        try await cap.shell.run("\(path) one two")
+        try await cap.shell.run("\(Self.bashQuote(path)) one two")
         let ctxs = await sink.contexts
         #expect(ctxs.count == 1)
         #expect(ctxs.first?.scriptPath == path)
@@ -168,7 +181,7 @@ import Foundation
                 "$0=\(Shell.current.scriptName) $@=\(pos.joined(separator: " "))\n")
             return .success
         }
-        try await cap.shell.run("\(path) alpha beta gamma")
+        try await cap.shell.run("\(Self.bashQuote(path)) alpha beta gamma")
         #expect(cap.stdout == "$0=\(path) $@=alpha beta gamma\n")
     }
 
@@ -188,7 +201,7 @@ import Foundation
         cap.shell.registerScriptInterpreter(name: "foolang") { _ in
             return .success
         }
-        try await cap.shell.run("\(path) inner")
+        try await cap.shell.run("\(Self.bashQuote(path)) inner")
         #expect(cap.shell.scriptName == "outer")
         #expect(cap.shell.positionalParameters == ["outerArg"])
     }
@@ -205,7 +218,7 @@ import Foundation
         cap.shell.registerScriptInterpreter(name: "foolang") { _ in
             ExitStatus(7)
         }
-        try await cap.shell.run("\(path); echo $?")
+        try await cap.shell.run("\(Self.bashQuote(path)); echo $?")
         #expect(cap.stdout == "7\n")
     }
 
@@ -226,7 +239,7 @@ import Foundation
             atPath: dir, withIntermediateDirectories: true)
         defer { try? FileManager.default.removeItem(atPath: dir) }
         cap.shell.registerScriptInterpreter(name: "foolang") { _ in .success }
-        let status = try await cap.shell.run(dir)
+        let status = try await cap.shell.run(Self.bashQuote(dir))
         #expect(status.code == 126)
         #expect(cap.stderr.contains("Is a directory"))
     }
@@ -266,7 +279,7 @@ import Foundation
             Issue.record("interpreter should not have been invoked")
             return .success
         }
-        let status = try await cap.shell.run(path)
+        let status = try await cap.shell.run(Self.bashQuote(path))
         #expect(status.code == 126)
         #expect(cap.stderr.contains("Permission denied"))
     }
@@ -299,7 +312,7 @@ import Foundation
         defer { try? FileManager.default.removeItem(atPath: dir) }
         let path = dir + "/run.foo"
         try Self.writeExecutable("#!/usr/bin/env nope-lang\n", to: path)
-        let status = try await cap.shell.run("\(path)")
+        let status = try await cap.shell.run("\(Self.bashQuote(path))")
         #expect(status.code == 127)
         #expect(cap.stderr.contains("command not found"))
     }
@@ -319,7 +332,7 @@ import Foundation
             Shell.current.stdout("ok\n")
             return .success
         }
-        try await cap.shell.run("(\(path))")
+        try await cap.shell.run("(\(Self.bashQuote(path)))")
         #expect(cap.stdout == "ok\n")
     }
 
@@ -353,7 +366,7 @@ import Foundation
             await sink.record(ctx.source)
             return .success
         }
-        try await cap.shell.run(path)
+        try await cap.shell.run(Self.bashQuote(path))
         let body = await sink.source ?? ""
         let originalLines = original.split(separator: "\n",
                                            omittingEmptySubsequences: false)
@@ -376,7 +389,7 @@ import Foundation
         try Self.writeExecutable("#!/usr/bin/env foolang\nbody", to: path)
         cap.shell.registerScriptInterpreter(name: "foolang") { _ in .success }
         cap.shell.unregisterScriptInterpreter("foolang")
-        let status = try await cap.shell.run("\(path)")
+        let status = try await cap.shell.run("\(Self.bashQuote(path))")
         #expect(status.code == 127)
     }
 }

--- a/Tests/BashSwiftScriptTests/BashSwiftScriptTests.swift
+++ b/Tests/BashSwiftScriptTests/BashSwiftScriptTests.swift
@@ -58,6 +58,15 @@ import ShellKit
         return (path, dir)
     }
 
+    /// POSIX-single-quote a path so it survives bash's word
+    /// expansion intact. Critical on Windows where
+    /// `NSTemporaryDirectory()` returns `\`-separated paths and
+    /// unquoted `\X` is a bash escape — without quoting the path
+    /// reaches the dispatcher with every backslash already eaten.
+    private static func bashQuote(_ s: String) -> String {
+        "'" + s.replacingOccurrences(of: "'", with: "'\\''") + "'"
+    }
+
     // MARK: smoke
 
     @Test func runsHelloWorldFromShebang() async throws {
@@ -68,7 +77,7 @@ import ShellKit
             """)
         defer { try? FileManager.default.removeItem(atPath: s.dir) }
 
-        let status = try await shell.run(s.path)
+        let status = try await shell.run(Self.bashQuote(s.path))
         #expect(status.code == 0)
         #expect(cap.stdout == "hello swiftscript\n")
     }
@@ -81,7 +90,7 @@ import ShellKit
             """)
         defer { try? FileManager.default.removeItem(atPath: s.dir) }
 
-        let status = try await shell.run(s.path)
+        let status = try await shell.run(Self.bashQuote(s.path))
         #expect(status.code == 0)
         #expect(cap.stdout == "42\n")
     }
@@ -98,9 +107,12 @@ import ShellKit
             """)
         defer { try? FileManager.default.removeItem(atPath: s.dir) }
 
-        try await shell.run("\(s.path) one two three")
+        try await shell.run("\(Self.bashQuote(s.path)) one two three")
         let lines = cap.stdout.split(separator: "\n").map(String.init)
-        #expect(lines == [s.path, "one", "two", "three"])
+        // The dispatcher passes the *resolved* path through
+        // `CommandLine.arguments[0]` — on Windows that's the
+        // forward-slash drive-letter form, on Unix it's identity.
+        #expect(lines == [shell.resolvePath(s.path), "one", "two", "three"])
     }
 
     // MARK: exit code
@@ -117,7 +129,7 @@ import ShellKit
             """)
         defer { try? FileManager.default.removeItem(atPath: s.dir) }
 
-        let status = try await shell.run(s.path)
+        let status = try await shell.run(Self.bashQuote(s.path))
         #expect(status.code == 7)
         #expect(cap.stdout == "before\n")
     }
@@ -132,7 +144,7 @@ import ShellKit
             """)
         defer { try? FileManager.default.removeItem(atPath: s.dir) }
 
-        try await shell.run("\(s.path); echo $?")
+        try await shell.run("\(Self.bashQuote(s.path)); echo $?")
         #expect(cap.stdout == "3\n")
     }
 
@@ -146,7 +158,7 @@ import ShellKit
             """)
         defer { try? FileManager.default.removeItem(atPath: s.dir) }
 
-        let status = try await shell.run(s.path)
+        let status = try await shell.run(Self.bashQuote(s.path))
         #expect(status.code == 1)
         #expect(cap.stderr.contains("error:"))
     }
@@ -163,7 +175,7 @@ import ShellKit
             """)
         defer { try? FileManager.default.removeItem(atPath: s.dir) }
 
-        _ = try await shell.run(s.path)
+        _ = try await shell.run(Self.bashQuote(s.path))
         let captured = cap.stderr
         let mentions3 = captured.contains(":3:") || captured.contains("3 |")
         #expect(mentions3, "expected line-3 reference in stderr")
@@ -181,7 +193,7 @@ import ShellKit
             """)
         defer { try? FileManager.default.removeItem(atPath: s.dir) }
 
-        try await shell.run("\(s.path) inner")
+        try await shell.run("\(Self.bashQuote(s.path)) inner")
         #expect(shell.scriptName == "outer")
         #expect(shell.positionalParameters == ["outerArg"])
     }
@@ -201,7 +213,7 @@ import ShellKit
             """)
         defer { try? FileManager.default.removeItem(atPath: s.dir) }
 
-        try await shell.run("echo hello | \(s.path)")
+        try await shell.run("echo hello | \(Self.bashQuote(s.path))")
         #expect(cap.stdout == "got: hello\n")
     }
 
@@ -232,7 +244,7 @@ import ShellKit
             """)
         defer { try? FileManager.default.removeItem(atPath: s.dir) }
 
-        try await shell.run(s.path)
+        try await shell.run(Self.bashQuote(s.path))
         #expect(cap.stdout == "denied\n")
     }
 
@@ -251,7 +263,7 @@ import ShellKit
             """)
         defer { try? FileManager.default.removeItem(atPath: s.dir) }
 
-        try await shell.run(s.path)
+        try await shell.run(Self.bashQuote(s.path))
         #expect(cap.stdout == "agent\nsandbox.local\n")
     }
 }

--- a/Tests/SwiftJSCoreTests/SandboxGateTests.swift
+++ b/Tests/SwiftJSCoreTests/SandboxGateTests.swift
@@ -1,0 +1,340 @@
+import XCTest
+@testable import SwiftJSCore
+import BashInterpreter
+import BashCommandKit
+
+#if canImport(JavaScriptCore)
+
+/// Verifies that every host-touching JS surface in SwiftJSCore consults
+/// the bound `Shell`'s `sandbox` / `networkConfig` and the synthetic
+/// identity fields on `hostInfo` / `environment`. Mirrors the pattern
+/// `SwiftScript`'s `ShellKitIntegrationTests` use: bind a shell with a
+/// confining sandbox, run a JS snippet, assert the JS-side error shape
+/// or the redirected value.
+final class SandboxGateTests: XCTestCase {
+
+    // MARK: - Helpers
+
+    private func makeRuntime() -> (JSRuntime, () -> String, () -> String) {
+        var out = ""
+        var err = ""
+        let r = JSRuntime(
+            argv: ["swift-js", "test.js"],
+            env: ["FOO": "bar"],
+            stdout: { out += $0 },
+            stderr: { err += $0 }
+        )
+        return (r, { out }, { err })
+    }
+
+    private func withSandboxedShell(
+        sandbox: Sandbox? = nil,
+        networkConfig: NetworkConfig? = nil,
+        env: [String: String] = [:],
+        cwd: String? = nil,
+        hostName: String = "sandbox",
+        userName: String = "user",
+        virtualPID: Int32 = 1,
+        body: () -> Void
+    ) async {
+        let shell = Shell(
+            environment: Environment(
+                variables: env,
+                workingDirectory: cwd ?? "/sandbox-cwd"
+            ),
+            sandbox: sandbox,
+            networkConfig: networkConfig,
+            hostInfo: {
+                var info = HostInfo.synthetic
+                info.userName = userName
+                info.hostName = hostName
+                info.nodeName = hostName
+                return info
+            }(),
+            virtualPID: virtualPID
+        )
+        await shell.withCurrent { body() }
+    }
+
+    private func makeRootedSandbox() -> (Sandbox, URL) {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("swiftjs-sandbox-\(UUID().uuidString)",
+                                    isDirectory: true)
+        try? FileManager.default.createDirectory(
+            at: root, withIntermediateDirectories: true)
+        return (Sandbox.rooted(at: root, allowedHosts: []), root)
+    }
+
+    // MARK: - fs gate
+
+    func testReadFileSyncDeniedOutsideSandboxRoot() async {
+        let (r, _, _) = makeRuntime()
+        let (sandbox, root) = makeRootedSandbox()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        await withSandboxedShell(sandbox: sandbox) {
+            let result = r.run(#"""
+            try {
+              require('fs').readFileSync('/etc/passwd');
+              'no-throw';
+            } catch (e) {
+              `${e.code}|${e.syscall}`;
+            }
+            """#)
+            XCTAssertEqual(result?.toString(), "EACCES|open")
+        }
+    }
+
+    func testReadFileSyncAllowedInsideSandboxRoot() async throws {
+        let (r, _, _) = makeRuntime()
+        let (sandbox, root) = makeRootedSandbox()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let allowed = root.appendingPathComponent("note.txt")
+        try "hello".data(using: .utf8)!.write(to: allowed)
+
+        await withSandboxedShell(sandbox: sandbox) {
+            let result = r.run(#"""
+            require('fs').readFileSync('\#(allowed.path)', 'utf-8');
+            """#)
+            XCTAssertEqual(result?.toString(), "hello")
+        }
+    }
+
+    func testWriteFileSyncDeniedOutsideRoot() async {
+        let (r, _, _) = makeRuntime()
+        let (sandbox, root) = makeRootedSandbox()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        await withSandboxedShell(sandbox: sandbox) {
+            let result = r.run(#"""
+            try {
+              require('fs').writeFileSync('/tmp/should-not-exist.txt', 'x');
+              'no-throw';
+            } catch (e) {
+              e.code;
+            }
+            """#)
+            XCTAssertEqual(result?.toString(), "EACCES")
+        }
+    }
+
+    func testStatSyncDenied() async {
+        let (r, _, _) = makeRuntime()
+        let (sandbox, root) = makeRootedSandbox()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        await withSandboxedShell(sandbox: sandbox) {
+            let result = r.run(#"""
+            try {
+              require('fs').statSync('/etc');
+              'no-throw';
+            } catch (e) {
+              e.code;
+            }
+            """#)
+            XCTAssertEqual(result?.toString(), "EACCES")
+        }
+    }
+
+    func testExistsSyncReturnsFalseOnDeny() async {
+        let (r, _, _) = makeRuntime()
+        let (sandbox, root) = makeRootedSandbox()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        await withSandboxedShell(sandbox: sandbox) {
+            let result = r.run("require('fs').existsSync('/etc/passwd')")
+            XCTAssertEqual(result?.toBool(), false)
+        }
+    }
+
+    func testRequireRelativeDeniedOutsideRoot() async throws {
+        let (r, _, err) = makeRuntime()
+        let (sandbox, root) = makeRootedSandbox()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        // Stage a module *outside* the sandbox root.
+        let outside = FileManager.default.temporaryDirectory
+            .appendingPathComponent("swiftjs-outside-\(UUID().uuidString).js")
+        try "module.exports = 'leaked';".data(using: .utf8)!.write(to: outside)
+        defer { try? FileManager.default.removeItem(at: outside) }
+
+        await withSandboxedShell(sandbox: sandbox) {
+            r.run(#"""
+            try {
+              const v = require('\#(outside.path)');
+              console.log('LEAKED:' + v);
+            } catch (e) {
+              console.log('CODE:' + e.code);
+            }
+            """#)
+        }
+        let combined = err()  // throwSandboxDenial sets ctx.exception, which the
+        XCTAssertFalse(combined.contains("LEAKED:leaked"),
+                       "require should not have read outside-sandbox source")
+    }
+
+    // MARK: - fetch / network gate
+
+    func testFetchDeniedWhenURLNotInAllowList() async {
+        let (r, _, _) = makeRuntime()
+        let config = NetworkConfig(
+            allowedURLPrefixes: [AllowedURLEntry("https://allowed.example.com")],
+            allowedMethods: [.GET]
+        )
+
+        await withSandboxedShell(networkConfig: config) {
+            let promise = r.run(#"""
+            globalThis.__fetchOutcome = "(unset)";
+            fetch('https://denied.example.com/x')
+              .then(_ => { globalThis.__fetchOutcome = 'resolved'; })
+              .catch(e => { globalThis.__fetchOutcome = `${e.code}|${e.message}`; });
+            """#)
+            _ = promise
+            // Run the runloop briefly so the rejection propagates.
+            r.run("(() => { for (let i=0;i<3;i++) Promise.resolve().then(()=>{}); })();")
+            let outcome = r.run("globalThis.__fetchOutcome")?.toString() ?? ""
+            XCTAssertTrue(outcome.hasPrefix("EACCES|"), "got: \(outcome)")
+            XCTAssertTrue(outcome.contains("URL not in allow-list"),
+                          "got: \(outcome)")
+        }
+    }
+
+    func testFetchDeniedForBlockedMethod() async {
+        let (r, _, _) = makeRuntime()
+        let config = NetworkConfig(
+            allowedURLPrefixes: [AllowedURLEntry("https://allowed.example.com")],
+            allowedMethods: [.GET]  // POST not allowed
+        )
+
+        await withSandboxedShell(networkConfig: config) {
+            r.run(#"""
+            globalThis.__fetchOutcome = "(unset)";
+            fetch('https://allowed.example.com/x', { method: 'POST' })
+              .then(_ => { globalThis.__fetchOutcome = 'resolved'; })
+              .catch(e => { globalThis.__fetchOutcome = `${e.code}|${e.message}`; });
+            """#)
+            r.run("(() => { for (let i=0;i<3;i++) Promise.resolve().then(()=>{}); })();")
+            let outcome = r.run("globalThis.__fetchOutcome")?.toString() ?? ""
+            XCTAssertTrue(outcome.contains("HTTP method POST not in allow-list"),
+                          "got: \(outcome)")
+        }
+    }
+
+    // MARK: - child_process gate
+
+    func testSpawnDeniedUnderSandbox() async {
+        let (r, _, _) = makeRuntime()
+        let (sandbox, root) = makeRootedSandbox()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        await withSandboxedShell(sandbox: sandbox) {
+            let result = r.run(#"""
+            try {
+              require('child_process').spawn('whoami');
+              'no-throw';
+            } catch (e) {
+              `${e.code}|${e.syscall}`;
+            }
+            """#)
+            XCTAssertEqual(result?.toString(), "EACCES|spawn")
+        }
+    }
+
+    func testExecSyncDeniedUnderSandbox() async {
+        let (r, _, _) = makeRuntime()
+        let (sandbox, root) = makeRootedSandbox()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        await withSandboxedShell(sandbox: sandbox) {
+            let result = r.run(#"""
+            try {
+              require('child_process').execSync('echo hi');
+              'no-throw';
+            } catch (e) {
+              e.code;
+            }
+            """#)
+            XCTAssertEqual(result?.toString(), "EACCES")
+        }
+    }
+
+    // MARK: - identity redirects
+
+    func testProcessEnvRoutesThroughBoundShell() async {
+        let (r, _, _) = makeRuntime()
+
+        // FOO=bar in the runtime's envProvider, but BAZ=qux only in
+        // the bound Shell's environment. Under the bound shell, only
+        // BAZ should resolve — FOO must NOT leak through.
+        await withSandboxedShell(env: ["BAZ": "qux"]) {
+            let baz = r.run("process.env.BAZ")?.toString() ?? ""
+            XCTAssertEqual(baz, "qux")
+            let foo = r.run("process.env.FOO")
+            XCTAssertTrue(foo?.isUndefined ?? false || foo?.toString() == "undefined",
+                          "FOO must not leak through the bound shell")
+        }
+    }
+
+    func testProcessPidReturnsVirtualPID() async {
+        let (r, _, _) = makeRuntime()
+        await withSandboxedShell(virtualPID: 42) {
+            let pid = r.run("process.pid")?.toInt32() ?? -1
+            XCTAssertEqual(pid, 42)
+        }
+    }
+
+    func testProcessCwdReturnsBoundWorkingDirectory() async {
+        let (r, _, _) = makeRuntime()
+        await withSandboxedShell(cwd: "/sandboxed/path") {
+            let cwd = r.run("process.cwd()")?.toString() ?? ""
+            XCTAssertEqual(cwd, "/sandboxed/path")
+        }
+    }
+
+    func testProcessChdirDeniedOutsideSandbox() async {
+        let (r, _, _) = makeRuntime()
+        let (sandbox, root) = makeRootedSandbox()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        await withSandboxedShell(sandbox: sandbox, cwd: root.path) {
+            r.run(#"""
+            try { process.chdir('/etc'); globalThis.__chdirOutcome = 'no-throw'; }
+            catch (e) { globalThis.__chdirOutcome = e.code; }
+            """#)
+            let outcome = r.run("globalThis.__chdirOutcome")?.toString() ?? ""
+            XCTAssertEqual(outcome, "EACCES")
+        }
+    }
+
+    func testOsHostnameReflectsBoundShell() async {
+        let (r, _, _) = makeRuntime()
+        await withSandboxedShell(hostName: "fake-host") {
+            let h = r.run("require('os').hostname()")?.toString() ?? ""
+            XCTAssertEqual(h, "fake-host")
+        }
+    }
+
+    // MARK: - standalone passthrough (no Shell bound)
+
+    func testStandaloneFsReadsHostFiles() throws {
+        let (r, _, _) = makeRuntime()
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("swiftjs-standalone-\(UUID().uuidString).txt")
+        try "passthrough".data(using: .utf8)!.write(to: tmp)
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        // No Shell.withCurrent — Shell.processDefault is in scope, so
+        // every gate must be a no-op.
+        let v = r.run(#"require('fs').readFileSync('\#(tmp.path)', 'utf-8')"#)?.toString()
+        XCTAssertEqual(v, "passthrough")
+    }
+
+    func testStandalonePidIsRealPID() {
+        let (r, _, _) = makeRuntime()
+        let pid = r.run("process.pid")?.toInt32() ?? -1
+        XCTAssertEqual(pid, getpid())
+    }
+}
+
+#endif

--- a/Tests/SwiftJSCoreTests/SandboxGateTests.swift
+++ b/Tests/SwiftJSCoreTests/SandboxGateTests.swift
@@ -221,6 +221,32 @@ final class SandboxGateTests: XCTestCase {
         }
     }
 
+    func testFetchDeniedForUnknownHTTPMethod() async {
+        // Earlier the gate fell back to `.GET` when `HTTPMethod(rawValue:)`
+        // returned nil, so `fetch(url, { method: "FOO" })` would be
+        // evaluated against GET permissions and pass when only GET was
+        // allowed — even though the actual request method stayed `FOO`.
+        // Unknown verbs must be rejected outright.
+        let (r, _, _) = makeRuntime()
+        let config = NetworkConfig(
+            allowedURLPrefixes: [AllowedURLEntry("https://allowed.example.com")],
+            allowedMethods: [.GET, .POST, .PUT, .DELETE, .HEAD, .PATCH, .OPTIONS]
+        )
+
+        await withSandboxedShell(networkConfig: config) {
+            r.run(#"""
+            globalThis.__fetchOutcome = "(unset)";
+            fetch('https://allowed.example.com/x', { method: 'FOO' })
+              .then(_ => { globalThis.__fetchOutcome = 'resolved'; })
+              .catch(e => { globalThis.__fetchOutcome = `${e.code}|${e.message}`; });
+            """#)
+            r.run("(() => { for (let i=0;i<3;i++) Promise.resolve().then(()=>{}); })();")
+            let outcome = r.run("globalThis.__fetchOutcome")?.toString() ?? ""
+            XCTAssertTrue(outcome.contains("HTTP method FOO not supported"),
+                          "got: \(outcome)")
+        }
+    }
+
     // MARK: - child_process gate
 
     func testSpawnDeniedUnderSandbox() async {
@@ -304,6 +330,66 @@ final class SandboxGateTests: XCTestCase {
             """#)
             let outcome = r.run("globalThis.__chdirOutcome")?.toString() ?? ""
             XCTAssertEqual(outcome, "EACCES")
+        }
+    }
+
+    func testRelativePathResolvedAgainstBoundShellCWDAfterChdir() async throws {
+        // After `process.chdir(boundDir)`, a subsequent
+        // `fs.readFileSync("./marker")` must resolve relative to the
+        // bound shell's logical CWD — not the host process CWD. Earlier
+        // the relative-path resolution happened via `URL(fileURLWithPath:)`
+        // which uses host CWD, so `process.cwd()` and the actual file
+        // read diverged: the gate authorised the wrong path and the
+        // open failed (or succeeded against the wrong file).
+        let (r, _, _) = makeRuntime()
+        let (sandbox, root) = makeRootedSandbox()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        // Drop a sentinel so a relative read can find it once we chdir
+        // the bound shell into `root`.
+        try "inside".data(using: .utf8)!.write(
+            to: root.appendingPathComponent("marker"))
+
+        await withSandboxedShell(sandbox: sandbox, cwd: "/somewhere/else") {
+            // `chdir` into root (an allowed write under the rooted
+            // sandbox), then read `./marker` — which must resolve to
+            // `<root>/marker` for both the gate and the open.
+            let result = r.run(#"""
+            process.chdir('\#(root.path)');
+            require('fs').readFileSync('./marker', 'utf-8');
+            """#)
+            XCTAssertEqual(result?.toString(), "inside")
+        }
+    }
+
+    func testChdirAcceptsRelativePath() async throws {
+        // `process.chdir('./sub')` after `chdir('/work')` must end up
+        // at `/work/sub`. Storing the raw "./sub" into
+        // `Shell.current.environment.workingDirectory` would leave the
+        // bound CWD unusable for any subsequent `fs.*` op.
+        let (r, _, _) = makeRuntime()
+        let (sandbox, root) = makeRootedSandbox()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let sub = root.appendingPathComponent("sub", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: sub, withIntermediateDirectories: true)
+        try "leaf".data(using: .utf8)!.write(
+            to: sub.appendingPathComponent("file"))
+
+        await withSandboxedShell(sandbox: sandbox, cwd: root.path) {
+            // chdir('./sub') is relative — must compose with the
+            // existing bound CWD (root). Then a relative read
+            // `./file` resolves into <root>/sub/file.
+            let cwd = r.run(#"""
+            process.chdir('./sub');
+            process.cwd();
+            """#)?.toString() ?? ""
+            XCTAssertEqual(cwd, sub.path)
+
+            let leaf = r.run(#"require('fs').readFileSync('./file', 'utf-8')"#)?
+                .toString() ?? ""
+            XCTAssertEqual(leaf, "leaf")
         }
     }
 


### PR DESCRIPTION
## Summary

Closes [#17](https://github.com/Cocoanetics/SwiftBash/issues/17). SwiftJSCore previously routed `fs`, `fetch`, `child_process`, and identity surfaces (`process.{pid,ppid,env,cwd,chdir}`, `os.{homedir,tmpdir,hostname}`) straight to Foundation without consulting the bound `Shell`. A `swift-js` script in the same shell could break out where a `swift-script` script is now confined. This PR mirrors SwiftScript's [HostHooks.swift](https://github.com/Cocoanetics/SwiftScript/blob/feat/adopt-shellkit/Sources/SwiftScriptInterpreter/API/HostHooks.swift) pattern across every JS-side host hop.

- **New [`SandboxBridge.swift`](Sources/SwiftJSCore/SandboxBridge.swift)** — `authorizePath(_:for:)`, `authorizeURL(_:method:)`, `denyProcessIfSandboxed`, plus an `awaitSync` helper that captures `Shell.current` and re-binds it inside a detached `Task` so sync JS bridges (`fs.readFileSync`, `execSync`, …) can call the async gates without breaking Node's sync contract. `throwSandboxDenial` surfaces a Node-shape `EACCES` Error with `code` / `errno` / `syscall` / `path`.
- **Filesystem** — every `fs.*Sync` op plus the `require('./relative')` source-read call the path gate before touching disk. `existsSync` returns `false` on deny to match Node's spec (no leak through the boolean).
- **Network** — `fetch()` rejects the returned Promise before any socket opens when the URL or method falls outside the bound `NetworkConfig`.
- **Process spawning** — `child_process.{exec,execSync,spawn,spawnSync}` deny when a sandbox is bound, closing the `spawn('cat',['/etc/passwd'])` loophole without waiting on a virtual process table.
- **Identity redirects** route through `Shell.current` only when a non-default shell is bound; under `Shell.processDefault` the legacy host APIs (`getpid`, `NSHomeDirectory`, `OSEnvProvider`, `FileManager.currentDirectoryPath`) still answer, so the standalone `swift-js` CLI is byte-for-byte unchanged. `process.pid` / `ppid` switch to `Object.defineProperty` getters so each access re-reads the bound shell.

## Test plan

- [x] `swift test --filter SwiftJSCoreTests` — 111 / 111 pass (94 existing + 17 new in [`SandboxGateTests.swift`](Tests/SwiftJSCoreTests/SandboxGateTests.swift), covering deny + allow for fs / fetch / child_process / identity redirects + standalone passthrough)
- [x] `swift build` clean on macOS (Linux / Windows compile to the existing empty-module shape — every gate site is inside `#if canImport(JavaScriptCore)`)
- [x] Spot-check on iOS Simulator that gates compile through the App-Sandbox `child_process` deny path

🤖 Generated with [Claude Code](https://claude.com/claude-code)