### PR TITLE
BashProcessLauncher: route Shell.processLauncher through the bash command registry

### DIFF
--- a/Sources/BashInterpreter/API/BashProcessLauncher.swift
+++ b/Sources/BashInterpreter/API/BashProcessLauncher.swift
@@ -16,15 +16,27 @@ import ShellKit
 ///
 /// Resolution rules:
 /// - ``Executable/name(_:)`` is looked up by the supplied name as-is.
-/// - ``Executable/path(_:)`` is resolved by basename (so
-///   `/usr/bin/echo` finds the registered `echo`); SwiftBash's
-///   virtual `/bin` and `/usr/bin` already make these paths point at
-///   the registry from the bash side, and this matches that view from
-///   the launcher side.
+/// - ``Executable/path(_:)`` resolves only when the supplied path
+///   matches the canonical bin location for the name in
+///   ``ShellKit/BinCatalog`` (so `/bin/echo` and `/usr/bin/jq`
+///   resolve, but `/tmp/echo` doesn't — that one would be running
+///   *some* file on disk under a different command shape, not the
+///   registered `echo`). Mirrors ``VirtualBinFileSystem``'s
+///   synthesized-file rule on the bash side.
 /// - A miss throws ``ProcessLaunchUnresolved`` — for SwiftBash that
 ///   means "command not found." Bash itself never composes through
 ///   ``ChainLauncher`` (no real-exec fall-through), so the error is
 ///   what reaches the caller.
+///
+/// Termination: a launched command that calls `exit N` (the bash
+/// `exit` builtin throws an internal ``ShellExit`` to unwind the
+/// interpreter) is caught here and converted to an
+/// ``ExecutionRecord`` with `.exited(N)`. Without this catch, an
+/// `exit` from a script-launched command would unwind the caller's
+/// own task as an error rather than reporting a clean exit code —
+/// that's wrong for subprocess-style callers (a SwiftScript /
+/// SwiftJSCore bridge running `Subprocess.run(.name("exit-1"))`
+/// expects an `ExecutionRecord` back, not a thrown error).
 ///
 /// Stdio: the launcher swaps the subshell's `stdin` / `stdout` /
 /// `stderr` to the caller-supplied sinks before running the command,
@@ -61,7 +73,20 @@ public struct BashProcessLauncher: ProcessLauncher {
         case .name(let n):
             resolvedName = n
         case .path(let p):
-            resolvedName = (p as NSString).lastPathComponent
+            // Path-based resolution is restricted to the canonical
+            // bin paths registered with `BinCatalog` (`/bin/echo`,
+            // `/usr/bin/jq`, `/usr/local/bin/rg`, …). Anything else
+            // — `/tmp/echo`, a relative path, an absolute path
+            // shadowing a builtin — falls through to "unresolved"
+            // because dispatching it to the registered command would
+            // change exact-path subprocess semantics.
+            let basename = (p as NSString).lastPathComponent
+            guard let canonical = BinCatalog.knownPaths[basename],
+                  canonical == p
+            else {
+                throw ProcessLaunchUnresolved(executable: executable)
+            }
+            resolvedName = basename
         }
 
         guard let command = parent.commands[resolvedName] else {
@@ -83,8 +108,21 @@ public struct BashProcessLauncher: ProcessLauncher {
 
         let argv = [resolvedName] + arguments.values
 
-        let status: ExitStatus = try await subShell.withCurrent {
-            try await command.run(argv)
+        // `ExitCommand` (and any registered command that calls into
+        // the same machinery) throws an internal `ShellExit` to
+        // unwind the interpreter on `exit N`. The bash dispatcher
+        // catches it at the top of `Shell.run`, but a launcher
+        // consumer is calling beneath that — so a child `exit 1`
+        // would otherwise unwind the caller's task as an error
+        // instead of reporting a clean exit code. Translate it here
+        // to the `.exited(N)` record the caller expects.
+        let status: ExitStatus
+        do {
+            status = try await subShell.withCurrent {
+                try await command.run(argv)
+            }
+        } catch let exit as ShellExit {
+            status = exit.status
         }
 
         return ExecutionRecord(

--- a/Sources/BashInterpreter/API/BashProcessLauncher.swift
+++ b/Sources/BashInterpreter/API/BashProcessLauncher.swift
@@ -1,0 +1,94 @@
+import Foundation
+import ShellKit
+
+/// `ProcessLauncher` that resolves an executable against this shell's
+/// command registry and runs the matching ``Command`` in a subshell
+/// with the supplied environment / cwd / stdio overrides applied.
+///
+/// SwiftBash is a pure-Swift, sandbox-by-default interpreter — there
+/// is no `posix_spawn` / `fork` path. Every "process" is a registered
+/// Swift command. This launcher is the door through which any
+/// `ShellKit.Shell.current.processLauncher` consumer reaches that
+/// registry: a SwiftScript script going through its `Subprocess`
+/// bridge, a SwiftJSCore script going through `child_process.spawn`,
+/// any future runtime — all converge on the same `commands[…]` table
+/// when bound to a SwiftBash `Shell`.
+///
+/// Resolution rules:
+/// - ``Executable/name(_:)`` is looked up by the supplied name as-is.
+/// - ``Executable/path(_:)`` is resolved by basename (so
+///   `/usr/bin/echo` finds the registered `echo`); SwiftBash's
+///   virtual `/bin` and `/usr/bin` already make these paths point at
+///   the registry from the bash side, and this matches that view from
+///   the launcher side.
+/// - A miss throws ``ProcessLaunchUnresolved`` — for SwiftBash that
+///   means "command not found." Bash itself never composes through
+///   ``ChainLauncher`` (no real-exec fall-through), so the error is
+///   what reaches the caller.
+///
+/// Stdio: the launcher swaps the subshell's `stdin` / `stdout` /
+/// `stderr` to the caller-supplied sinks before running the command,
+/// so anything the command writes to ``Shell/stdout`` is streamed
+/// straight to the caller. The returned ``ExecutionRecord`` carries
+/// empty `standardOutput` / `standardError` buffers — consumers that
+/// want a buffered copy (SwiftScript's `Output.string(limit:)`
+/// adapter) supply a buffering ``OutputSink`` and read it after
+/// ``launch(_:arguments:environment:workingDirectory:input:output:error:)``
+/// returns.
+public struct BashProcessLauncher: ProcessLauncher {
+
+    public init() {}
+
+    public func launch(
+        _ executable: Executable,
+        arguments: Arguments,
+        environment: Environment,
+        workingDirectory: String?,
+        input: InputSource,
+        output: OutputSink,
+        error: OutputSink
+    ) async throws -> ExecutionRecord {
+        // Read the bash-typed TaskLocal — the launcher's caller is
+        // expected to be running inside a `Shell.bashCurrent.withCurrent`
+        // binding (the SwiftScript / SwiftJSCore bridges run their
+        // script bodies that way). Falls back to the default shell
+        // outside that context, in which case the registry is empty
+        // and resolution misses cleanly.
+        let parent = Shell.bashCurrent
+
+        let resolvedName: String
+        switch executable.storage {
+        case .name(let n):
+            resolvedName = n
+        case .path(let p):
+            resolvedName = (p as NSString).lastPathComponent
+        }
+
+        guard let command = parent.commands[resolvedName] else {
+            throw ProcessLaunchUnresolved(executable: executable)
+        }
+
+        // Subshell for the run. `copy()` already inherits everything
+        // inheritable (including the parent's `processLauncher`, so a
+        // command that re-enters this launcher recursively keeps
+        // resolving against the same registry).
+        let subShell = parent.copy()
+        subShell.environment = environment
+        if let wd = workingDirectory, !wd.isEmpty {
+            subShell.environment.workingDirectory = wd
+        }
+        subShell.stdin = input
+        subShell.stdout = output
+        subShell.stderr = error
+
+        let argv = [resolvedName] + arguments.values
+
+        let status: ExitStatus = try await subShell.withCurrent {
+            try await command.run(argv)
+        }
+
+        return ExecutionRecord(
+            processIdentifier: Int64(parent.virtualPID),
+            terminationStatus: TerminationStatus.exited(status.code))
+    }
+}

--- a/Sources/BashInterpreter/API/Shell.swift
+++ b/Sources/BashInterpreter/API/Shell.swift
@@ -216,11 +216,19 @@ public final class Shell: ShellKit.Shell, @unchecked Sendable {
         hostInfo: HostInfo = .synthetic,
         processTable: ProcessTable = ProcessTable(),
         virtualPID: Int32 = 1,
-        commands: [String: Command] = [:]
+        commands: [String: Command] = [:],
+        processLauncher: (any ProcessLauncher)? = nil
     ) {
         // FileSystem is bash-specific (legacy protocol). The
         // VirtualBinFileSystem wrap happens after super.init.
         self._fileSystem = VirtualBinFileSystem(backing: RealFileSystem())
+        // SwiftBash is sandbox-by-default and never spawns real OS
+        // subprocesses. Resolve `nil` to ``BashProcessLauncher`` so a
+        // launcher consumer (a SwiftScript / SwiftJSCore script
+        // calling `Shell.current.processLauncher.launch(...)`)
+        // reaches this shell's command registry instead of falling
+        // through to `DefaultProcessLauncher`'s real-exec path that
+        // ShellKit installs by default.
         super.init(
             stdin: stdin,
             stdout: stdout,
@@ -234,7 +242,8 @@ public final class Shell: ShellKit.Shell, @unchecked Sendable {
             hostInfo: hostInfo,
             processTable: processTable,
             virtualPID: virtualPID,
-            commands: commands)
+            commands: commands,
+            processLauncher: processLauncher ?? BashProcessLauncher())
     }
 
     /// Convenience initializer matching SwiftBash's pre-migration
@@ -245,7 +254,11 @@ public final class Shell: ShellKit.Shell, @unchecked Sendable {
                             commands: [String: Command] = Shell.defaultCommands(),
                             fileSystem: FileSystem = RealFileSystem())
     {
+        // `stdin:` is passed explicitly to disambiguate this call from
+        // the convenience init (which doesn't have a `stdin:` parameter)
+        // — without it the overload set is ambiguous between the two.
         self.init(
+            stdin: .empty,
             stdout: stdout ?? .forwarding(to: FileHandle.standardOutput),
             stderr: stderr ?? .forwarding(to: FileHandle.standardError),
             environment: environment,

--- a/Tests/BashInterpreterTests/BashProcessLauncherTests.swift
+++ b/Tests/BashInterpreterTests/BashProcessLauncherTests.swift
@@ -42,11 +42,11 @@ import Testing
         #expect(buffer.text == "hello alice\n")
     }
 
-    @Test func launcherDispatchesByPathBasename() async throws {
-        // `Executable.path("/usr/bin/echo")` should reach the shell's
-        // registered `echo` — SwiftBash's virtual `/bin` and
-        // `/usr/bin` already make this true on the bash side, and
-        // basename-resolution mirrors that for any launcher consumer.
+    @Test func launcherDispatchesCanonicalBinPath() async throws {
+        // `Executable.path("/bin/echo")` should reach the shell's
+        // registered `echo` — that's the canonical bin path per
+        // `BinCatalog`, so it matches `VirtualBinFileSystem`'s
+        // synthesized-file rule on the bash side.
         let shell = Shell()
         shell.register(name: "echo") { argv in
             Shell.bashCurrent.stdout(argv.dropFirst().joined(separator: " ") + "\n")
@@ -56,7 +56,7 @@ import Testing
         let buffer = BufferingSink()
         let record = try await shell.withCurrent {
             try await shell.processLauncher.launch(
-                .path("/usr/bin/echo"),
+                .path("/bin/echo"),
                 arguments: ["hi"],
                 environment: shell.environment,
                 workingDirectory: nil,
@@ -67,6 +67,29 @@ import Testing
 
         #expect(record.terminationStatus.isSuccess)
         #expect(buffer.text == "hi\n")
+    }
+
+    @Test func launcherRefusesNonCanonicalPath() async {
+        // `/tmp/echo` is NOT a canonical bin path — basename-resolving
+        // it to the registered `echo` would change exact-path
+        // subprocess semantics (the caller asked for a specific file
+        // location, not the registry). Throws `ProcessLaunchUnresolved`
+        // instead of silently dispatching.
+        let shell = Shell()
+        shell.register(name: "echo") { _ in .success }
+
+        await #expect(throws: ProcessLaunchUnresolved.self) {
+            try await shell.withCurrent {
+                _ = try await shell.processLauncher.launch(
+                    .path("/tmp/echo"),
+                    arguments: [],
+                    environment: shell.environment,
+                    workingDirectory: nil,
+                    input: .empty,
+                    output: .discard,
+                    error: .discard)
+            }
+        }
     }
 
     // MARK: Resolve miss
@@ -172,6 +195,37 @@ import Testing
 
         #expect(bridgeBuffer.text == "captured\n")
         #expect(parentBuffer.text == "")
+    }
+
+    // MARK: exit-code conversion
+
+    @Test func launcherTranslatesExitToTerminationStatus() async throws {
+        // A launched command that calls `exit N` (the bash builtin
+        // throws an internal `ShellExit` to unwind) must surface as a
+        // clean `ExecutionRecord` with `.exited(N)` — NOT as a thrown
+        // error. Subprocess-style callers (a SwiftScript / SwiftJSCore
+        // bridge running `Subprocess.run(.name("exit-2"))`) expect a
+        // record back so they can branch on success / failure.
+        let shell = Shell()
+        // The default `exit` builtin is registered by `defaultCommands()`
+        // — exercise it directly.
+
+        let record = try await shell.withCurrent {
+            try await shell.processLauncher.launch(
+                .name("exit"),
+                arguments: ["7"],
+                environment: shell.environment,
+                workingDirectory: nil,
+                input: .empty,
+                output: .discard,
+                error: .discard)
+        }
+
+        guard case .exited(let code) = record.terminationStatus else {
+            Issue.record("expected .exited, got \(record.terminationStatus)")
+            return
+        }
+        #expect(code == 7)
     }
 
     @Test func launcherEnvironmentMutationsDontLeakToParent() async throws {

--- a/Tests/BashInterpreterTests/BashProcessLauncherTests.swift
+++ b/Tests/BashInterpreterTests/BashProcessLauncherTests.swift
@@ -1,0 +1,244 @@
+import Foundation
+import Testing
+@testable import BashInterpreter
+
+@Suite(.timeLimit(.minutes(1))) struct BashProcessLauncherTests {
+
+    // MARK: Default install
+
+    @Test func defaultLauncherIsBashProcessLauncher() {
+        let shell = Shell()
+        // The SwiftBash designated init resolves a `nil`
+        // `processLauncher` argument to ``BashProcessLauncher`` instead
+        // of the ShellKit-default ``DefaultProcessLauncher``.
+        // (Fall-through to real exec is wrong for SwiftBash's
+        // sandbox-by-default model.)
+        #expect(shell.processLauncher is BashProcessLauncher)
+    }
+
+    // MARK: Resolve hit
+
+    @Test func launcherDispatchesByExecutableName() async throws {
+        let shell = Shell()
+        shell.register(name: "greet") { argv in
+            let who = argv.dropFirst().first ?? "world"
+            Shell.bashCurrent.stdout("hello \(who)\n")
+            return .success
+        }
+
+        let buffer = BufferingSink()
+        let record = try await shell.withCurrent {
+            try await shell.processLauncher.launch(
+                .name("greet"),
+                arguments: ["alice"],
+                environment: shell.environment,
+                workingDirectory: nil,
+                input: .empty,
+                output: buffer.sink,
+                error: .discard)
+        }
+
+        #expect(record.terminationStatus.isSuccess)
+        #expect(buffer.text == "hello alice\n")
+    }
+
+    @Test func launcherDispatchesByPathBasename() async throws {
+        // `Executable.path("/usr/bin/echo")` should reach the shell's
+        // registered `echo` — SwiftBash's virtual `/bin` and
+        // `/usr/bin` already make this true on the bash side, and
+        // basename-resolution mirrors that for any launcher consumer.
+        let shell = Shell()
+        shell.register(name: "echo") { argv in
+            Shell.bashCurrent.stdout(argv.dropFirst().joined(separator: " ") + "\n")
+            return .success
+        }
+
+        let buffer = BufferingSink()
+        let record = try await shell.withCurrent {
+            try await shell.processLauncher.launch(
+                .path("/usr/bin/echo"),
+                arguments: ["hi"],
+                environment: shell.environment,
+                workingDirectory: nil,
+                input: .empty,
+                output: buffer.sink,
+                error: .discard)
+        }
+
+        #expect(record.terminationStatus.isSuccess)
+        #expect(buffer.text == "hi\n")
+    }
+
+    // MARK: Resolve miss
+
+    @Test func launcherThrowsUnresolvedForUnknownName() async {
+        let shell = Shell(commands: [:])
+        // SwiftBash never composes through ChainLauncher — the
+        // unresolved error reaches the caller as the "command not
+        // found" signal.
+        await #expect(throws: ProcessLaunchUnresolved.self) {
+            try await shell.withCurrent {
+                _ = try await shell.processLauncher.launch(
+                    .name("does-not-exist"),
+                    arguments: [],
+                    environment: shell.environment,
+                    workingDirectory: nil,
+                    input: .empty,
+                    output: .discard,
+                    error: .discard)
+            }
+        }
+    }
+
+    // MARK: Argv plumbing
+
+    @Test func launcherPassesArgvWithNameAtIndexZero() async throws {
+        let shell = Shell()
+        let captured = ArgvCapture()
+        shell.register(name: "argecho") { argv in
+            captured.set(argv)
+            return .success
+        }
+
+        try await shell.withCurrent {
+            _ = try await shell.processLauncher.launch(
+                .name("argecho"),
+                arguments: ["one", "two", "three"],
+                environment: shell.environment,
+                workingDirectory: nil,
+                input: .empty,
+                output: .discard,
+                error: .discard)
+        }
+
+        #expect(captured.value == ["argecho", "one", "two", "three"])
+    }
+
+    // MARK: Exit-code mapping
+
+    @Test func launcherReturnsExitCodeFromCommand() async throws {
+        let shell = Shell()
+        shell.register(name: "rc") { argv in
+            let code = Int32(argv.dropFirst().first.flatMap(Int.init) ?? 0)
+            return ExitStatus(code)
+        }
+
+        let record = try await shell.withCurrent {
+            try await shell.processLauncher.launch(
+                .name("rc"),
+                arguments: ["42"],
+                environment: shell.environment,
+                workingDirectory: nil,
+                input: .empty,
+                output: .discard,
+                error: .discard)
+        }
+
+        guard case .exited(let code) = record.terminationStatus else {
+            Issue.record("expected .exited, got \(record.terminationStatus)")
+            return
+        }
+        #expect(code == 42)
+    }
+
+    // MARK: Stdio override / sub-shell isolation
+
+    @Test func launcherStdoutGoesToCallerSinkNotShellSink() async throws {
+        // A SwiftScript / SwiftJSCore bridge that wants to capture
+        // output passes its own `OutputSink`. The parent shell's
+        // stdout (where bash command output normally goes) must NOT
+        // see the bytes — otherwise `$(cmd)` substitution and
+        // `Subprocess.run(.string(...))` would double-print.
+        let shell = Shell()
+        shell.register(name: "shout") { _ in
+            Shell.bashCurrent.stdout("captured\n")
+            return .success
+        }
+
+        let parentBuffer = BufferingSink()
+        shell.stdout = parentBuffer.sink
+
+        let bridgeBuffer = BufferingSink()
+        try await shell.withCurrent {
+            _ = try await shell.processLauncher.launch(
+                .name("shout"),
+                arguments: [],
+                environment: shell.environment,
+                workingDirectory: nil,
+                input: .empty,
+                output: bridgeBuffer.sink,
+                error: .discard)
+        }
+
+        #expect(bridgeBuffer.text == "captured\n")
+        #expect(parentBuffer.text == "")
+    }
+
+    @Test func launcherEnvironmentMutationsDontLeakToParent() async throws {
+        // The launcher copies the parent shell before applying
+        // overrides. A command that mutates `Shell.bashCurrent.environment`
+        // sees its mutations within the launch but the parent shell is
+        // untouched on the way out.
+        let shell = Shell()
+        shell.environment["PARENT_KEY"] = "parent"
+        shell.register(name: "tamper") { _ in
+            Shell.bashCurrent.environment["LEAKED"] = "yes"
+            return .success
+        }
+
+        var overrideEnv = shell.environment
+        overrideEnv["RUNTIME_OVERRIDE"] = "v"
+
+        try await shell.withCurrent {
+            _ = try await shell.processLauncher.launch(
+                .name("tamper"),
+                arguments: [],
+                environment: overrideEnv,
+                workingDirectory: nil,
+                input: .empty,
+                output: .discard,
+                error: .discard)
+        }
+
+        #expect(shell.environment["LEAKED"] == nil)
+        #expect(shell.environment["RUNTIME_OVERRIDE"] == nil)
+        #expect(shell.environment["PARENT_KEY"] == "parent")
+    }
+}
+
+// MARK: Helpers
+
+private final class BufferingSink: @unchecked Sendable {
+    private final class Box: @unchecked Sendable {
+        let lock = NSLock()
+        var buf = Data()
+    }
+    private let box = Box()
+    let sink: OutputSink
+
+    init() {
+        let box = self.box
+        self.sink = OutputSink(onWrite: { data in
+            box.lock.lock(); defer { box.lock.unlock() }
+            box.buf.append(data)
+        })
+    }
+
+    var text: String {
+        box.lock.lock(); defer { box.lock.unlock() }
+        return String(decoding: box.buf, as: UTF8.self)
+    }
+}
+
+private final class ArgvCapture: @unchecked Sendable {
+    private let lock = NSLock()
+    private var argv: [String] = []
+    func set(_ a: [String]) {
+        lock.lock(); defer { lock.unlock() }
+        argv = a
+    }
+    var value: [String] {
+        lock.lock(); defer { lock.unlock() }
+        return argv
+    }
+}


### PR DESCRIPTION
ShellKit landed [`Shell.processLauncher`](https://github.com/Cocoanetics/ShellKit/issues/1) as the unified subprocess-dispatch primitive. SwiftBash needs to install a launcher that resolves against the bash command registry instead of `DefaultProcessLauncher` (which would do real exec — wrong for SwiftBash's sandbox-by-default, pure-Swift, no-Process/fork/exec model).

This is the SwiftBash side of the polyglot subprocess unification: SwiftScript scripts going through their upcoming `Subprocess` bridge, SwiftJSCore scripts going through `child_process.spawn`, and any future runtime — all reach the same `commands[…]` table when bound to a SwiftBash `Shell`.

## Summary

- New [`BashProcessLauncher`](Sources/BashInterpreter/API/BashProcessLauncher.swift) — `ProcessLauncher` that:
  - Resolves `Executable.name(\"foo\")` → `Shell.bashCurrent.commands[\"foo\"]`.
  - Resolves `Executable.path(\"/usr/bin/foo\")` by basename. (SwiftBash's `VirtualBinFileSystem` already makes `/bin` and `/usr/bin` point at the registry from the bash side; the launcher mirrors that view for any external runtime.)
  - Throws `ProcessLaunchUnresolved` on miss — SwiftBash never composes through `ChainLauncher` (no real-exec fall-through), so this surfaces as \"command not found\" to the caller.
  - Copies the parent shell, applies `environment` / `workingDirectory` / `stdin` / `stdout` / `stderr` overrides on the copy, then runs the command via `subShell.withCurrent`. Caller-supplied `OutputSink` receives every byte the command writes to `Shell.bashCurrent.stdout`, without contaminating the parent shell's stdout (so `\$(cmd)` substitution and `Subprocess.run(.string(...))` don't double-print).

- [`Shell.swift`](Sources/BashInterpreter/API/Shell.swift) — designated `init(...)` resolves a `nil` `processLauncher` argument to `BashProcessLauncher()` instead of letting `ShellKit.Shell.init` substitute `DefaultProcessLauncher`. New parameter defaults; all existing call sites stay source-compatible.

- [`Package.resolved`](Package.resolved) — already at the `Shell.processLauncher`-bearing ShellKit commit (`4395986`).

## Tests

[`BashProcessLauncherTests`](Tests/BashInterpreterTests/BashProcessLauncherTests.swift) — 8 tests:

- `defaultLauncherIsBashProcessLauncher` — fresh `Shell()` gets the bash launcher, not the ShellKit default.
- `launcherDispatchesByExecutableName` — `.name(\"greet\")` resolves the registered command.
- `launcherDispatchesByPathBasename` — `.path(\"/usr/bin/echo\")` resolves the registered `echo`.
- `launcherThrowsUnresolvedForUnknownName` — miss throws `ProcessLaunchUnresolved`.
- `launcherPassesArgvWithNameAtIndexZero` — argv = `[name] + arguments.values`.
- `launcherReturnsExitCodeFromCommand` — `ExitStatus(42)` → `TerminationStatus.exited(42)`.
- `launcherStdoutGoesToCallerSinkNotShellSink` — bridge-supplied sink receives bytes; parent stdout is empty.
- `launcherEnvironmentMutationsDontLeakToParent` — sub-shell isolation verified.

Full SwiftBash suite: 1768 tests run; the 3 unrelated failures are timing-sensitive flakes in `StreamingPipelineTests.stagesRunConcurrently()` and `SleepLoopPipelineTests` (pass cleanly when run in isolation).

## Test plan

- [ ] CI green on macOS / iOS / tvOS / watchOS / Linux / Windows / Android
- [x] Local: 8/8 new tests pass; 1765/1768 in full suite (3 known timing flakes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)