### PR TITLE
BashInterpreter.Shell: forward processLauncher to super.init

### DIFF
--- a/Sources/BashInterpreter/API/Shell.swift
+++ b/Sources/BashInterpreter/API/Shell.swift
@@ -216,7 +216,8 @@ public final class Shell: ShellKit.Shell, @unchecked Sendable {
         hostInfo: HostInfo = .synthetic,
         processTable: ProcessTable = ProcessTable(),
         virtualPID: Int32 = 1,
-        commands: [String: Command] = [:]
+        commands: [String: Command] = [:],
+        processLauncher: (any ProcessLauncher)? = nil
     ) {
         // FileSystem is bash-specific (legacy protocol). The
         // VirtualBinFileSystem wrap happens after super.init.
@@ -234,7 +235,8 @@ public final class Shell: ShellKit.Shell, @unchecked Sendable {
             hostInfo: hostInfo,
             processTable: processTable,
             virtualPID: virtualPID,
-            commands: commands)
+            commands: commands,
+            processLauncher: processLauncher)
     }
 
     /// Convenience initializer matching SwiftBash's pre-migration


### PR DESCRIPTION
## Summary

ShellKit's [\`Shell.init\` (\`required\`)](https://github.com/Cocoanetics/ShellKit/blob/main/Sources/ShellKit/Shell.swift#L159) added a 14th parameter \`processLauncher: (any ProcessLauncher)?\` upstream. SwiftBash's \`Shell\` subclass override still listed only 13 parameters, so it stopped satisfying the required-init contract:

\`\`\`
error: 'required' initializer 'init(stdin:...:processLauncher:)'
       must be provided by subclass of 'Shell'
\`\`\`

This bites every Apple build on \`main\`. Adding the parameter (defaulting to \`nil\`, same default as the base) and forwarding it to \`super.init\` is a 4-line fix. \`ProcessLauncher\` is already in scope via the existing \`import ShellKit\` at the top of the file.

## Verification

Local: \`swift build --build-tests\` succeeds and the 1760-test suite passes.

Caught when CI on a separate PR ([#20](https://github.com/Cocoanetics/SwiftBash/pull/20)) surfaced this on macOS / iOS — fixing on \`main\` so that PR (and any other branches) clear the same blocker.

## Test plan

- [ ] macOS CI builds + tests pass
- [ ] iOS compile-only build passes
- [ ] Linux CI builds + tests pass
- [ ] Windows CI builds + tests pass
- [ ] Android CI builds + tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)