### PR TITLE
swift-jsc-smoke: full create-evaluate-release lifecycle on every platform

### DIFF
--- a/Sources/SwiftJSCore/JSContext.swift
+++ b/Sources/SwiftJSCore/JSContext.swift
@@ -25,13 +25,6 @@ public final class JSContext {
     /// callback trampoline's fallback path).
     let raw: JSGlobalContextRef
 
-    /// The explicit context group that owns the VM. Held alongside
-    /// `raw` so we can release context-then-group on `deinit` —
-    /// the only release path that exits cleanly on Bun's
-    /// `bun-webkit` static archive (oven-sh/bun#30434). `nil` for
-    /// non-owning wrappers built by the callback trampoline.
-    private let group: JSContextGroupRef?
-
     /// `true` when this wrapper owns its underlying context — the
     /// normal case via the public `init()`. `false` for ephemeral
     /// wrappers built by the callback trampoline when a registered
@@ -52,36 +45,11 @@ public final class JSContext {
     // MARK: - Lifecycle
 
     public init() {
-        // Construct the VM via an explicit context group rather than
-        // the bare `JSGlobalContextCreate(nil)`. Both produce a fresh
-        // single-context VM; the difference is the teardown path.
-        //
-        // Bun's `bun-webkit` fork stripped `JSLockHolder` from
-        // `JSGlobalContextRelease` (oven-sh/WebKit at 88b2f7a2,
-        // `Source/JavaScriptCore/API/JSContextRef.cpp`) but kept it in
-        // `JSContextGroupRelease`. Releasing the bare context drives
-        // `~VM` without the API lock held, with the wrong atom string
-        // table on the thread, and hangs ~25 s before SIGKILL on
-        // Linux/Android. Releasing context-then-group runs `~VM` from
-        // inside `JSContextGroupRelease`'s `JSLockHolder` scope, which
-        // exits cleanly in single-digit ms on every platform we test.
-        //
-        // Filed as oven-sh/bun#30434; once the patch ships in a
-        // bun-webkit release the workflow stays correct (the group
-        // path is the standard Apple-supported lifecycle anyway).
-        guard let group = JSContextGroupCreate() else {
+        guard let ctx = JSGlobalContextCreate(nil) else {
             preconditionFailure(
-                "JSContextGroupCreate returned nil — the engine " +
+                "JSGlobalContextCreate returned nil — the engine " +
                 "is in an unrecoverable state.")
         }
-        guard let ctx = JSGlobalContextCreateInGroup(group, nil) else {
-            // Drop the group ref we just took before bailing.
-            JSContextGroupRelease(group)
-            preconditionFailure(
-                "JSGlobalContextCreateInGroup returned nil — the " +
-                "engine is in an unrecoverable state.")
-        }
-        self.group = group
         self.raw = ctx
         self.ownsContext = true
         registerForCallbacks()
@@ -92,7 +60,6 @@ public final class JSContext {
     /// Doesn't retain or release the underlying context.
     init(rawNonOwning ctx: JSGlobalContextRef) {
         self.raw = ctx
-        self.group = nil
         self.ownsContext = false
     }
 
@@ -100,39 +67,19 @@ public final class JSContext {
         if ownsContext {
             unregisterForCallbacks()
             // `exception` and any user-held JSValues hold protect
-            // counts against this context's GC; the context release
+            // counts against this context's GC; `JSGlobalContextRelease`
             // only tears the engine state down once those have
             // dropped.
             //
-            // Drop the context ref first (VM refcount 2 → 1, no
-            // `~VM`), then the group ref (VM refcount 1 → 0, runs
-            // `~VM` under `JSContextGroupRelease`'s `JSLockHolder`
-            // scope). On Apple this matches the framework's
-            // standard lifecycle and runs in single-digit ms.
-            //
-            // On bun-webkit (Linux/Android) the same lifecycle
-            // works fine for a single VM-per-process (the
-            // `swift-jsc-shutdown-diag` `group-release` variant
-            // exits clean in 6 ms there) — but accumulating the
-            // teardown across many VMs in one process hangs.
-            // Test suites that spin up dozens of `JSContext`s
-            // (e.g. `JSRuntimeTests`) freeze at the ~50th teardown.
-            // Symptom is consistent with VM-internal state (ICU
-            // tables, bmalloc IsoHeaps) not fully releasing
-            // between VM destructions on the fork's stripped-lock
-            // C-API surface — see oven-sh/bun#30434.
-            //
-            // Until that lands upstream we skip the release on
-            // non-Apple. Per-context VM state leaks but is bounded
-            // (one VM's worth per `JSContext` ever created in
-            // this process, freed by the kernel at exit). The
-            // group structure stays intact so removing the gate
-            // is a one-line revert when the patch ships.
+            // Skip the release on non-Apple to dodge a known
+            // shutdown stall in Bun's prebuilt JSC archive — the
+            // bmalloc heap shutdown asserts ~62s after teardown
+            // begins (see `swift-jsc-smoke` for the same workaround
+            // and Docs/SwiftJS.md § Cross-platform for context).
+            // Memory leaks per-context are bounded; fix lands when
+            // upstream resolves the assert.
             #if canImport(Darwin)
             JSGlobalContextRelease(raw)
-            if let group = group {
-                JSContextGroupRelease(group)
-            }
             #endif
         }
     }

--- a/Sources/SwiftJSCore/JSContext.swift
+++ b/Sources/SwiftJSCore/JSContext.swift
@@ -107,13 +107,33 @@ public final class JSContext {
             // Drop the context ref first (VM refcount 2 → 1, no
             // `~VM`), then the group ref (VM refcount 1 → 0, runs
             // `~VM` under `JSContextGroupRelease`'s `JSLockHolder`
-            // scope). On Apple this matches the framework's standard
-            // lifecycle; on bun-webkit it sidesteps the
-            // `JSGlobalContextRelease` hang (oven-sh/bun#30434).
+            // scope). On Apple this matches the framework's
+            // standard lifecycle and runs in single-digit ms.
+            //
+            // On bun-webkit (Linux/Android) the same lifecycle
+            // works fine for a single VM-per-process (the
+            // `swift-jsc-shutdown-diag` `group-release` variant
+            // exits clean in 6 ms there) — but accumulating the
+            // teardown across many VMs in one process hangs.
+            // Test suites that spin up dozens of `JSContext`s
+            // (e.g. `JSRuntimeTests`) freeze at the ~50th teardown.
+            // Symptom is consistent with VM-internal state (ICU
+            // tables, bmalloc IsoHeaps) not fully releasing
+            // between VM destructions on the fork's stripped-lock
+            // C-API surface — see oven-sh/bun#30434.
+            //
+            // Until that lands upstream we skip the release on
+            // non-Apple. Per-context VM state leaks but is bounded
+            // (one VM's worth per `JSContext` ever created in
+            // this process, freed by the kernel at exit). The
+            // group structure stays intact so removing the gate
+            // is a one-line revert when the patch ships.
+            #if canImport(Darwin)
             JSGlobalContextRelease(raw)
             if let group = group {
                 JSContextGroupRelease(group)
             }
+            #endif
         }
     }
 

--- a/Sources/SwiftJSCore/JSContext.swift
+++ b/Sources/SwiftJSCore/JSContext.swift
@@ -25,6 +25,13 @@ public final class JSContext {
     /// callback trampoline's fallback path).
     let raw: JSGlobalContextRef
 
+    /// The explicit context group that owns the VM. Held alongside
+    /// `raw` so we can release context-then-group on `deinit` —
+    /// the only release path that exits cleanly on Bun's
+    /// `bun-webkit` static archive (oven-sh/bun#30434). `nil` for
+    /// non-owning wrappers built by the callback trampoline.
+    private let group: JSContextGroupRef?
+
     /// `true` when this wrapper owns its underlying context — the
     /// normal case via the public `init()`. `false` for ephemeral
     /// wrappers built by the callback trampoline when a registered
@@ -45,11 +52,36 @@ public final class JSContext {
     // MARK: - Lifecycle
 
     public init() {
-        guard let ctx = JSGlobalContextCreate(nil) else {
+        // Construct the VM via an explicit context group rather than
+        // the bare `JSGlobalContextCreate(nil)`. Both produce a fresh
+        // single-context VM; the difference is the teardown path.
+        //
+        // Bun's `bun-webkit` fork stripped `JSLockHolder` from
+        // `JSGlobalContextRelease` (oven-sh/WebKit at 88b2f7a2,
+        // `Source/JavaScriptCore/API/JSContextRef.cpp`) but kept it in
+        // `JSContextGroupRelease`. Releasing the bare context drives
+        // `~VM` without the API lock held, with the wrong atom string
+        // table on the thread, and hangs ~25 s before SIGKILL on
+        // Linux/Android. Releasing context-then-group runs `~VM` from
+        // inside `JSContextGroupRelease`'s `JSLockHolder` scope, which
+        // exits cleanly in single-digit ms on every platform we test.
+        //
+        // Filed as oven-sh/bun#30434; once the patch ships in a
+        // bun-webkit release the workflow stays correct (the group
+        // path is the standard Apple-supported lifecycle anyway).
+        guard let group = JSContextGroupCreate() else {
             preconditionFailure(
-                "JSGlobalContextCreate returned nil — the engine " +
+                "JSContextGroupCreate returned nil — the engine " +
                 "is in an unrecoverable state.")
         }
+        guard let ctx = JSGlobalContextCreateInGroup(group, nil) else {
+            // Drop the group ref we just took before bailing.
+            JSContextGroupRelease(group)
+            preconditionFailure(
+                "JSGlobalContextCreateInGroup returned nil — the " +
+                "engine is in an unrecoverable state.")
+        }
+        self.group = group
         self.raw = ctx
         self.ownsContext = true
         registerForCallbacks()
@@ -60,6 +92,7 @@ public final class JSContext {
     /// Doesn't retain or release the underlying context.
     init(rawNonOwning ctx: JSGlobalContextRef) {
         self.raw = ctx
+        self.group = nil
         self.ownsContext = false
     }
 
@@ -67,20 +100,20 @@ public final class JSContext {
         if ownsContext {
             unregisterForCallbacks()
             // `exception` and any user-held JSValues hold protect
-            // counts against this context's GC; `JSGlobalContextRelease`
+            // counts against this context's GC; the context release
             // only tears the engine state down once those have
             // dropped.
             //
-            // Skip the release on non-Apple to dodge a known
-            // shutdown stall in Bun's prebuilt JSC archive — the
-            // bmalloc heap shutdown asserts ~62s after teardown
-            // begins (see `swift-jsc-smoke` for the same workaround
-            // and Docs/SwiftJS.md § Cross-platform for context).
-            // Memory leaks per-context are bounded; fix lands when
-            // upstream resolves the assert.
-            #if canImport(Darwin)
+            // Drop the context ref first (VM refcount 2 → 1, no
+            // `~VM`), then the group ref (VM refcount 1 → 0, runs
+            // `~VM` under `JSContextGroupRelease`'s `JSLockHolder`
+            // scope). On Apple this matches the framework's standard
+            // lifecycle; on bun-webkit it sidesteps the
+            // `JSGlobalContextRelease` hang (oven-sh/bun#30434).
             JSGlobalContextRelease(raw)
-            #endif
+            if let group = group {
+                JSContextGroupRelease(group)
+            }
         }
     }
 

--- a/Sources/swift-jsc-smoke/main.swift
+++ b/Sources/swift-jsc-smoke/main.swift
@@ -39,20 +39,26 @@ func stage(_ message: String) {
 }
 
 func evaluate(_ source: String) -> Double {
-    stage("JSGlobalContextCreate")
-    guard let ctx = JSGlobalContextCreate(nil) else {
-        print("swift-jsc-smoke: JSGlobalContextCreate returned nil")
+    // Use the explicit context-group lifecycle (`JSContextGroupCreate`
+    // + `JSGlobalContextCreateInGroup` + release context, then group)
+    // rather than the bare `JSGlobalContextCreate(nil)` /
+    // `JSGlobalContextRelease` pair. Same VM, but the teardown runs
+    // from inside `JSContextGroupRelease`'s `JSLockHolder` scope,
+    // which is the only release path that exits cleanly on Bun's
+    // `bun-webkit` static archive (oven-sh/bun#30434). On Apple's
+    // framework JSC the two paths are equivalent.
+    stage("JSContextGroupCreate")
+    guard let group = JSContextGroupCreate() else {
+        print("swift-jsc-smoke: JSContextGroupCreate returned nil")
         fflush(stdout)
         exit(1)
     }
-    // Note: deliberately *not* calling JSGlobalContextRelease /
-    // JSStringRelease here. Bun's static-archive JSC crashes
-    // ~62s after teardown begins (likely the GC's bmalloc heap
-    // shutdown asserting against an unfinished worker), even
-    // though every C API call returns cleanly. Process exit
-    // reclaims everything anyway, and this binary's whole job
-    // is "did the engine evaluate `1 + 2`" — exit before
-    // teardown runs, document as a follow-up.
+    stage("JSGlobalContextCreateInGroup")
+    guard let ctx = JSGlobalContextCreateInGroup(group, nil) else {
+        print("swift-jsc-smoke: JSGlobalContextCreateInGroup returned nil")
+        fflush(stdout)
+        exit(1)
+    }
 
     stage("JSStringCreateWithUTF8CString")
     guard let scriptRef = source.withCString(JSStringCreateWithUTF8CString)
@@ -67,11 +73,17 @@ func evaluate(_ source: String) -> Double {
     guard let result = JSEvaluateScript(ctx, scriptRef, nil, nil, 0,
                                         &exception)
     else {
+        JSStringRelease(scriptRef)
+        JSGlobalContextRelease(ctx)
+        JSContextGroupRelease(group)
         print("swift-jsc-smoke: JSEvaluateScript returned nil")
         fflush(stdout)
         exit(1)
     }
     if exception != nil {
+        JSStringRelease(scriptRef)
+        JSGlobalContextRelease(ctx)
+        JSContextGroupRelease(group)
         print("swift-jsc-smoke: script raised an exception")
         fflush(stdout)
         exit(1)
@@ -80,6 +92,17 @@ func evaluate(_ source: String) -> Double {
     stage("JSValueToNumber")
     let n = JSValueToNumber(ctx, result, nil)
     stage("JSValueToNumber returned: \(n)")
+
+    // Tear everything down deliberately — context first, then group.
+    // Used to be skipped because `JSGlobalContextRelease` hangs on
+    // bun-webkit; the group-release path doesn't.
+    stage("JSStringRelease")
+    JSStringRelease(scriptRef)
+    stage("JSGlobalContextRelease (drops ctx ref)")
+    JSGlobalContextRelease(ctx)
+    stage("JSContextGroupRelease (drops group ref → ~VM)")
+    JSContextGroupRelease(group)
+    stage("teardown complete")
     return n
 }
 
@@ -98,9 +121,6 @@ let backend = "bun-webkit static archive"
 #endif
 print("swift-jsc-smoke: 1 + 2 = \(Int(result))  [\(backend)]")
 fflush(stdout)
-// Skip Swift's atexit / Foundation teardown chain by exiting
-// directly. Same reason as above — anything that touches JSC
-// state on shutdown trips the bmalloc assert on Linux.
 exit(0)
 
 #else  // !canImport(CJavaScriptCore)


### PR DESCRIPTION
## Summary

- Switch `swift-jsc-smoke` from `JSGlobalContextCreate(nil)` (and "skip the release, exit before teardown") to the explicit context-group lifecycle: `JSContextGroupCreate` + `JSGlobalContextCreateInGroup` + release context, then group.
- Production `JSContext.swift` left alone — see "What didn't work" below.

## Background

`bun-webkit` (oven-sh/WebKit `88b2f7a2`) stripped `JSLockHolder` from `JSGlobalContextRelease` but kept it in `JSContextGroupRelease`. The 5-variant CI diag in #24 proved the group-release path is the only one that exits cleanly on bun-webkit:

| Variant            | macOS  | Linux (bun-webkit)     |
|--------------------|--------|------------------------|
| `plain` (bare API) | 2.7 ms | HANG → SIGKILL @ 27 s  |
| `evaluated`        | 2.5 ms | HANG → SIGKILL @ 25 s  |
| `gc-then-release`  | 2.4 ms | HANG → SIGKILL @ 22 s  |
| **`group-release`** | **2.4 ms** | **6.4 ms (clean)** |
| `no-release` (ctrl) | 2.2 ms | 6.0 ms (clean)        |

Updating the smoke binary to use that lifecycle means CI exercises the full create-evaluate-release loop on every platform, including teardown — which used to be deliberately skipped to dodge the hang. Filed upstream as oven-sh/bun#30434.

## What didn't work — and why JSContext stayed on main

I attempted to push the same lifecycle into `JSContext.swift`. Both attempts broke Linux CI:

1. **`f1c1cba`** — release context+group on every platform, no `#if` gate. Linux Test step hung at the ~50th teardown:
   ```
   Test Case 'JSRuntimeTests.testPathModule' started at 20:13:05.609
   [no further output for 9+ minutes; job timeout cancels]
   ```
   The diag binary tested ONE VM-per-process; the SwiftBash test suite is a many-VMs-per-process workload (`runtime()` spins up a fresh `JSContext` per test). The group-release path works in isolation but doesn't survive accumulating teardown across many VMs in one process. Symptom looks like internal state (ICU, bmalloc IsoHeaps, atom string tables) not draining between `~VM`s on the fork's stripped-lock surface.

2. **`689c7eb`** — group structure on init, deinit release still gated to Apple-only. CI: SIGSEGV at `testSpawnStdinEndsOnChildExit`. So even the init-only change — `JSContextGroupCreate` + `JSGlobalContextCreateInGroup` instead of bare `JSGlobalContextCreate(nil)` — has bun-webkit-specific effects in a multi-VM workload, even though both routes converge to `VMType::APIContextGroup` in the C++.

3. **`b7a2bb3`** — revert `JSContext.swift` to main. Linux CI green again on prior research-branch runs with this exact code.

So a second hang shape exists in bun-webkit that the single-VM diag can't see. Mentioned in a comment on oven-sh/bun#30434 so robobun's fix can address both.

## What's actually shipping

- **`Sources/swift-jsc-smoke/main.swift`** — full create + evaluate + release-context + release-group lifecycle. Stage markers print at every step. On every platform CI now proves: bunch of C-API calls, including the teardown pair, all complete cleanly.
- **`Sources/SwiftJSCore/JSContext.swift`** — unchanged from main.

## Test plan

- [x] Local macOS: smoke runs the full lifecycle clean.
- [x] Local macOS: 116 SwiftJSCoreTests pass.
- [ ] CI macOS: smoke + tests pass.
- [ ] CI Linux: smoke runs the full create-evaluate-release lifecycle (the actual proof point).
- [ ] CI Android: smoke + tests pass.
- [ ] CI iOS / Windows: build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)