### PR TITLE
Embedder adoption: API + filesystems + parser fixes for in-process interactive shells

### DIFF
--- a/Sources/BashCommandKit/Commands/ChmodCommand.swift
+++ b/Sources/BashCommandKit/Commands/ChmodCommand.swift
@@ -2,8 +2,12 @@ import ArgumentParser
 import BashInterpreter
 import Foundation
 
-/// `chmod MODE FILE...` — change file permission bits. MODE is octal
-/// only (we don't yet parse symbolic modes like `u+x`).
+/// `chmod MODE FILE...` — change file permission bits.
+///
+/// Accepts both numeric octal modes (`755`, `0644`) and POSIX symbolic
+/// modes (`u+x`, `+x`, `go-w`, `u=rwx,go=rx`). Symbolic clauses are
+/// applied left-to-right onto the file's current mode; numeric modes
+/// replace the mode wholesale.
 public struct ChmodCommand: ParsableBashCommand {
     public static let configuration = CommandConfiguration(
         commandName: "chmod",
@@ -24,19 +28,21 @@ public struct ChmodCommand: ParsableBashCommand {
             Shell.bashCurrent.stderr("chmod: missing operand\n")
             return ExitStatus(2)
         }
-        let modeStr = operands[0]
-        guard let mode = UInt16(modeStr, radix: 8) else {
-            Shell.bashCurrent.stderr("chmod: invalid mode: \(modeStr)\n")
+        let modeSpec = operands[0]
+        let symbolic = parseSymbolic(modeSpec)
+        let octalMode = UInt16(modeSpec, radix: 8)
+
+        guard symbolic != nil || octalMode != nil else {
+            Shell.bashCurrent.stderr("chmod: invalid mode: \(modeSpec)\n")
             return ExitStatus(2)
         }
         var hadError = false
         for f in operands.dropFirst() {
             let resolved = Shell.bashCurrent.resolvePath(f)
             do {
-                try await Shell.bashCurrent.fileSystem.chmod(resolved, mode: mode)
-                if recursive {
-                    try await applyRecursive(resolved, mode: mode)
-                }
+                try await applyMode(to: resolved,
+                                    symbolic: symbolic,
+                                    octalMode: octalMode)
             } catch {
                 Shell.bashCurrent.stderr("chmod: \(f): \(error)\n")
                 hadError = true
@@ -45,14 +51,122 @@ public struct ChmodCommand: ParsableBashCommand {
         return hadError ? .failure : .success
     }
 
-    private func applyRecursive(_ path: String, mode: UInt16) async throws {
+    /// Apply the parsed mode to `path`, recursing if `--recursive`.
+    private func applyMode(to path: String,
+                           symbolic: [SymbolicClause]?,
+                           octalMode: UInt16?) async throws {
+        let resolvedMode: UInt16
+        if let octalMode {
+            resolvedMode = octalMode
+        } else if let symbolic {
+            let current = (try? await Shell.bashCurrent.fileSystem
+                .metadata(path)?.mode) ?? 0
+            resolvedMode = symbolic.reduce(current) { $1.apply(to: $0) }
+        } else {
+            return
+        }
+        try await Shell.bashCurrent.fileSystem.chmod(path, mode: resolvedMode)
+        if recursive {
+            try await applyRecursive(path,
+                                     symbolic: symbolic,
+                                     octalMode: octalMode)
+        }
+    }
+
+    private func applyRecursive(_ path: String,
+                                symbolic: [SymbolicClause]?,
+                                octalMode: UInt16?) async throws {
         guard let meta = try? await Shell.bashCurrent.fileSystem.metadata(path),
               meta.kind == .directory else { return }
         let entries = (try? await Shell.bashCurrent.fileSystem.list(path)) ?? []
         for name in entries {
             let child = (path as NSString).appendingPathComponent(name)
-            try? await Shell.bashCurrent.fileSystem.chmod(child, mode: mode)
-            try await applyRecursive(child, mode: mode)
+            try? await applyMode(to: child,
+                                 symbolic: symbolic,
+                                 octalMode: octalMode)
         }
+    }
+
+    // MARK: - Symbolic-mode parser
+
+    /// One `who op perms` clause, e.g. `u+x` or `go=r`. Multiple clauses
+    /// can be comma-separated in a single mode argument.
+    fileprivate struct SymbolicClause {
+        enum Op { case add, remove, set }
+        let whoMask: UInt16   // permission bits this clause writes into
+        let op: Op
+        let permBits: UInt16  // r/w/x bits as an "all-positions" mask
+
+        func apply(to current: UInt16) -> UInt16 {
+            // The actual bits-to-touch is permBits projected onto whoMask.
+            // permBits is in lowest-three-bits form; replicate it across
+            // user/group/other depending on whoMask, then mask to whoMask.
+            let replicated = (permBits << 6) | (permBits << 3) | permBits
+            let target = replicated & whoMask
+            switch op {
+            case .add:    return current | target
+            case .remove: return current & ~target
+            case .set:    return (current & ~whoMask) | target
+            }
+        }
+    }
+
+    /// Parse a symbolic chmod expression like `u+x`, `+x`, `go-w`,
+    /// `u=rwx,go=rx`. Returns `nil` if the string isn't a valid symbolic
+    /// expression — caller falls through to the numeric path.
+    fileprivate func parseSymbolic(_ spec: String) -> [SymbolicClause]? {
+        var clauses: [SymbolicClause] = []
+        for raw in spec.split(separator: ",") {
+            guard let clause = parseClause(String(raw)) else { return nil }
+            clauses.append(clause)
+        }
+        return clauses.isEmpty ? nil : clauses
+    }
+
+    private func parseClause(_ raw: String) -> SymbolicClause? {
+        var i = raw.startIndex
+        // `who` — optional run of `[ugoa]`. Default to "a" (all) when
+        // missing, matching bash and POSIX.
+        var who: UInt16 = 0
+        let whoChars: Set<Character> = ["u", "g", "o", "a"]
+        while i < raw.endIndex, whoChars.contains(raw[i]) {
+            switch raw[i] {
+            case "u": who |= 0o700
+            case "g": who |= 0o070
+            case "o": who |= 0o007
+            case "a": who |= 0o777
+            default:  break
+            }
+            i = raw.index(after: i)
+        }
+        if who == 0 { who = 0o777 }
+
+        // `op` — exactly one of `+`, `-`, `=`.
+        guard i < raw.endIndex else { return nil }
+        let opChar = raw[i]
+        let op: SymbolicClause.Op
+        switch opChar {
+        case "+": op = .add
+        case "-": op = .remove
+        case "=": op = .set
+        default: return nil
+        }
+        i = raw.index(after: i)
+
+        // `perms` — run of `[rwxX]`. We treat capital `X` as `x`.
+        // Extensions like `s` (setuid) and `t` (sticky) aren't supported
+        // by the underlying FileSystem.chmod surface, so we leave them
+        // for a future PR rather than silently swallow them.
+        var perm: UInt16 = 0
+        while i < raw.endIndex {
+            switch raw[i] {
+            case "r": perm |= 0o4
+            case "w": perm |= 0o2
+            case "x", "X": perm |= 0o1
+            default: return nil
+            }
+            i = raw.index(after: i)
+        }
+        return SymbolicClause(whoMask: who, op: op, permBits: perm)
     }
 }

--- a/Sources/BashInterpreter/API/Shell+BashShebang.swift
+++ b/Sources/BashInterpreter/API/Shell+BashShebang.swift
@@ -1,0 +1,39 @@
+import Foundation
+
+extension Shell {
+
+    /// Register `bash`, `sh`, and `dash` as shebang interpreters so a
+    /// path-invoked script with `#!/usr/bin/env bash` (or `#!/bin/sh`,
+    /// or `#!/usr/bin/env dash`) runs through this shell's bash
+    /// interpreter.
+    ///
+    /// Without this, `./hello.sh` fails with `command not found` —
+    /// SwiftBash is in-process and doesn't fall back to host `exec`,
+    /// so a `#!`-shebang naming an unregistered interpreter has
+    /// nowhere to go. `bash <path>` (the builtin) still works because
+    /// it goes through the registry directly, but every embedder
+    /// building an interactive shell ends up writing the same
+    /// boilerplate to make `./script.sh` work. Lift it into the API.
+    ///
+    /// ```swift
+    /// let shell = Shell()
+    /// shell.registerStandardCommands()   // BashCommandKit
+    /// shell.registerBashShebang()        // <- this
+    /// try await shell.run("./hello.sh")  // dispatches via the
+    ///                                    //    shebang now
+    /// ```
+    ///
+    /// Each name gets its own ``ClosureScriptInterpreter`` so the
+    /// `[String: ScriptInterpreter]` invariant `interpreter.name ==
+    /// registryKey` holds. The body just feeds the script source back
+    /// into the bash interpreter — same semantics as `bash <path>`.
+    public func registerBashShebang(
+        names: [String] = ["bash", "sh", "dash"]
+    ) {
+        for name in names {
+            registerScriptInterpreter(ClosureScriptInterpreter(name: name) { context in
+                try await Shell.bashCurrent.run(context.source)
+            })
+        }
+    }
+}

--- a/Sources/BashInterpreter/API/Shell+Profile.swift
+++ b/Sources/BashInterpreter/API/Shell+Profile.swift
@@ -1,0 +1,44 @@
+import Foundation
+
+extension Shell {
+
+    /// Source `~/.profile` and `~/.bashrc` (in that order) into the
+    /// running shell, skipping files that don't exist on disk.
+    ///
+    /// Real bash sources these once at session startup so the user's
+    /// `export PATH=...`, aliases, and PS1 customisation apply for
+    /// the whole REPL. SwiftBash doesn't do that automatically —
+    /// embedders building an interactive shell call this once before
+    /// the first user keystroke.
+    ///
+    /// ```swift
+    /// let shell = Shell()
+    /// shell.registerStandardCommands()
+    /// shell.registerBashShebang()
+    /// try await shell.sourceProfileIfPresent(at: sandboxRoot)
+    /// ```
+    ///
+    /// Reads through ``Shell/fileSystem``, so ConfinedFileSystem and
+    /// SandboxedOverlayFileSystem all gate this — a profile sitting
+    /// outside the sandbox is silently ignored, the same way a
+    /// missing one is. Use ``filenames:`` to add `.bash_profile`,
+    /// `.zshrc`, etc.
+    @discardableResult
+    public func sourceProfileIfPresent(
+        at home: URL,
+        filenames: [String] = [".profile", ".bashrc"]
+    ) async throws -> [String] {
+        var sourced: [String] = []
+        for name in filenames {
+            let path = home.appendingPathComponent(name).path
+            let meta = try? await fileSystem.metadata(path)
+            guard let meta = meta ?? nil, meta.kind == .file else { continue }
+            guard let data = try? await fileSystem.readData(path),
+                  let body = String(data: data, encoding: .utf8)
+            else { continue }
+            _ = try await run(body)
+            sourced.append(name)
+        }
+        return sourced
+    }
+}

--- a/Sources/BashInterpreter/API/Shell.swift
+++ b/Sources/BashInterpreter/API/Shell.swift
@@ -42,10 +42,20 @@ public final class Shell: ShellKit.Shell, @unchecked Sendable {
         return line
     }
 
+    /// When `true`, ``errorLocationPrefix()`` drops the `: line N:`
+    /// portion. Embedders running each user keystroke as its own
+    /// `Shell.run(line)` call set this so error diagnostics read
+    /// `iBash: ./foo: not found` rather than `iBash: line 1: ./foo:
+    /// not found` — real bash's interactive REPL behaves the same
+    /// way. Defaults to `false` (script-style prefix).
+    public var interactive: Bool = false
+
     /// `script:line:` prefix for diagnostics, or just `script:` when
-    /// no command is currently being executed.
+    /// no command is currently being executed. When ``interactive``
+    /// is `true`, the line number is suppressed since each REPL
+    /// input is its own implicit line 1.
     public func errorLocationPrefix() -> String {
-        if let r = currentCommandRange {
+        if let r = currentCommandRange, !interactive {
             return "\(scriptName): line \(lineNumber(for: r.lowerBound)): "
         }
         return "\(scriptName): "

--- a/Sources/BashInterpreter/Execution/Shell+ParameterExpansion.swift
+++ b/Sources/BashInterpreter/Execution/Shell+ParameterExpansion.swift
@@ -29,14 +29,14 @@ extension Shell {
             return String(lookup(name).count)
 
         case .defaultValue(let name, let checkEmpty, let value):
-            let raw = environment[name]
+            let raw = lookupOptional(name)
             if isMissing(raw, checkEmpty: checkEmpty) {
                 return try await recursivelyExpand(value)
             }
             return raw ?? ""
 
         case .assignDefault(let name, let checkEmpty, let value):
-            let raw = environment[name]
+            let raw = lookupOptional(name)
             if isMissing(raw, checkEmpty: checkEmpty) {
                 let expanded = try await recursivelyExpand(value)
                 environment[name] = expanded
@@ -45,7 +45,7 @@ extension Shell {
             return raw ?? ""
 
         case .errorIfUnset(let name, let checkEmpty, let message):
-            let raw = environment[name]
+            let raw = lookupOptional(name)
             if isMissing(raw, checkEmpty: checkEmpty) {
                 let msg = message.isEmpty
                     ? "parameter null or not set"
@@ -60,7 +60,7 @@ extension Shell {
             return raw ?? ""
 
         case .alternative(let name, let checkEmpty, let value):
-            let raw = environment[name]
+            let raw = lookupOptional(name)
             if isMissing(raw, checkEmpty: checkEmpty) {
                 return ""
             }
@@ -135,6 +135,51 @@ extension Shell {
     }
 
     // MARK: Lookup helper
+
+    /// Optional-returning sibling of ``lookup(_:)`` that distinguishes
+    /// "unset" (`nil`) from "set but empty" (`""`). Used by the
+    /// `${var:-default}`, `${var:=default}`, `${var:+alt}`, and
+    /// `${var:?msg}` forms — they need that distinction to decide
+    /// whether to substitute / assign / error.
+    ///
+    /// Without this routine those forms would call `environment[name]`
+    /// directly, which only consults the *named* variables map and
+    /// silently skips positional parameters: `${1:-fallback}` would
+    /// always evaluate to `fallback` even when `$1` is set, because
+    /// `environment["1"]` is `nil`. Routing through here closes that
+    /// bug.
+    private func lookupOptional(_ name: String) -> String? {
+        // Special parameters — `$?` `$$` `$#` `$@` `$*` `$0` are
+        // always "set", and digit-only names are positional params.
+        switch name {
+        case "?": return "\(lastExitStatus.code)"
+        case "$": return "\(virtualPID)"
+        case "#": return "\(positionalParameters.count)"
+        case "0": return scriptName
+        case "@", "*":
+            // Same join behaviour as `lookup` — we don't have IFS here
+            // because the caller (parameter expansion) handles word-
+            // splitting separately. Always-set: empty array still
+            // returns "" (set), not nil (unset).
+            return positionalParameters.joined(separator: " ")
+        default:
+            break
+        }
+        if !name.isEmpty, name.allSatisfy(\.isNumber),
+           let n = Int(name), n >= 1
+        {
+            let idx = n - 1
+            return idx < positionalParameters.count
+                ? positionalParameters[idx]
+                : nil
+        }
+        // Indexed-array reference falls through to lookup() — arrays
+        // never appear as `${arr[0]:-…}` against unset vs. empty in a
+        // way the regular environment subscript can't already answer
+        // (`environment[name]` for `arr[0]` is the element value or
+        // nil if unset).
+        return environment[name]
+    }
 
     private func lookup(_ name: String) -> String {
         // Special parameters first.

--- a/Sources/BashInterpreter/FileSystems/MountedFileSystem.swift
+++ b/Sources/BashInterpreter/FileSystems/MountedFileSystem.swift
@@ -149,24 +149,21 @@ public final class MountedFileSystem: FileSystem, @unchecked Sendable {
     private func canonicalGate(_ r: (mount: Mount, host: String),
                                virtual: String) async throws -> String {
         if isSyntheticBinPath(virtual) { return r.host }
-        // Allow not-yet-existing paths: a write to a brand-new file
-        // standardises to itself. Existing paths get realpath
-        // resolution so symlinks under the mount can't escape.
-        //
-        // Both the path AND the mount root are pushed through the
-        // backing's `canonicalize` — on Windows / NTFS the mount.host
-        // we stored may be a shortname form (e.g. `RUNNER~1`) while
-        // the canonical path comes back as the long form
-        // (`runneradmin`). Comparing pre-canonicalisation strings
-        // would mismatch even when the path is genuinely inside the
-        // mount.
+        // Canonicalise BOTH sides via the deepest-existing-ancestor
+        // walk. On Windows / NTFS `canonicalize(allowMissing: true)`
+        // doesn't expand shortname components (`RUNNER~1` →
+        // `runneradmin`) when the leaf doesn't exist yet, so a write
+        // to a brand-new file under a mount whose host *does* exist
+        // would normalise asymmetrically and trip the prefix check
+        // even though the path is genuinely inside the mount.
+        // Walking up to the deepest existing parent and
+        // canonicalising THAT yields a normalised prefix we can
+        // safely compare.
         let canonicalPath: String
         let canonicalRoot: String
         do {
-            canonicalPath = try await backing.canonicalize(r.host,
-                                                           allowMissing: true)
-            canonicalRoot = try await backing.canonicalize(r.mount.host,
-                                                           allowMissing: true)
+            canonicalPath = try await canonicalizeDeepest(r.host)
+            canonicalRoot = try await canonicalizeDeepest(r.mount.host)
         } catch {
             throw FileSystemError.notFound(virtual)
         }
@@ -184,6 +181,43 @@ public final class MountedFileSystem: FileSystem, @unchecked Sendable {
             throw FileSystemError.notFound(virtual)
         }
         return r.host
+    }
+
+    /// Resolve `path` to its canonical form by walking up to the
+    /// deepest ancestor that actually exists, canonicalising that,
+    /// and re-attaching the missing tail components.
+    ///
+    /// This sidesteps a Windows-only quirk: `canonicalize(_,
+    /// allowMissing: true)` on a non-existent path may leave shortname
+    /// components (`RUNNER~1`) un-expanded because the OS APIs that
+    /// expand them require an existing inode to query. Once we've
+    /// canonicalised an existing prefix, the result is a stable form
+    /// that compares correctly against any other deepest-ancestor
+    /// resolution under the same root.
+    private func canonicalizeDeepest(_ path: String) async throws -> String {
+        var probe = (path as NSString).standardizingPath
+        var tail: [String] = []
+        while !probe.isEmpty {
+            if let canon = try? await backing.canonicalize(probe,
+                                                           allowMissing: false) {
+                return tail.reversed().reduce(canon) { acc, name in
+                    (acc as NSString).appendingPathComponent(name)
+                }
+            }
+            let parent = (probe as NSString).deletingLastPathComponent
+            let leaf = (probe as NSString).lastPathComponent
+            // `deletingLastPathComponent` on `/` returns `/` — bail
+            // out before we loop forever. Same for Windows volume
+            // roots like `C:\` where the parent is itself.
+            if parent == probe || leaf.isEmpty { break }
+            tail.append(leaf)
+            probe = parent
+        }
+        // Nothing on the path exists. Fall back to lexical
+        // standardisation so the caller still has a usable string;
+        // the prefix check downstream will fail naturally if this
+        // path isn't under any real mount.
+        return (path as NSString).standardizingPath
     }
 
     // MARK: - FileSystem conformance

--- a/Sources/BashInterpreter/FileSystems/MountedFileSystem.swift
+++ b/Sources/BashInterpreter/FileSystems/MountedFileSystem.swift
@@ -118,19 +118,57 @@ public final class MountedFileSystem: FileSystem, @unchecked Sendable {
         return dirs.contains(parent)
     }
 
-    private func gateRead(_ path: String) throws -> String {
+    private func gateRead(_ path: String) async throws -> String {
         guard let r = resolve(path) else {
             throw FileSystemError.notFound(path)
         }
-        return r.host
+        return try await canonicalGate(r, virtual: path)
     }
 
-    private func gateWrite(_ path: String) throws -> String {
+    private func gateWrite(_ path: String) async throws -> String {
         guard let r = resolve(path) else {
             throw FileSystemError.notFound(path)
         }
         if r.mount.readOnly {
             throw FileSystemError.permissionDenied(path)
+        }
+        return try await canonicalGate(r, virtual: path)
+    }
+
+    /// Resolve symlinks on the host side and re-verify the canonical
+    /// host path is still inside the mount's host root. Without this
+    /// step a symlink stored under the mount could point to `/etc`,
+    /// `/Users`, or anywhere else on the real disk and the gate would
+    /// happily delegate the read to the backing FS — undermining the
+    /// chrooted-shell guarantee scripts depend on.
+    ///
+    /// Synthetic-bin paths (`/bin/cat`, `/usr/bin/grep`, etc.) skip
+    /// the canonical check: they're handed off to
+    /// `VirtualBinFileSystem` which synthesises responses from the
+    /// command registry, not from disk.
+    private func canonicalGate(_ r: (mount: Mount, host: String),
+                               virtual: String) async throws -> String {
+        if isSyntheticBinPath(virtual) { return r.host }
+        // Allow not-yet-existing paths: a write to a brand-new file
+        // standardises to itself. Existing paths get realpath
+        // resolution so symlinks under the mount can't escape.
+        let canonical: String
+        do {
+            canonical = try await backing.canonicalize(r.host,
+                                                       allowMissing: true)
+        } catch {
+            // Backing FS refused to canonicalise — treat as gate
+            // failure (the chrooted-shell answer is "no such file").
+            throw FileSystemError.notFound(virtual)
+        }
+        let mountHost = (r.mount.host as NSString).standardizingPath
+        if canonical == mountHost { return r.host }
+        let prefix = mountHost.hasSuffix("/") ? mountHost : mountHost + "/"
+        guard canonical.hasPrefix(prefix) else {
+            // Symlink (or `..` traversal that survived
+            // standardisation) escaped the mount. Hide the host
+            // path; report ENOENT against the virtual path.
+            throw FileSystemError.notFound(virtual)
         }
         return r.host
     }
@@ -142,11 +180,20 @@ public final class MountedFileSystem: FileSystem, @unchecked Sendable {
         // not a thrown error, just `nil`, so test idioms like
         // `[ -f /etc/passwd ]` behave as on a chrooted shell.
         guard let r = resolve(path) else { return nil }
-        return try await backing.metadata(r.host)
+        // The same chrooted-shell answer for symlinks escaping the
+        // mount: report nil rather than a thrown error so `[ -f ]`
+        // tests stay quiet.
+        let host: String
+        do {
+            host = try await canonicalGate(r, virtual: path)
+        } catch FileSystemError.notFound {
+            return nil
+        }
+        return try await backing.metadata(host)
     }
 
     public func list(_ path: String) async throws -> [String] {
-        try await backing.list(try gateRead(path))
+        try await backing.list(try await gateRead(path))
     }
 
     public func canonicalize(_ path: String,
@@ -157,52 +204,58 @@ public final class MountedFileSystem: FileSystem, @unchecked Sendable {
         guard let r = resolve(path) else {
             throw FileSystemError.notFound(path)
         }
-        // Verify the host path is canonicalisable; let the backing FS
-        // throw notFound if `allowMissing == false` and nothing's there.
-        _ = try await backing.canonicalize(r.host, allowMissing: allowMissing)
+        // Verify the host path is canonicalisable AND that any
+        // symlink chain stays inside the mount.
+        _ = try await canonicalGate(r, virtual: path)
+        if !allowMissing {
+            // Honour the contract: throw if the path doesn't exist
+            // and `allowMissing == false`.
+            _ = try await backing.canonicalize(r.host, allowMissing: false)
+        }
         return (path as NSString).standardizingPath
     }
 
     public func readData(_ path: String) async throws -> Data {
-        try await backing.readData(try gateRead(path))
+        try await backing.readData(try await gateRead(path))
     }
 
     public func openRead(_ path: String) async throws -> InputSource {
-        try await backing.openRead(try gateRead(path))
+        try await backing.openRead(try await gateRead(path))
     }
 
     public func writeData(_ data: Data, to path: String,
                           append: Bool) async throws {
-        try await backing.writeData(data, to: try gateWrite(path), append: append)
+        try await backing.writeData(data, to: try await gateWrite(path),
+                                    append: append)
     }
 
     public func openWrite(_ path: String,
                           append: Bool) async throws -> OutputSink {
-        try await backing.openWrite(try gateWrite(path), append: append)
+        try await backing.openWrite(try await gateWrite(path), append: append)
     }
 
     public func touch(_ path: String) async throws {
-        try await backing.touch(try gateWrite(path))
+        try await backing.touch(try await gateWrite(path))
     }
 
     public func createDirectory(_ path: String,
                                 intermediates: Bool) async throws {
-        try await backing.createDirectory(try gateWrite(path),
+        try await backing.createDirectory(try await gateWrite(path),
                                           intermediates: intermediates)
     }
 
     public func remove(_ path: String, recursive: Bool) async throws {
-        try await backing.remove(try gateWrite(path), recursive: recursive)
+        try await backing.remove(try await gateWrite(path), recursive: recursive)
     }
 
     public func move(from: String, to: String) async throws {
-        try await backing.move(from: try gateWrite(from),
-                               to: try gateWrite(to))
+        try await backing.move(from: try await gateWrite(from),
+                               to: try await gateWrite(to))
     }
 
     public func copy(from: String, to: String) async throws {
-        try await backing.copy(from: try gateRead(from),
-                               to: try gateWrite(to))
+        try await backing.copy(from: try await gateRead(from),
+                               to: try await gateWrite(to))
     }
 
     public func makeTempPath(prefix: String) async throws -> String {
@@ -215,7 +268,7 @@ public final class MountedFileSystem: FileSystem, @unchecked Sendable {
             return "/tmp/\(prefix)\(suffix)"
         }
         let fallback = "/.tmp/\(prefix)\(UUID().uuidString.prefix(12))"
-        if let host = try? gateWrite(fallback) {
+        if let host = try? await gateWrite(fallback) {
             try? await backing.createDirectory(
                 (host as NSString).deletingLastPathComponent,
                 intermediates: true)
@@ -224,38 +277,48 @@ public final class MountedFileSystem: FileSystem, @unchecked Sendable {
     }
 
     public func chmod(_ path: String, mode: UInt16) async throws {
-        try await backing.chmod(try gateWrite(path), mode: mode)
+        try await backing.chmod(try await gateWrite(path), mode: mode)
     }
 
     public func chown(_ path: String, uid: UInt32?, gid: UInt32?) async throws {
-        try await backing.chown(try gateWrite(path), uid: uid, gid: gid)
+        try await backing.chown(try await gateWrite(path), uid: uid, gid: gid)
     }
 
     public func symlink(target: String, at linkPath: String) async throws {
-        // Both ends are virtual — guard them both, then translate.
-        try await backing.symlink(target: try gateRead(target),
-                                  at: try gateWrite(linkPath))
+        // Symlink targets are stored verbatim — they may be relative
+        // (`ln -s foo bar`) or absolute, and resolution happens at
+        // *use* time through the same gate as any other path access.
+        // Translating the target through `gateRead` would (a) break
+        // relative-target semantics and (b) leak the host's mount
+        // path into the link's stored target text. Only the link
+        // *site* needs to be remapped through the mount table.
+        try await backing.symlink(target: target,
+                                  at: try await gateWrite(linkPath))
     }
 
     public func hardlink(target: String, at linkPath: String) async throws {
-        try await backing.hardlink(target: try gateRead(target),
-                                   at: try gateWrite(linkPath))
+        // Hardlinks resolve immediately to an inode and the target
+        // file must already exist, so gate the read side too — the
+        // `target` stored on disk is the path used at link-creation
+        // time, not text resolved later.
+        try await backing.hardlink(target: try await gateRead(target),
+                                   at: try await gateWrite(linkPath))
     }
 
     public func listXattrs(_ path: String) async throws -> [String] {
-        try await backing.listXattrs(try gateRead(path))
+        try await backing.listXattrs(try await gateRead(path))
     }
 
     public func getXattr(_ path: String, name: String) async throws -> Data {
-        try await backing.getXattr(try gateRead(path), name: name)
+        try await backing.getXattr(try await gateRead(path), name: name)
     }
 
     public func setXattr(_ path: String, name: String, value: Data) async throws {
-        try await backing.setXattr(try gateWrite(path),
+        try await backing.setXattr(try await gateWrite(path),
                                    name: name, value: value)
     }
 
     public func removeXattr(_ path: String, name: String) async throws {
-        try await backing.removeXattr(try gateWrite(path), name: name)
+        try await backing.removeXattr(try await gateWrite(path), name: name)
     }
 }

--- a/Sources/BashInterpreter/FileSystems/MountedFileSystem.swift
+++ b/Sources/BashInterpreter/FileSystems/MountedFileSystem.swift
@@ -161,10 +161,17 @@ public final class MountedFileSystem: FileSystem, @unchecked Sendable {
             // failure (the chrooted-shell answer is "no such file").
             throw FileSystemError.notFound(virtual)
         }
-        let mountHost = (r.mount.host as NSString).standardizingPath
-        if canonical == mountHost { return r.host }
-        let prefix = mountHost.hasSuffix("/") ? mountHost : mountHost + "/"
-        guard canonical.hasPrefix(prefix) else {
+        // Path-component comparison via URL keeps the check
+        // separator-agnostic, so a canonical Windows path like
+        // `C:\Users\runner\Temp\sandbox\foo` correctly matches a
+        // mount host of `C:\Users\runner\Temp\sandbox` instead of
+        // tripping over the `+ "/"` literal a string-prefix check
+        // would have used.
+        let canonicalComps = URL(fileURLWithPath: canonical)
+            .standardizedFileURL.pathComponents
+        let mountComps = URL(fileURLWithPath: r.mount.host)
+            .standardizedFileURL.pathComponents
+        guard canonicalComps.starts(with: mountComps) else {
             // Symlink (or `..` traversal that survived
             // standardisation) escaped the mount. Hide the host
             // path; report ENOENT against the virtual path.

--- a/Sources/BashInterpreter/FileSystems/MountedFileSystem.swift
+++ b/Sources/BashInterpreter/FileSystems/MountedFileSystem.swift
@@ -152,26 +152,32 @@ public final class MountedFileSystem: FileSystem, @unchecked Sendable {
         // Allow not-yet-existing paths: a write to a brand-new file
         // standardises to itself. Existing paths get realpath
         // resolution so symlinks under the mount can't escape.
-        let canonical: String
+        //
+        // Both the path AND the mount root are pushed through the
+        // backing's `canonicalize` — on Windows / NTFS the mount.host
+        // we stored may be a shortname form (e.g. `RUNNER~1`) while
+        // the canonical path comes back as the long form
+        // (`runneradmin`). Comparing pre-canonicalisation strings
+        // would mismatch even when the path is genuinely inside the
+        // mount.
+        let canonicalPath: String
+        let canonicalRoot: String
         do {
-            canonical = try await backing.canonicalize(r.host,
-                                                       allowMissing: true)
+            canonicalPath = try await backing.canonicalize(r.host,
+                                                           allowMissing: true)
+            canonicalRoot = try await backing.canonicalize(r.mount.host,
+                                                           allowMissing: true)
         } catch {
-            // Backing FS refused to canonicalise — treat as gate
-            // failure (the chrooted-shell answer is "no such file").
             throw FileSystemError.notFound(virtual)
         }
         // Path-component comparison via URL keeps the check
-        // separator-agnostic, so a canonical Windows path like
-        // `C:\Users\runner\Temp\sandbox\foo` correctly matches a
-        // mount host of `C:\Users\runner\Temp\sandbox` instead of
-        // tripping over the `+ "/"` literal a string-prefix check
-        // would have used.
-        let canonicalComps = URL(fileURLWithPath: canonical)
+        // separator-agnostic — Windows backslashes, Unix forward
+        // slashes, mixed case on NTFS all roll up the same way.
+        let pathComps = URL(fileURLWithPath: canonicalPath)
             .standardizedFileURL.pathComponents
-        let mountComps = URL(fileURLWithPath: r.mount.host)
+        let rootComps = URL(fileURLWithPath: canonicalRoot)
             .standardizedFileURL.pathComponents
-        guard canonicalComps.starts(with: mountComps) else {
+        guard pathComps.starts(with: rootComps) else {
             // Symlink (or `..` traversal that survived
             // standardisation) escaped the mount. Hide the host
             // path; report ENOENT against the virtual path.

--- a/Sources/BashInterpreter/FileSystems/MountedFileSystem.swift
+++ b/Sources/BashInterpreter/FileSystems/MountedFileSystem.swift
@@ -1,0 +1,261 @@
+import Foundation
+
+/// A `FileSystem` that presents a virtual root (`/`) backed by one or
+/// more host directories mounted at chosen virtual prefixes.
+///
+/// Embedders building "iOS-app-as-sandbox" experiences want:
+///
+/// - `/` to be the user's writable workspace, NOT the host's real
+///   `/Users/oliver/Library/.../Documents/Untitled.ibash` — which
+///   leaks into `pwd`, error diagnostics, `$0`, and basically every
+///   path the script sees;
+/// - `/tmp` to mean the OS temp directory (so `mktemp`, `$TMPDIR`,
+///   etc. work the way scripts expect, but persisted state stays
+///   under the document package);
+/// - everything else (`/etc`, `/usr`, `/Users`) to look as if it
+///   doesn't exist — same model as a chrooted shell.
+///
+/// `MountedFileSystem` is the building block for that. You hand it a
+/// list of mount points and a backing FS; it rewrites every virtual
+/// path to a host path before delegating, and rejects paths that
+/// don't fall inside any mount with `notFound`.
+///
+/// ```swift
+/// let fs = MountedFileSystem(
+///     mounts: [
+///         .init(virtual: "/",    host: sandboxRoot.path),
+///         .init(virtual: "/tmp", host: NSTemporaryDirectory()),
+///     ],
+///     backing: RealFileSystem())
+/// shell.fileSystem = fs
+/// shell.environment.workingDirectory = "/home"
+/// shell.environment["HOME"] = "/home"
+/// shell.environment["TMPDIR"] = "/tmp"
+/// ```
+///
+/// Mount precedence is "longest virtual prefix wins" — `/tmp/foo`
+/// matches the `/tmp` mount, not `/`. Synthetic `/bin/*` paths
+/// supplied by `VirtualBinFileSystem` always fall through (so
+/// `which cat` still resolves) regardless of mounts.
+public final class MountedFileSystem: FileSystem, @unchecked Sendable {
+
+    public struct Mount: Sendable {
+        /// Virtual prefix this mount answers to. `/` matches every
+        /// virtual path; `/tmp` matches `/tmp` and `/tmp/...`.
+        public var virtual: String
+        /// Absolute host path the mount maps onto.
+        public var host: String
+        /// If true, every write through this mount is rejected with
+        /// `permissionDenied`. Reads still pass.
+        public var readOnly: Bool
+
+        public init(virtual: String, host: String, readOnly: Bool = false) {
+            // Normalise: strip trailing `/` so `/tmp` and `/tmp/`
+            // compare equal. The empty string represents the root
+            // mount specially.
+            var v = (virtual as NSString).standardizingPath
+            if v.count > 1, v.hasSuffix("/") { v.removeLast() }
+            self.virtual = v
+            self.host = (host as NSString).standardizingPath
+            self.readOnly = readOnly
+        }
+    }
+
+    public let backing: any FileSystem
+    private let mounts: [Mount]
+
+    public init(mounts: [Mount], backing: any FileSystem) {
+        // Sort longest-prefix-first so prefix matching picks the
+        // most specific mount.
+        self.mounts = mounts.sorted { $0.virtual.count > $1.virtual.count }
+        self.backing = backing
+    }
+
+    // MARK: - Mount lookup
+
+    /// Translate a virtual path to a host path, or return `nil` when
+    /// no mount matches. `(mount, hostPath, readOnly)`.
+    private func resolve(_ virtual: String) -> (mount: Mount, host: String)? {
+        // Synthetic /bin paths are handed verbatim to the backing FS
+        // (VirtualBinFileSystem expects them at the virtual position
+        // they advertise). Don't try to remap.
+        if isSyntheticBinPath(virtual) {
+            return (Mount(virtual: "/__virtual_bin__", host: virtual,
+                          readOnly: true),
+                    virtual)
+        }
+        // Standardise the virtual path so `/tmp/../home/foo` resolves
+        // to `/home/foo` BEFORE we route it. Otherwise `..` could
+        // escape its mount.
+        let std = (virtual as NSString).standardizingPath
+        for mount in mounts {
+            if mount.virtual == "/" {
+                // Root mount — every path lands here unless an earlier
+                // (more specific) mount matched. Strip the leading `/`
+                // and append.
+                let rel = std == "/" ? "" : String(std.dropFirst())
+                let host = (mount.host as NSString)
+                    .appendingPathComponent(rel)
+                return (mount, host)
+            }
+            if std == mount.virtual {
+                return (mount, mount.host)
+            }
+            if std.hasPrefix(mount.virtual + "/") {
+                let rel = String(std.dropFirst(mount.virtual.count + 1))
+                let host = (mount.host as NSString)
+                    .appendingPathComponent(rel)
+                return (mount, host)
+            }
+        }
+        return nil
+    }
+
+    private func isSyntheticBinPath(_ path: String) -> Bool {
+        let dirs: Set<String> = ["/bin", "/usr/bin", "/usr/local/bin"]
+        if dirs.contains(path) { return true }
+        let parent = (path as NSString).deletingLastPathComponent
+        return dirs.contains(parent)
+    }
+
+    private func gateRead(_ path: String) throws -> String {
+        guard let r = resolve(path) else {
+            throw FileSystemError.notFound(path)
+        }
+        return r.host
+    }
+
+    private func gateWrite(_ path: String) throws -> String {
+        guard let r = resolve(path) else {
+            throw FileSystemError.notFound(path)
+        }
+        if r.mount.readOnly {
+            throw FileSystemError.permissionDenied(path)
+        }
+        return r.host
+    }
+
+    // MARK: - FileSystem conformance
+
+    public func metadata(_ path: String) async throws -> FileMetadata? {
+        // "Outside the mount table" looks like ENOENT to scripts —
+        // not a thrown error, just `nil`, so test idioms like
+        // `[ -f /etc/passwd ]` behave as on a chrooted shell.
+        guard let r = resolve(path) else { return nil }
+        return try await backing.metadata(r.host)
+    }
+
+    public func list(_ path: String) async throws -> [String] {
+        try await backing.list(try gateRead(path))
+    }
+
+    public func canonicalize(_ path: String,
+                             allowMissing: Bool) async throws -> String {
+        // Important: return the VIRTUAL path back, not the host one.
+        // Otherwise `realpath /home/foo` leaks the host path into
+        // the script's view.
+        guard let r = resolve(path) else {
+            throw FileSystemError.notFound(path)
+        }
+        // Verify the host path is canonicalisable; let the backing FS
+        // throw notFound if `allowMissing == false` and nothing's there.
+        _ = try await backing.canonicalize(r.host, allowMissing: allowMissing)
+        return (path as NSString).standardizingPath
+    }
+
+    public func readData(_ path: String) async throws -> Data {
+        try await backing.readData(try gateRead(path))
+    }
+
+    public func openRead(_ path: String) async throws -> InputSource {
+        try await backing.openRead(try gateRead(path))
+    }
+
+    public func writeData(_ data: Data, to path: String,
+                          append: Bool) async throws {
+        try await backing.writeData(data, to: try gateWrite(path), append: append)
+    }
+
+    public func openWrite(_ path: String,
+                          append: Bool) async throws -> OutputSink {
+        try await backing.openWrite(try gateWrite(path), append: append)
+    }
+
+    public func touch(_ path: String) async throws {
+        try await backing.touch(try gateWrite(path))
+    }
+
+    public func createDirectory(_ path: String,
+                                intermediates: Bool) async throws {
+        try await backing.createDirectory(try gateWrite(path),
+                                          intermediates: intermediates)
+    }
+
+    public func remove(_ path: String, recursive: Bool) async throws {
+        try await backing.remove(try gateWrite(path), recursive: recursive)
+    }
+
+    public func move(from: String, to: String) async throws {
+        try await backing.move(from: try gateWrite(from),
+                               to: try gateWrite(to))
+    }
+
+    public func copy(from: String, to: String) async throws {
+        try await backing.copy(from: try gateRead(from),
+                               to: try gateWrite(to))
+    }
+
+    public func makeTempPath(prefix: String) async throws -> String {
+        // If the mount table covers `/tmp`, defer to the backing FS
+        // there. Otherwise drop into a hidden `.tmp` directory under
+        // the root mount.
+        if let tmp = mounts.first(where: { $0.virtual == "/tmp" }), !tmp.readOnly {
+            try? await backing.createDirectory(tmp.host, intermediates: true)
+            let suffix = String(UUID().uuidString.prefix(12))
+            return "/tmp/\(prefix)\(suffix)"
+        }
+        let fallback = "/.tmp/\(prefix)\(UUID().uuidString.prefix(12))"
+        if let host = try? gateWrite(fallback) {
+            try? await backing.createDirectory(
+                (host as NSString).deletingLastPathComponent,
+                intermediates: true)
+        }
+        return fallback
+    }
+
+    public func chmod(_ path: String, mode: UInt16) async throws {
+        try await backing.chmod(try gateWrite(path), mode: mode)
+    }
+
+    public func chown(_ path: String, uid: UInt32?, gid: UInt32?) async throws {
+        try await backing.chown(try gateWrite(path), uid: uid, gid: gid)
+    }
+
+    public func symlink(target: String, at linkPath: String) async throws {
+        // Both ends are virtual — guard them both, then translate.
+        try await backing.symlink(target: try gateRead(target),
+                                  at: try gateWrite(linkPath))
+    }
+
+    public func hardlink(target: String, at linkPath: String) async throws {
+        try await backing.hardlink(target: try gateRead(target),
+                                   at: try gateWrite(linkPath))
+    }
+
+    public func listXattrs(_ path: String) async throws -> [String] {
+        try await backing.listXattrs(try gateRead(path))
+    }
+
+    public func getXattr(_ path: String, name: String) async throws -> Data {
+        try await backing.getXattr(try gateRead(path), name: name)
+    }
+
+    public func setXattr(_ path: String, name: String, value: Data) async throws {
+        try await backing.setXattr(try gateWrite(path),
+                                   name: name, value: value)
+    }
+
+    public func removeXattr(_ path: String, name: String) async throws {
+        try await backing.removeXattr(try gateWrite(path), name: name)
+    }
+}

--- a/Sources/SwiftJSCore/Shell+SwiftJS.swift
+++ b/Sources/SwiftJSCore/Shell+SwiftJS.swift
@@ -43,13 +43,14 @@ extension Shell {
                     childShell: .inProcess,
                     stdout: { shell.stdout($0) },
                     stderr: { shell.stderr($0) })
-                do {
-                    _ = try runtime.runFile(context.scriptPath)
-                } catch {
-                    shell.stderr("\(context.scriptPath): \(error.localizedDescription)\n")
-                    runtime.fireExitListeners()
-                    return ExitStatus(1)
-                }
+                // Use the source the dispatcher already read through
+                // `Shell.fileSystem`, NOT `runtime.runFile(scriptPath)`
+                // — the latter reads from the host filesystem and
+                // skips the embedder's filesystem mounts. With a
+                // virtualised shell (e.g. `MountedFileSystem`),
+                // `context.scriptPath` is a virtual path like
+                // `/foo.js` that doesn't exist on the host.
+                _ = runtime.run(context.source, name: context.scriptPath)
                 runtime.fireExitListeners()
                 return ExitStatus(Int32(runtime.exitCode))
             })

--- a/Sources/SwiftJSCore/Shell+SwiftJS.swift
+++ b/Sources/SwiftJSCore/Shell+SwiftJS.swift
@@ -1,0 +1,59 @@
+#if canImport(JavaScriptCore)
+import Foundation
+import BashInterpreter
+
+extension Shell {
+
+    /// Register `swift-js`, `node`, and `bun` as shebang interpreters
+    /// so a path-invoked script with `#!/usr/bin/env swift-js`
+    /// (or `#!/usr/bin/env node`) runs in-process via `JSRuntime`.
+    ///
+    /// Mirrors ``Shell/registerBashShebang()`` and
+    /// ``Shell/registerSwiftScript()``: one call wires the entire
+    /// JavaScript shebang surface, with stdout / stderr routed
+    /// through the calling shell's sinks, argv pinned to
+    /// ``ShellArgvProvider``, env to ``ShellEnvProvider``, and
+    /// `child_process` left in-process so JS spawns route back into
+    /// SwiftBash's command registry rather than fork/exec.
+    ///
+    /// ```swift
+    /// let shell = Shell()
+    /// shell.registerStandardCommands()
+    /// shell.registerSwiftScript()        // .swift via SwiftScript
+    /// shell.registerSwiftJS()            // .js   via SwiftJSCore
+    /// try await shell.run("./hello.js Alice")
+    /// ```
+    ///
+    /// Apple-platforms only — JavaScriptCore isn't available on
+    /// Linux / Windows / Android. The whole file is gated on
+    /// `canImport(JavaScriptCore)`.
+    public func registerSwiftJS(
+        names: [String] = ["swift-js", "node", "bun"]
+    ) {
+        for name in names {
+            let interpreterName = name
+            registerScriptInterpreter(ClosureScriptInterpreter(name: name) { context in
+                let shell = Shell.bashCurrent
+                let runtime = JSRuntime(
+                    argvProvider: ShellArgvProvider(
+                        shell,
+                        interpreter: interpreterName,
+                        scriptPath: context.scriptPath),
+                    envProvider: ShellEnvProvider(shell),
+                    childShell: .inProcess,
+                    stdout: { shell.stdout($0) },
+                    stderr: { shell.stderr($0) })
+                do {
+                    _ = try runtime.runFile(context.scriptPath)
+                } catch {
+                    shell.stderr("\(context.scriptPath): \(error.localizedDescription)\n")
+                    runtime.fireExitListeners()
+                    return ExitStatus(1)
+                }
+                runtime.fireExitListeners()
+                return ExitStatus(Int32(runtime.exitCode))
+            })
+        }
+    }
+}
+#endif

--- a/Tests/BashCommandKitTests/ChmodSymbolicTests.swift
+++ b/Tests/BashCommandKitTests/ChmodSymbolicTests.swift
@@ -1,0 +1,137 @@
+import Testing
+import Foundation
+@testable import BashInterpreter
+@testable import BashCommandKit
+
+/// Symbolic-mode chmod parser tests. Numeric mode handling already lives
+/// in the broader filesystem suite; this file pins the `u+x`/`go-w`/
+/// `u=rwx,go=rx` parsing added with iBash adoption.
+@Suite("chmod symbolic-mode parsing")
+struct ChmodSymbolicTests {
+
+    private func makeFile(in dir: URL,
+                          name: String,
+                          mode: UInt16) throws -> URL {
+        let url = dir.appendingPathComponent(name)
+        try "".write(to: url, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: NSNumber(value: mode)],
+            ofItemAtPath: url.path)
+        return url
+    }
+
+    private func mode(of url: URL) throws -> UInt16 {
+        let attrs = try FileManager.default.attributesOfItem(atPath: url.path)
+        let n = attrs[.posixPermissions] as? NSNumber
+        return UInt16(truncating: n ?? 0)
+    }
+
+    @Test("`chmod +x file` sets the execute bit for all without touching r/w")
+    func plusX() async throws {
+        let dir = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("ibash-chmod-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir,
+                                                withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let file = try makeFile(in: dir, name: "script.sh", mode: 0o644)
+
+        let cap = CapturingShell()
+        cap.shell.registerStandardCommands()
+        cap.shell.environment.workingDirectory = dir.path
+
+        let status = try await cap.shell.run("chmod +x script.sh")
+        #expect(status == .success)
+        #expect(try mode(of: file) == 0o755)
+    }
+
+    @Test("`chmod u+x` only adds execute for owner")
+    func userPlusX() async throws {
+        let dir = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("ibash-chmod-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir,
+                                                withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let file = try makeFile(in: dir, name: "script.sh", mode: 0o644)
+        let cap = CapturingShell()
+        cap.shell.registerStandardCommands()
+        cap.shell.environment.workingDirectory = dir.path
+
+        let status = try await cap.shell.run("chmod u+x script.sh")
+        #expect(status == .success)
+        #expect(try mode(of: file) == 0o744)
+    }
+
+    @Test("`chmod go-w` strips group/other write")
+    func groupOtherMinusW() async throws {
+        let dir = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("ibash-chmod-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir,
+                                                withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let file = try makeFile(in: dir, name: "f", mode: 0o666)
+        let cap = CapturingShell()
+        cap.shell.registerStandardCommands()
+        cap.shell.environment.workingDirectory = dir.path
+
+        let status = try await cap.shell.run("chmod go-w f")
+        #expect(status == .success)
+        #expect(try mode(of: file) == 0o644)
+    }
+
+    @Test("`chmod u=rwx,go=rx` uses `=` to replace bits exactly")
+    func multipleClausesWithEquals() async throws {
+        let dir = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("ibash-chmod-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir,
+                                                withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let file = try makeFile(in: dir, name: "f", mode: 0o000)
+        let cap = CapturingShell()
+        cap.shell.registerStandardCommands()
+        cap.shell.environment.workingDirectory = dir.path
+
+        let status = try await cap.shell.run("chmod u=rwx,go=rx f")
+        #expect(status == .success)
+        #expect(try mode(of: file) == 0o755)
+    }
+
+    @Test("`chmod 755` (numeric octal) still works")
+    func numericStillWorks() async throws {
+        let dir = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("ibash-chmod-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir,
+                                                withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let file = try makeFile(in: dir, name: "f", mode: 0o644)
+        let cap = CapturingShell()
+        cap.shell.registerStandardCommands()
+        cap.shell.environment.workingDirectory = dir.path
+
+        let status = try await cap.shell.run("chmod 755 f")
+        #expect(status == .success)
+        #expect(try mode(of: file) == 0o755)
+    }
+
+    @Test("invalid mode emits diagnostic and returns failure")
+    func invalidMode() async throws {
+        let dir = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("ibash-chmod-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir,
+                                                withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        _ = try makeFile(in: dir, name: "f", mode: 0o644)
+        let cap = CapturingShell()
+        cap.shell.registerStandardCommands()
+        cap.shell.environment.workingDirectory = dir.path
+
+        let status = try await cap.shell.run("chmod nonsense f")
+        #expect(status != .success)
+        #expect(cap.stderr.contains("invalid mode"))
+    }
+}

--- a/Tests/BashCommandKitTests/ChmodSymbolicTests.swift
+++ b/Tests/BashCommandKitTests/ChmodSymbolicTests.swift
@@ -3,6 +3,15 @@ import Foundation
 @testable import BashInterpreter
 @testable import BashCommandKit
 
+// POSIX permission bits aren't meaningful on Windows — Foundation's
+// `setAttributes(.posixPermissions:)` is a best-effort no-op there
+// (NTFS uses ACLs, not Unix mode bits), so any test that asserts the
+// file ended up at exactly `0o755` will fail. Gate the whole suite
+// on non-Windows; the parser logic is platform-independent and runs
+// on every other supported target. Mirrors the `#if !os(Windows)`
+// gate around the exec-bit check inside `dispatchAsExternalScript…`.
+#if !os(Windows)
+
 /// Symbolic-mode chmod parser tests. Numeric mode handling already lives
 /// in the broader filesystem suite; this file pins the `u+x`/`go-w`/
 /// `u=rwx,go=rx` parsing added with iBash adoption.
@@ -135,3 +144,5 @@ struct ChmodSymbolicTests {
         #expect(cap.stderr.contains("invalid mode"))
     }
 }
+
+#endif // !os(Windows)

--- a/Tests/BashCommandKitTests/EmbedderConveniencesTests.swift
+++ b/Tests/BashCommandKitTests/EmbedderConveniencesTests.swift
@@ -1,0 +1,104 @@
+import Testing
+import Foundation
+@testable import BashInterpreter
+@testable import BashCommandKit
+
+/// Conveniences added for SwiftBash embedders building interactive
+/// shells (iBash, swift-bash --interactive, similar). Each one used
+/// to require a closure or a regex on the embedder side; these tests
+/// pin the new public surface.
+@Suite("Embedder conveniences")
+struct EmbedderConveniencesTests {
+
+    @Test("registerBashShebang lets ./script.sh dispatch via #!bash")
+    func bashShebangRoutesScript() async throws {
+        let dir = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("ibash-shebang-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir,
+                                                withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let script = dir.appendingPathComponent("greet.sh")
+        try "#!/usr/bin/env bash\necho hello $1\n"
+            .write(to: script, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: NSNumber(value: 0o755)],
+            ofItemAtPath: script.path)
+
+        let cap = CapturingShell()
+        cap.shell.registerStandardCommands()
+        cap.shell.registerBashShebang()
+        cap.shell.environment.workingDirectory = dir.path
+
+        let status = try await cap.shell.run("./greet.sh world")
+        #expect(status == .success)
+        #expect(cap.stdout.contains("hello world"))
+    }
+
+    @Test("interactive shell suppresses `: line N:` in error prefix")
+    func interactiveErrorFormat() async throws {
+        let cap = CapturingShell()
+        cap.shell.registerStandardCommands()
+        cap.shell.registerBashShebang()
+        cap.shell.scriptName = "iBash"
+        cap.shell.interactive = true
+
+        // Trigger a "command not found" — that's the easiest path
+        // through `errorLocationPrefix()`.
+        let status = try await cap.shell.run("nonexistent_command_xyz")
+        #expect(!status.isSuccess)
+        #expect(cap.stderr.contains("iBash: nonexistent_command_xyz"))
+        #expect(!cap.stderr.contains("line 1:"))
+    }
+
+    @Test("non-interactive (default) keeps the line-N prefix")
+    func nonInteractiveErrorFormat() async throws {
+        let cap = CapturingShell()
+        cap.shell.registerStandardCommands()
+        cap.shell.scriptName = "myscript"
+        // interactive defaults to false
+
+        let status = try await cap.shell.run("nonexistent_command_xyz")
+        #expect(!status.isSuccess)
+        #expect(cap.stderr.contains("myscript: line 1:"))
+    }
+
+    @Test("sourceProfileIfPresent runs ~/.profile then ~/.bashrc and reports which it ran")
+    func profileSourcing() async throws {
+        let dir = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("ibash-profile-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir,
+                                                withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        try "export GREETING='hello from profile'\n"
+            .write(to: dir.appendingPathComponent(".profile"),
+                   atomically: true, encoding: .utf8)
+        try "export FROM_BASHRC=1\n"
+            .write(to: dir.appendingPathComponent(".bashrc"),
+                   atomically: true, encoding: .utf8)
+
+        let cap = CapturingShell()
+        cap.shell.registerStandardCommands()
+
+        let sourced = try await cap.shell.sourceProfileIfPresent(at: dir)
+        #expect(sourced == [".profile", ".bashrc"])
+        #expect(cap.shell.environment["GREETING"] == "hello from profile")
+        #expect(cap.shell.environment["FROM_BASHRC"] == "1")
+    }
+
+    @Test("sourceProfileIfPresent skips missing files silently")
+    func profileSourcingMissing() async throws {
+        let dir = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("ibash-profile-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir,
+                                                withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let cap = CapturingShell()
+        cap.shell.registerStandardCommands()
+
+        let sourced = try await cap.shell.sourceProfileIfPresent(at: dir)
+        #expect(sourced.isEmpty)
+    }
+}

--- a/Tests/BashCommandKitTests/MountedFileSystemTests.swift
+++ b/Tests/BashCommandKitTests/MountedFileSystemTests.swift
@@ -126,6 +126,54 @@ struct MountedFileSystemTests {
                 == "/")
     }
 
+    @Test("symlink under mount pointing outside is rejected (no escape)")
+    func symlinkEscapeRejected() async throws {
+        let bench = try makeBench()
+        defer {
+            try? FileManager.default.removeItem(at: bench.sandboxRoot)
+            try? FileManager.default.removeItem(at: bench.tmpRoot)
+        }
+
+        // Plant a symlink under the sandbox that points to /etc on the
+        // host filesystem. A naive lexical confinement check would
+        // accept reads through it because the symlink path itself
+        // lives under the sandbox; canonicalisation has to catch it.
+        let escape = bench.sandboxRoot.appendingPathComponent("escape")
+        try FileManager.default.createSymbolicLink(
+            at: escape,
+            withDestinationURL: URL(fileURLWithPath: "/etc"))
+
+        // `cat /escape/passwd` should report ENOENT, not the contents
+        // of /etc/passwd.
+        let status = try await bench.cap.shell.run("cat /escape/passwd")
+        #expect(!status.isSuccess)
+        #expect(!bench.cap.stdout.contains("root:"))
+        #expect(bench.cap.stderr.contains("/escape/passwd"))
+    }
+
+    @Test("symlink target is stored verbatim, not remapped")
+    func symlinkTargetVerbatim() async throws {
+        let bench = try makeBench()
+        defer {
+            try? FileManager.default.removeItem(at: bench.sandboxRoot)
+            try? FileManager.default.removeItem(at: bench.tmpRoot)
+        }
+
+        // `ln -s foo bar` from inside the mount should land on disk
+        // as a symlink with target literally `foo` (not the host
+        // path of foo). Verify by reading the link's destination via
+        // FileManager.
+        try "hi".write(to: bench.sandboxRoot.appendingPathComponent("foo"),
+                       atomically: true, encoding: .utf8)
+        let status = try await bench.cap.shell.run("cd /; ln -s foo bar")
+        #expect(status == .success)
+
+        let bar = bench.sandboxRoot.appendingPathComponent("bar")
+        let dest = try FileManager.default
+            .destinationOfSymbolicLink(atPath: bar.path)
+        #expect(dest == "foo")
+    }
+
     @Test("read-only mount rejects writes")
     func readOnlyMount() async throws {
         let sandbox = URL(fileURLWithPath: NSTemporaryDirectory())

--- a/Tests/BashCommandKitTests/MountedFileSystemTests.swift
+++ b/Tests/BashCommandKitTests/MountedFileSystemTests.swift
@@ -1,0 +1,169 @@
+import Testing
+import Foundation
+@testable import BashInterpreter
+@testable import BashCommandKit
+
+@Suite("MountedFileSystem path mapping")
+struct MountedFileSystemTests {
+
+    /// Build a sandbox dir + tmp dir + a shell wired to a 2-mount FS.
+    private struct Bench {
+        let sandboxRoot: URL
+        let tmpRoot: URL
+        let cap: CapturingShell
+    }
+
+    private func makeBench() throws -> Bench {
+        let sandbox = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("ibash-mount-\(UUID().uuidString)")
+        let tmp = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("ibash-mount-tmp-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: sandbox,
+                                                withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: tmp,
+                                                withIntermediateDirectories: true)
+
+        let real = RealFileSystem()
+        let mounted = MountedFileSystem(
+            mounts: [
+                .init(virtual: "/",    host: sandbox.path),
+                .init(virtual: "/tmp", host: tmp.path),
+            ],
+            backing: real)
+
+        let cap = CapturingShell()
+        cap.shell.fileSystem = mounted
+        cap.shell.registerStandardCommands()
+        cap.shell.environment.workingDirectory = "/"
+        return Bench(sandboxRoot: sandbox, tmpRoot: tmp, cap: cap)
+    }
+
+    @Test("`ls /` lists the sandbox root, not the host root")
+    func lsRootMapsToSandbox() async throws {
+        let bench = try makeBench()
+        defer {
+            try? FileManager.default.removeItem(at: bench.sandboxRoot)
+            try? FileManager.default.removeItem(at: bench.tmpRoot)
+        }
+
+        try "hi".write(to: bench.sandboxRoot.appendingPathComponent("hello.txt"),
+                       atomically: true, encoding: .utf8)
+        try FileManager.default.createDirectory(
+            at: bench.sandboxRoot.appendingPathComponent("home"),
+            withIntermediateDirectories: true)
+
+        let status = try await bench.cap.shell.run("ls /")
+        #expect(status == .success)
+        let lines = bench.cap.stdout.split(separator: "\n").map(String.init).sorted()
+        #expect(lines.contains("hello.txt"))
+        #expect(lines.contains("home"))
+    }
+
+    @Test("`/tmp/foo` writes go to the tmp mount, not the root")
+    func tmpMountIsSeparate() async throws {
+        let bench = try makeBench()
+        defer {
+            try? FileManager.default.removeItem(at: bench.sandboxRoot)
+            try? FileManager.default.removeItem(at: bench.tmpRoot)
+        }
+
+        let status = try await bench.cap.shell.run("echo wrote > /tmp/scratch.txt")
+        #expect(status == .success)
+
+        // Lands in the tmp mount's host directory.
+        let tmpFile = bench.tmpRoot.appendingPathComponent("scratch.txt")
+        #expect(FileManager.default.fileExists(atPath: tmpFile.path))
+
+        // Does NOT leak into the sandbox root.
+        let leaked = bench.sandboxRoot.appendingPathComponent("tmp/scratch.txt")
+        #expect(!FileManager.default.fileExists(atPath: leaked.path))
+    }
+
+    @Test("paths outside any mount look like ENOENT")
+    func unmountedIsMissing() async throws {
+        let bench = try makeBench()
+        defer {
+            try? FileManager.default.removeItem(at: bench.sandboxRoot)
+            try? FileManager.default.removeItem(at: bench.tmpRoot)
+        }
+
+        let status = try await bench.cap.shell.run("cat /etc/passwd")
+        #expect(!status.isSuccess)
+        #expect(bench.cap.stderr.contains("/etc/passwd"))
+    }
+
+    @Test("realpath returns virtual paths, not host paths")
+    func realpathStaysVirtual() async throws {
+        let bench = try makeBench()
+        defer {
+            try? FileManager.default.removeItem(at: bench.sandboxRoot)
+            try? FileManager.default.removeItem(at: bench.tmpRoot)
+        }
+
+        try "x".write(to: bench.sandboxRoot.appendingPathComponent("x.txt"),
+                      atomically: true, encoding: .utf8)
+        let status = try await bench.cap.shell.run("realpath /x.txt")
+        #expect(status == .success)
+        #expect(bench.cap.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+                == "/x.txt")
+        // Specifically, the host path must NOT leak.
+        #expect(!bench.cap.stdout.contains(bench.sandboxRoot.path))
+    }
+
+    @Test("`cd ..` from `/` stays at `/`")
+    func dotDotFromRoot() async throws {
+        let bench = try makeBench()
+        defer {
+            try? FileManager.default.removeItem(at: bench.sandboxRoot)
+            try? FileManager.default.removeItem(at: bench.tmpRoot)
+        }
+
+        // Pwd is `/` initially. `..` standardises to `/` and the
+        // resolve walk lands back at the sandbox root.
+        let status = try await bench.cap.shell.run("cd ..; pwd")
+        #expect(status == .success)
+        #expect(bench.cap.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+                == "/")
+    }
+
+    @Test("read-only mount rejects writes")
+    func readOnlyMount() async throws {
+        let sandbox = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("ibash-mount-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: sandbox,
+                                                withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: sandbox) }
+
+        let examples = sandbox.appendingPathComponent("ex")
+        try FileManager.default.createDirectory(at: examples,
+                                                withIntermediateDirectories: true)
+        try "x".write(to: examples.appendingPathComponent("x.txt"),
+                      atomically: true, encoding: .utf8)
+
+        let mounted = MountedFileSystem(
+            mounts: [
+                .init(virtual: "/",         host: sandbox.path),
+                .init(virtual: "/examples", host: examples.path,
+                      readOnly: true),
+            ],
+            backing: RealFileSystem())
+
+        let cap = CapturingShell()
+        cap.shell.fileSystem = mounted
+        cap.shell.registerStandardCommands()
+        cap.shell.environment.workingDirectory = "/"
+
+        let read = try await cap.shell.run("cat /examples/x.txt")
+        #expect(read == .success)
+        #expect(cap.stdout == "x")
+
+        // Write redirection through `>` reaches the FS layer's
+        // openWrite, which throws permissionDenied. The interpreter
+        // surfaces that as either a non-zero status or a thrown
+        // BashInterpreterError depending on where it lands; either
+        // way, the file content is unchanged.
+        _ = try? await cap.shell.run("echo y > /examples/x.txt")
+        let stillX = try Data(contentsOf: examples.appendingPathComponent("x.txt"))
+        #expect(String(decoding: stillX, as: UTF8.self) == "x")
+    }
+}

--- a/Tests/BashCommandKitTests/PositionalParamDefaultExpansionTests.swift
+++ b/Tests/BashCommandKitTests/PositionalParamDefaultExpansionTests.swift
@@ -1,0 +1,94 @@
+import Testing
+@testable import BashInterpreter
+@testable import BashCommandKit
+
+/// `${1:-default}` and friends previously routed through `environment[name]`
+/// rather than `lookup`, so positional parameters were invisible to the
+/// `:-` / `:=` / `:?` / `:+` forms. Pin the behaviour now that they read
+/// through `lookupOptional`.
+@Suite("Positional parameters in :-/:=/:?/:+")
+struct PositionalParamDefaultExpansionTests {
+
+    private func makeShellWithArgs(_ args: [String]) -> CapturingShell {
+        let cap = CapturingShell()
+        cap.shell.registerStandardCommands()
+        cap.shell.positionalParameters = args
+        return cap
+    }
+
+    @Test("`${1:-fallback}` returns $1 when $1 is set")
+    func defaultWithSetParam() async throws {
+        let cap = makeShellWithArgs(["foo", "bar"])
+        let status = try await cap.shell.run(#"echo "${1:-fallback}""#)
+        #expect(status == .success)
+        #expect(cap.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+                == "foo")
+    }
+
+    @Test("`${1:-fallback}` returns the fallback when $1 is unset")
+    func defaultWithUnsetParam() async throws {
+        let cap = makeShellWithArgs([])
+        let status = try await cap.shell.run(#"echo "${1:-fallback}""#)
+        #expect(status == .success)
+        #expect(cap.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+                == "fallback")
+    }
+
+    @Test("`${1:?msg}` succeeds when $1 is set")
+    func errorIfUnsetWithSetParam() async throws {
+        let cap = makeShellWithArgs(["foo"])
+        let status = try await cap.shell.run(#"echo "${1:?need an arg}""#)
+        #expect(status == .success)
+        #expect(cap.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+                == "foo")
+        #expect(cap.stderr.isEmpty)
+    }
+
+    @Test("`${1:?msg}` errors when $1 is unset")
+    func errorIfUnsetWithUnsetParam() async throws {
+        let cap = makeShellWithArgs([])
+        let status = try await cap.shell.run(#"echo "${1:?usage: thing FILE}""#)
+        #expect(!status.isSuccess)
+        #expect(cap.stderr.contains("usage: thing FILE"))
+    }
+
+    @Test("`${1:+alt}` returns alt when $1 is set")
+    func alternativeWithSetParam() async throws {
+        let cap = makeShellWithArgs(["foo"])
+        let status = try await cap.shell.run(#"echo "${1:+have-arg}""#)
+        #expect(status == .success)
+        #expect(cap.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+                == "have-arg")
+    }
+
+    @Test("`${1:+alt}` returns empty when $1 is unset")
+    func alternativeWithUnsetParam() async throws {
+        let cap = makeShellWithArgs([])
+        let status = try await cap.shell.run(#"echo "${1:+have-arg}""#)
+        #expect(status == .success)
+        #expect(cap.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+                == "")
+    }
+
+    @Test("`${1:=default}` returns the default when $1 is unset")
+    func assignDefault() async throws {
+        // `:=` on a positional parameter is a syntax error in real
+        // bash, but iBash currently treats it like `:-` for positional
+        // params. Pin that "as if :-" behaviour for now so a future
+        // tighter check is intentional.
+        let cap = makeShellWithArgs([])
+        let status = try await cap.shell.run(#"echo "${1:=fallback}""#)
+        #expect(status == .success)
+        #expect(cap.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+                == "fallback")
+    }
+
+    @Test("$# and $@ keep working alongside the new lookup")
+    func countAndAllStillWork() async throws {
+        let cap = makeShellWithArgs(["foo", "bar", "baz"])
+        let status = try await cap.shell.run(#"echo "$# $@""#)
+        #expect(status == .success)
+        #expect(cap.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+                == "3 foo bar baz")
+    }
+}


### PR DESCRIPTION
Five iBash-driven commits, all in support of an in-process interactive
bash shell hosted by an iOS / macOS app (the running motivation is
the iBash document-based terminal). Each one removes ~10 lines of
boilerplate or a regex on the embedder side, or fixes a wrong-output
case caught while exercising the runtime.

## Commits

### `chmod`: POSIX symbolic modes
Numeric octal still works unchanged; symbolic clauses (`+x`, `u+x`,
`go-w`, `u=rwx,go=rx`) are applied left-to-right onto the file's
current mode. Default `who` is `a`, matching bash and POSIX.

Discovered while making iBash's coding agent able to mark scripts
executable — agents emit `chmod +x foo.sh` reflexively and previously
got `invalid mode`. **6 tests.**

### Parameter expansion: route `:-` / `:=` / `:?` / `:+` through positional-aware lookup
The four "checkEmpty" parameter forms — `${var:-default}`,
`${var:=default}`, `${var:?msg}`, `${var:+alt}` — were reading
from `environment[name]` directly, which only consults the named
variable map. Positional parameters live in `positionalParameters`
(consulted by `lookup()` for the bare `${1}` form), so the
default/error/alt forms always treated `$1` as unset:

```
$ cat ./script.sh foo bar
#!/usr/bin/env bash
file="${1:?usage: script.sh FILE}"
$ ./script.sh hello.sh
script.sh: line 2: 1: usage: script.sh FILE   # WRONG
```

Fix by introducing `lookupOptional(_ name:)` next to the existing
`lookup`. Same special-parameter handling, but returns `nil` for unset
positional params so the caller can distinguish set-but-empty from
unset the way real bash does. **8 tests.**

### Embedder API: bash-shebang dispatch, interactive flag, profile sourcing, swift-js helper
Four pieces of public API for hosts building interactive shells:

1. `Shell.registerBashShebang(names:)` — register `bash` / `sh` /
   `dash` as `ScriptInterpreter`s, so a path-invoked `./hello.sh`
   with `#!/usr/bin/env bash` runs through the same shell instead
   of reporting "command not found". Mirrors `registerSwiftScript()`.

2. `Shell.interactive: Bool` — when `true`, `errorLocationPrefix()`
   drops the `: line N:` portion. Each `Shell.run(line)` from a
   REPL is its own implicit line 1; the prefix reads as noise.
   Default `false` keeps script-style prefixes unchanged.

3. `Shell.sourceProfileIfPresent(at:filenames:)` — read `.profile`
   then `.bashrc` once at session start. Skips files that don't
   exist; reads through `Shell.fileSystem` so `MountedFileSystem` /
   `SandboxedOverlayFileSystem` still gate it. Returns the names
   that were sourced.

4. `Shell.registerSwiftJS(names:)` (SwiftJSCore) — analog to
   `registerSwiftScript()`. One call wires `swift-js` / `node` /
   `bun` shebangs to a `JSRuntime` configured with
   `ShellArgvProvider` + `ShellEnvProvider` + `.inProcess`, so JS
   scripts inherit the bash sandbox. Apple-only.

**5 tests.**

### `MountedFileSystem`: virtual `/` rooted at a host directory
A FileSystem wrapper that lets an embedder expose a virtual Unix
root made up of one or more host directories. Typical use:

```
/         ← the user's writable workspace (sandbox package)
/tmp      ← the OS temp directory
/examples ← bundled, read-only
```

vs. `SandboxedOverlayFileSystem` which keeps writes in an in-memory
COW layer; `MountedFileSystem` writes through to disk so the
sandbox persists across launches.

Behaviour:
- Longest-virtual-prefix-wins matching, so `/tmp/foo` routes to
  the `/tmp` mount, not `/`.
- Paths outside any mount surface as ENOENT (matches a chrooted
  shell — `[ -f /etc/passwd ]` simply false).
- `canonicalize` returns the *virtual* path back, so `realpath` /
  PS1's `\w` / dispatcher's `argv[0]` never leak host paths.
- Read-only mounts reject writes/touch/chmod with permissionDenied.
- VirtualBinFileSystem-style `/bin/cat` etc. always pass through.

The "just confine to one host root, keep host paths visible" use
case (an earlier draft of this PR shipped as a separate
`ConfinedFileSystem` type) is now expressed as a single mount where
`virtual == host` — same behaviour, one less type to maintain.

**6 tests.**

### SwiftJSCore: clear Swift-6 strict-concurrency warnings
Three threads of warnings the Swift 6 checker raises against the
JavaScript runtime + child_process bridge once a host adopts strict
concurrency:

1. `JSRuntime` captured in `@Sendable` closures — declare
   `JSRuntime: @unchecked Sendable`. The runtime is single-threaded
   by contract (every `JSValue` touch on main, documented in the
   class header).

2. `var` captures (`stdoutDone`, `stderrDone`, `processDone`,
   `exitStatus`) inside `@Sendable` Process callbacks — replace the
   `NSLock` + four vars with a small `SpawnState: @unchecked
   Sendable` reference type whose methods own the locking.

3. `unsafeBitCast(closure, to: AnyObject.self)` in `JSRuntime.block`
   — required in earlier Swift versions, no-op now. Replace with
   `closure` itself.

Behaviour unchanged; existing tests pass.

## Test summary

**25 new Swift Testing cases** across 4 suites in
`Tests/BashCommandKitTests/` and `Tests/BashInterpreterTests/`:

- `ChmodSymbolicTests` (6)
- `PositionalParamDefaultExpansionTests` (8)
- `EmbedderConveniencesTests` (5)
- `MountedFileSystemTests` (6)

Two pre-existing flaky timing tests (`stagesRunConcurrently`,
`ProcessTableTests`) are unrelated to this PR's surface — they fail
non-deterministically based on machine load.

## How iBash uses the new surface

iBash's `BashRunner.swift` shrank materially after this PR landed
locally:

```swift
let shell = BashInterpreter.Shell(environment: env)
shell.scriptName = "iBash"
shell.interactive = true                     // (2)
shell.registerStandardCommands()
shell.registerBashShebang()                  // (1)
shell.registerSwiftScript()
shell.registerSwiftJS()                      // (1) + (4)
shell.fileSystem = MountedFileSystem(        // (5)
    mounts: [
        .init(virtual: "/",         host: sandbox.root.path),
        .init(virtual: "/tmp",      host: tmp.path),
        .init(virtual: "/examples", host: examples.path,
              readOnly: true),
    ],
    backing: shell.fileSystem)
```

Plus a single `try await shell.sourceProfileIfPresent(at: ...)` on
first command, instead of an inline FileManager loop with caching.