### PR TITLE
[research] JSC shutdown diagnostics for oven-sh/bun#30434

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -57,14 +57,23 @@ jobs:
       # Apple baseline (every variant should complete within
       # milliseconds). Compare against the Linux output to localise
       # which path Bun's standalone-mode teardown breaks on.
+      # macOS doesn't ship `timeout(1)`; install via coreutils so the
+      # loop semantics match Linux (kernel-enforced cap per variant
+      # plus per-variant exit codes printed for the data table).
+      - name: Install coreutils (for timeout)
+        run: brew list --versions coreutils >/dev/null 2>&1 || brew install coreutils
       - name: JSC shutdown diagnostics (macOS)
         if: always()
         run: |
+          set +e
           for variant in plain evaluated gc-then-release group-release no-release; do
             echo "::group::variant=$variant"
-            time .build/debug/swift-jsc-shutdown-diag "$variant" || true
+            gtimeout --preserve-status --kill-after=5s 20s \
+              .build/debug/swift-jsc-shutdown-diag "$variant"
+            echo "[exit=$?]"
             echo "::endgroup::"
           done
+          exit 0
 
   build-ios:
     # Compile-only check on `generic/platform=iOS` (no simulator boots).
@@ -137,18 +146,30 @@ jobs:
       - name: JSC smoke (Linux)
         run: .build/debug/swift-jsc-smoke
       # Research probe for oven-sh/bun#30434. Each variant is run
-      # separately so a hang in one doesn't block the others. The
-      # `|| true` is intentional — we want the timing data
-      # regardless of whether the binary aborts. The 10-s watchdog
-      # baked into the binary keeps each variant capped.
+      # separately so a hang in one doesn't block the others. Both
+      # the in-process 10 s watchdog AND an external `timeout 20s`
+      # cap each invocation: when the bun-webkit teardown hangs the
+      # main thread it can wedge stdio so badly the watchdog's own
+      # `raise(SIGABRT)` doesn't escape — observed in the first run,
+      # where `plain` froze and the bash for-loop never advanced. The
+      # external `timeout` is enforced by the kernel and reliably
+      # frees the loop so subsequent variants still get exercised.
+      # `--preserve-status` propagates the binary's exit code (or 124
+      # on timeout) so we can tell pass / hang / abort apart in logs.
       - name: JSC shutdown diagnostics (Linux)
         if: always()
         run: |
+          set +e
           for variant in plain evaluated gc-then-release group-release no-release; do
             echo "::group::variant=$variant"
-            time .build/debug/swift-jsc-shutdown-diag "$variant" || true
+            timeout --preserve-status --kill-after=5s 20s \
+              .build/debug/swift-jsc-shutdown-diag "$variant"
+            echo "[exit=$?]"
             echo "::endgroup::"
           done
+          # Step itself always succeeds; analyse via the per-variant
+          # exit codes printed above.
+          exit 0
 
   build-windows:
     # Windows is a committed compatibility target — the build and

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -53,6 +53,18 @@ jobs:
       # below so CI proves the same C-API path on every platform.
       - name: JSC smoke (macOS)
         run: .build/debug/swift-jsc-smoke
+      # Research probe for oven-sh/bun#30434 — this run gives the
+      # Apple baseline (every variant should complete within
+      # milliseconds). Compare against the Linux output to localise
+      # which path Bun's standalone-mode teardown breaks on.
+      - name: JSC shutdown diagnostics (macOS)
+        if: always()
+        run: |
+          for variant in plain evaluated gc-then-release group-release no-release; do
+            echo "::group::variant=$variant"
+            time .build/debug/swift-jsc-shutdown-diag "$variant" || true
+            echo "::endgroup::"
+          done
 
   build-ios:
     # Compile-only check on `generic/platform=iOS` (no simulator boots).
@@ -124,6 +136,19 @@ jobs:
         run: swift test -v --skip-build --no-parallel
       - name: JSC smoke (Linux)
         run: .build/debug/swift-jsc-smoke
+      # Research probe for oven-sh/bun#30434. Each variant is run
+      # separately so a hang in one doesn't block the others. The
+      # `|| true` is intentional — we want the timing data
+      # regardless of whether the binary aborts. The 10-s watchdog
+      # baked into the binary keeps each variant capped.
+      - name: JSC shutdown diagnostics (Linux)
+        if: always()
+        run: |
+          for variant in plain evaluated gc-then-release group-release no-release; do
+            echo "::group::variant=$variant"
+            time .build/debug/swift-jsc-shutdown-diag "$variant" || true
+            echo "::endgroup::"
+          done
 
   build-windows:
     # Windows is a committed compatibility target — the build and

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -46,8 +46,6 @@ jobs:
         run: swift --version
       - name: Build (macOS)
         run: swift build --build-tests -v
-      - name: Test (macOS)
-        run: swift test -v --skip-build --no-parallel
       # JSC linkage smoke check — uses the system JavaScriptCore
       # framework on Apple. Mirror of the non-Apple verification
       # below so CI proves the same C-API path on every platform.
@@ -60,10 +58,13 @@ jobs:
       # macOS doesn't ship `timeout(1)`; install via coreutils so the
       # loop semantics match Linux (kernel-enforced cap per variant
       # plus per-variant exit codes printed for the data table).
+      # Runs BEFORE the test step so a long / cancelled test phase
+      # can't truncate the diag output (observed once when Linux
+      # tests hit the 15 min job timeout and the diag step ran into
+      # the cancellation grace period).
       - name: Install coreutils (for timeout)
         run: brew list --versions coreutils >/dev/null 2>&1 || brew install coreutils
       - name: JSC shutdown diagnostics (macOS)
-        if: always()
         run: |
           set +e
           for variant in plain evaluated gc-then-release group-release no-release; do
@@ -74,6 +75,8 @@ jobs:
             echo "::endgroup::"
           done
           exit 0
+      - name: Test (macOS)
+        run: swift test -v --skip-build --no-parallel
 
   build-ios:
     # Compile-only check on `generic/platform=iOS` (no simulator boots).
@@ -141,8 +144,6 @@ jobs:
           ls -la Vendor/bun-webkit/current/include/JavaScriptCore/JavaScript.h
       - name: Build (Linux)
         run: swift build --build-tests -v
-      - name: Test (Linux)
-        run: swift test -v --skip-build --no-parallel
       - name: JSC smoke (Linux)
         run: .build/debug/swift-jsc-smoke
       # Research probe for oven-sh/bun#30434. Each variant is run
@@ -155,9 +156,13 @@ jobs:
       # external `timeout` is enforced by the kernel and reliably
       # frees the loop so subsequent variants still get exercised.
       # `--preserve-status` propagates the binary's exit code (or 124
-      # on timeout) so we can tell pass / hang / abort apart in logs.
+      # on timeout / 137 on SIGKILL after grace period) so we can
+      # distinguish pass / hang / abort in the data table. Runs BEFORE
+      # the test step so a long / cancelled test phase can't truncate
+      # the diag output (observed once when Linux tests hit the 15 min
+      # job timeout and the diag step ran into the cancellation grace
+      # period).
       - name: JSC shutdown diagnostics (Linux)
-        if: always()
         run: |
           set +e
           for variant in plain evaluated gc-then-release group-release no-release; do
@@ -170,6 +175,8 @@ jobs:
           # Step itself always succeeds; analyse via the per-variant
           # exit codes printed above.
           exit 0
+      - name: Test (Linux)
+        run: swift test -v --skip-build --no-parallel
 
   build-windows:
     # Windows is a committed compatibility target — the build and

--- a/Package.swift
+++ b/Package.swift
@@ -67,6 +67,15 @@ if registerJSCSmoke {
     // the package. See Docs/SwiftJS.md § Cross-platform.
     products.append(
         .executable(name: "swift-jsc-smoke", targets: ["swift-jsc-smoke"]))
+    // Research probe for the bun-webkit standalone-mode teardown
+    // stall (oven-sh/bun#30434). Each invocation runs ONE variant
+    // of the JSGlobalContext lifecycle with a 10-second watchdog.
+    // Used by the `JSC shutdown diagnostics` matrix in the CI
+    // workflow on this branch — collect timing data, not a permanent
+    // part of the package. Will be removed once we have a fix.
+    products.append(
+        .executable(name: "swift-jsc-shutdown-diag",
+                    targets: ["swift-jsc-shutdown-diag"]))
 }
 
 let package = Package(
@@ -511,6 +520,28 @@ let package = Package(
             // direct use of the platform's `stderr` global on
             // Linux / Android (Glibc.stderr is a `var`). Matches
             // the language mode the rest of this package runs in.
+            swiftSettings: [
+                .swiftLanguageMode(.v5),
+                .unsafeFlags(
+                    ["-Xcc", "-I\(bunWebKitDir)/include",
+                     "-Xcc", "-DSTATICALLY_LINKED_WITH_JavaScriptCore",
+                     "-Xcc", "-DSTATICALLY_LINKED_WITH_WTF"],
+                    .when(platforms: [.linux, .windows, .android])),
+            ]
+        ),
+        // Research probe for oven-sh/bun#30434 — see comment on the
+        // product entry above.
+        .executableTarget(
+            name: "swift-jsc-shutdown-diag",
+            dependencies: [
+                .target(
+                    name: "CJavaScriptCore",
+                    condition: .when(platforms: [
+                        .macOS, .iOS, .tvOS, .watchOS, .visionOS,
+                        .linux, .android,
+                    ])),
+            ],
+            path: "Sources/swift-jsc-shutdown-diag",
             swiftSettings: [
                 .swiftLanguageMode(.v5),
                 .unsafeFlags(

--- a/Sources/swift-jsc-shutdown-diag/main.swift
+++ b/Sources/swift-jsc-shutdown-diag/main.swift
@@ -1,0 +1,192 @@
+// CI-driven research probe for the bun-webkit JSC standalone-mode
+// teardown stall (oven-sh/bun#30434). Each invocation runs ONE
+// variant of the JSGlobalContext lifecycle, prints structured
+// timing, and either completes cleanly or aborts. Hard timeout
+// (10 s wall) forces a backtrace dump if the call hangs, so we
+// don't burn CI minutes waiting for the natural ~62 s SIGABRT.
+//
+// Variants (selected by argv[1]):
+//
+//   plain       — create + release, no JS executed.
+//   evaluated   — create + evaluate("1+2") + release.
+//   gc-then-release — create + evaluate("1+2") + JSGarbageCollect + release.
+//   group-release   — create + release-group, no per-context release.
+//   no-release  — create only; never release. (Control — should always exit cleanly.)
+//
+// Each variant prints `[stage] ...` markers with monotonic timestamps
+// so the CI log shows where the hang sits. The watchdog thread
+// raises SIGABRT at 10 s elapsed if the main thread is still inside
+// the release call — a debug Swift build then dumps a Swift
+// backtrace, which is more useful than the bare 62-s wait.
+import Foundation
+import CJavaScriptCore
+
+#if canImport(Darwin)
+import Darwin
+#elseif canImport(Android)
+import Android
+#elseif canImport(Bionic)
+import Bionic
+#elseif canImport(Glibc)
+import Glibc
+#elseif canImport(Musl)
+import Musl
+#endif
+
+// ---- Timing helpers --------------------------------------------------------
+
+let processStart = monotonicNs()
+
+func monotonicNs() -> UInt64 {
+    #if canImport(Darwin)
+    return clock_gettime_nsec_np(CLOCK_MONOTONIC)
+    #else
+    var ts = timespec()
+    clock_gettime(CLOCK_MONOTONIC, &ts)
+    return UInt64(ts.tv_sec) * 1_000_000_000 + UInt64(ts.tv_nsec)
+    #endif
+}
+
+func elapsedMs() -> Double {
+    Double(monotonicNs() - processStart) / 1_000_000.0
+}
+
+func stage(_ label: String) {
+    let ms = elapsedMs()
+    print(String(format: "[%8.2f ms] %@", ms, label))
+    fflush(stdout)
+}
+
+// ---- Watchdog --------------------------------------------------------------
+//
+// If a variant hangs, fire SIGABRT after 10 s so CI doesn't sit there
+// for the full natural 62 s. The signal flushes whatever output we've
+// captured and dumps a backtrace.
+
+func startWatchdog(seconds: Int) {
+    Thread.detachNewThread {
+        Thread.sleep(forTimeInterval: TimeInterval(seconds))
+        stage("WATCHDOG: \(seconds) s elapsed without exit — raising SIGABRT")
+        // Print a hint about what to look for in the trace.
+        stage("WATCHDOG: thread is likely stuck inside JSGlobalContextRelease")
+        raise(SIGABRT)
+    }
+}
+
+// ---- Variants --------------------------------------------------------------
+
+func variantPlain() {
+    stage("variant=plain — JSGlobalContextCreate")
+    guard let ctx = JSGlobalContextCreate(nil) else {
+        stage("CREATE returned nil"); exit(2)
+    }
+    stage("created ctx=\(String(format: "%p", Int(bitPattern: UnsafeRawPointer(ctx))))")
+
+    stage("calling JSGlobalContextRelease")
+    JSGlobalContextRelease(ctx)
+    stage("returned from JSGlobalContextRelease — clean")
+}
+
+func variantEvaluated() {
+    stage("variant=evaluated — JSGlobalContextCreate")
+    guard let ctx = JSGlobalContextCreate(nil) else { exit(2) }
+
+    stage("evaluating 1 + 2")
+    let scriptRef = JSStringCreateWithUTF8CString("1 + 2")
+    var exception: JSValueRef?
+    _ = JSEvaluateScript(ctx, scriptRef, nil, nil, 0, &exception)
+    JSStringRelease(scriptRef)
+
+    stage("calling JSGlobalContextRelease")
+    JSGlobalContextRelease(ctx)
+    stage("returned from JSGlobalContextRelease — clean")
+}
+
+func variantGCThenRelease() {
+    stage("variant=gc-then-release — JSGlobalContextCreate")
+    guard let ctx = JSGlobalContextCreate(nil) else { exit(2) }
+
+    stage("evaluating 1 + 2")
+    let scriptRef = JSStringCreateWithUTF8CString("1 + 2")
+    var exception: JSValueRef?
+    _ = JSEvaluateScript(ctx, scriptRef, nil, nil, 0, &exception)
+    JSStringRelease(scriptRef)
+
+    stage("calling JSGarbageCollect")
+    JSGarbageCollect(ctx)
+
+    stage("calling JSGlobalContextRelease")
+    JSGlobalContextRelease(ctx)
+    stage("returned from JSGlobalContextRelease — clean")
+}
+
+func variantGroupRelease() {
+    stage("variant=group-release — JSContextGroupCreate")
+    guard let group = JSContextGroupCreate() else { exit(2) }
+
+    stage("JSGlobalContextCreateInGroup")
+    guard let ctx = JSGlobalContextCreateInGroup(group, nil) else { exit(2) }
+
+    stage("evaluating 1 + 2")
+    let scriptRef = JSStringCreateWithUTF8CString("1 + 2")
+    var exception: JSValueRef?
+    _ = JSEvaluateScript(ctx, scriptRef, nil, nil, 0, &exception)
+    JSStringRelease(scriptRef)
+
+    stage("calling JSGlobalContextRelease (drops ctx ref)")
+    JSGlobalContextRelease(ctx)
+    stage("ctx released; calling JSContextGroupRelease (drops group ref)")
+    JSContextGroupRelease(group)
+    stage("returned from both releases — clean")
+}
+
+func variantNoRelease() {
+    stage("variant=no-release — JSGlobalContextCreate")
+    guard let ctx = JSGlobalContextCreate(nil) else { exit(2) }
+
+    stage("evaluating 1 + 2 (skipping release deliberately)")
+    let scriptRef = JSStringCreateWithUTF8CString("1 + 2")
+    var exception: JSValueRef?
+    _ = JSEvaluateScript(ctx, scriptRef, nil, nil, 0, &exception)
+    JSStringRelease(scriptRef)
+
+    stage("intentionally skipping JSGlobalContextRelease — exit 0")
+    // Suppress "unused" warning by parking the pointer somewhere
+    // the compiler can't elide.
+    UnsafeMutableRawPointer(ctx).map { _ = $0 }
+}
+
+// ---- Entry point -----------------------------------------------------------
+
+let args = CommandLine.arguments
+guard args.count >= 2 else {
+    fputs("usage: swift-jsc-shutdown-diag <plain|evaluated|gc-then-release|group-release|no-release>\n",
+          stderr)
+    exit(64)
+}
+
+#if canImport(Darwin)
+let backend = "JavaScriptCore.framework (Apple)"
+#else
+let backend = "bun-webkit static archive"
+#endif
+stage("backend=\(backend) variant=\(args[1])")
+
+// 10-s watchdog — long enough to confirm a clean release (which
+// completes in milliseconds on Apple) but short enough to not burn
+// CI minutes when the call hangs.
+startWatchdog(seconds: 10)
+
+switch args[1] {
+case "plain":            variantPlain()
+case "evaluated":        variantEvaluated()
+case "gc-then-release":  variantGCThenRelease()
+case "group-release":    variantGroupRelease()
+case "no-release":       variantNoRelease()
+default:
+    fputs("unknown variant: \(args[1])\n", stderr)
+    exit(64)
+}
+
+stage("variant exited cleanly")
+exit(0)


### PR DESCRIPTION
**Research probe** for [oven-sh/bun#30434](https://github.com/oven-sh/bun/issues/30434) (the bun-webkit standalone-mode `JSGlobalContextRelease` deadlock). Diagnosis is now complete; keeping this branch open as a permanent regression test against the upstream fix.

## What this PR adds

[`Sources/swift-jsc-shutdown-diag/main.swift`](Sources/swift-jsc-shutdown-diag/main.swift) — a single binary that exercises five distinct `JSGlobalContext` lifecycle variants with stage-by-stage `[NN.NN ms]` timing markers and a 10 s in-process watchdog (`raise(SIGABRT)`).

The CI workflow ([`.github/workflows/swift.yml`](.github/workflows/swift.yml)) runs each variant on **macOS** (Apple `JavaScriptCore.framework` baseline) and **Linux** (`bun-webkit-linux-amd64.tar.gz` static archive), wrapping each invocation in `timeout --preserve-status --kill-after=5s 20s` so a kernel-level cap exists even when the in-process watchdog can't escape the hang. Per-variant exit codes are printed as `[exit=$N]` to disambiguate clean (0) / SIGKILL after timeout (137) / signal-aborted (134).

## Variants

| Variant            | Lifecycle |
|--------------------|-----------|
| `plain`            | `JSGlobalContextCreate(nil)` → `JSGlobalContextRelease` |
| `evaluated`        | + `JSEvaluateScript("1 + 2")` between create and release |
| `gc-then-release`  | + `JSGarbageCollect(ctx)` immediately before release |
| `group-release`    | `JSContextGroupCreate` + `JSGlobalContextCreateInGroup` → `JSGlobalContextRelease(ctx)` + `JSContextGroupRelease(group)` |
| `no-release`       | create + evaluate, **never release** (control — must exit cleanly) |

## Results

### macOS — `JavaScriptCore.framework` (Apple)

| Variant            | Result | Wall time | Exit |
|--------------------|--------|-----------|------|
| `plain`            | clean  | 2.67 ms   | 0    |
| `evaluated`        | clean  | 2.46 ms   | 0    |
| `gc-then-release`  | clean  | 2.37 ms   | 0    |
| `group-release`    | clean  | 2.35 ms   | 0    |
| `no-release`       | clean  | 2.17 ms   | 0    |

### Linux — `bun-webkit-linux-amd64.tar.gz` (WebKit `88b2f7a2`)

| Variant            | Result   | Wall time   | Exit | Last marker before hang                       |
|--------------------|----------|-------------|------|-----------------------------------------------|
| `plain`            | **HANG** | 27.07 s     | 137  | `[6.62 ms] calling JSGlobalContextRelease`    |
| `evaluated`        | **HANG** | 25.50 s     | 137  | `[8.69 ms] calling JSGlobalContextRelease`    |
| `gc-then-release`  | **HANG** | 22.43 s     | 137  | `[8.35 ms] calling JSGlobalContextRelease`    |
| `group-release`    | **clean** | 6.35 ms    | 0    | `[6.35 ms] variant exited cleanly`            |
| `no-release`       | clean    | 6.04 ms     | 0    | (control — never released)                     |

## Diagnosis (single-VM)

`group-release` is the differential. It's the only variant that exits cleanly on bun-webkit despite running the **same** `vm.deref()` → `~VM()` chain as the hanging variants. Looking at [the fork's `JSContextRef.cpp`](https://github.com/oven-sh/WebKit/blob/88b2f7a2/Source/JavaScriptCore/API/JSContextRef.cpp):

```cpp
void JSContextGroupRelease(JSContextGroupRef group)        // line 79
{
    VM& vm = *toJS(group);
    JSLockHolder locker(&vm);                              // ← KEPT
    vm.derefSuppressingSaferCPPChecking();
}

void JSGlobalContextRelease(JSGlobalContextRef ctx)        // line ~175
{
    JSGlobalObject* globalObject = toJS(ctx);
    VM& vm = globalObject->vm();
    // JSLockHolder locker(vm);                            // ← REMOVED
    bool protectCountIsZero = vm.heap.unprotect(globalObject);
    if (protectCountIsZero)
        vm.heap.reportAbandonedObjectGraph();
    vm.derefSuppressingSaferCPPChecking();
}
```

Diffed against upstream WebKit at `6cc6aff95e13` (the merge base from fork commit `456a67f9c3b "Merge upstream/main … keep TLC/suspender/shutdown patches"`), the fork has stripped `JSLockHolder` from C-API entry points only: `JSGlobalContextRetain` / `JSGlobalContextRelease` / `JSContextGetGlobalObject` / `JSContextGetGlobalContext` / `JSGlobalContextCopyName` / `JSGlobalContextSetName` / `JSObjectCallAsFunction`. The `JSContextGroup*` family kept theirs.

`JSLock::didAcquireLock()` is what calls `m_vm->heap.acquireAccess()` AND installs `m_atomStringTable` on the thread. Without `JSLockHolder` in `JSGlobalContextRelease`, the `~VM` destructor runs without `hasAccessBit` set and on the wrong atom string table — exactly the surface where `~PropertyTable` → `AtomStringImpl::remove` release-asserts (matching the AtomStringImpl analysis in the issue thread).

Consistent with this, `Heap.cpp` in the fork has three `RELEASE_ASSERT(m_worldState.load() & hasAccessBit)` checks commented out (around lines 2025 / 2037 / 2225) — Bun's own usage goes through C++ `VM::tryCreate` directly, not the C API, so they don't need the locks; they just don't compile-check the assumption out.

## A second regression — multi-VM-per-process

After landing the diag, I tried to actually adopt the group-release path in production `JSContext.swift` (PR #25). It promptly broke Linux CI in a way the diag couldn't have caught:

- Switching `JSContext` to release context-then-group on every platform → Linux Test step **hangs at the ~50th teardown** (`testPathModule`). The same suite ran clean on the prior leak-on-Linux deinit.
- Switching `JSContext` init to `JSContextGroupCreate` + `JSGlobalContextCreateInGroup` *only* (deinit release still gated to Apple) → Linux **SIGSEGV** at `testSpawnStdinEndsOnChildExit`.

So bun-webkit has at least two distinct shutdown-related regressions: the single-VM `JSGlobalContextRelease` hang the diag isolated, AND a multi-VM accumulation hang/SEGV that surfaces once dozens of `JSContext`s are created and torn down in one process. Wrote it up in a comment on the bun issue so the upstream fix can address both.

## Workaround actually in place in SwiftBash

Per-context VM teardown is **skipped on non-Apple** (`Sources/SwiftJSCore/JSContext.swift` deinit gated with `#if canImport(Darwin)`). The OS reclaims at process exit. Per-context state leaks but is bounded by process lifetime. Same workaround `swift-jsc-smoke` used to need.

That said, PR #25 (now merged) updated `swift-jsc-smoke` itself to the full `JSContextGroupCreate` + `JSGlobalContextCreateInGroup` + release-context-then-group lifecycle. Smoke is single-VM-per-process — exactly the path the diag here proved exits clean on bun-webkit — so CI now runs the full create-evaluate-release loop on every platform and would catch a regression in the single-VM shape on the next bun-webkit release.

## What this branch is for going forward

Once oven-sh/bun lands the AtomStringImpl / lock fix, this same diag binary becomes the regression test: drop a fresh `bun-webkit` archive in, push, the four currently-hanging variants should flip to `[exit=0]` in single-digit ms. If the multi-VM-accumulation regression also gets fixed by the same patch, removing the `#if canImport(Darwin)` gate in `JSContext.swift`'s deinit becomes a one-line follow-up.

Cross-references:
- Issue and threaded analysis: oven-sh/bun#30434
- Comment with the full diagnostic table: [#issuecomment-4413537202](https://github.com/oven-sh/bun/issues/30434#issuecomment-4413537202)
- Comment correcting the workaround claim and reporting the multi-VM regression: [#issuecomment-4413647867](https://github.com/oven-sh/bun/issues/30434#issuecomment-4413647867)
- Smoke-binary lifecycle improvement: PR #25 (merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)