### PR TITLE
ParsableCommandBridge: stop Sandbox.Denial leaking host paths

### DIFF
--- a/Sources/BashCommandKit/API/ParsableCommandBridge.swift
+++ b/Sources/BashCommandKit/API/ParsableCommandBridge.swift
@@ -21,6 +21,18 @@ struct ParsableCommandBridge<Parsed: ParsableBashCommand>: Command {
             // CancellationError is and would render it as a stray
             // "Error: CancellationError()" usage diagnostic.
             throw CancellationError()
+        } catch let denial as Sandbox.Denial {
+            // ShellKit's `Sandbox.Denial` is a plain struct with `url`,
+            // `reason`, and `suggestion` fields. Through ArgumentParser's
+            // `fullMessage(for:)` it would land on `String(describing:)`
+            // and dump every field — including `suggestion`, which is
+            // the embedder's host sandbox root + the requested path.
+            // For an iOS-app-as-sandbox embedder that means leaking
+            // the full container path into a `gh issue list`-style
+            // error. Render just the reason; the user already knows
+            // which command they ran.
+            Shell.bashCurrent.stderr("\(name): \(denial.reason)\n")
+            return ExitStatus(1)
         } catch {
             // ArgumentParser uses the error type to convey both real
             // usage errors *and* clean non-error exits like `--help`.

--- a/Tests/BashCommandKitTests/ParsableBashCommandTests.swift
+++ b/Tests/BashCommandKitTests/ParsableBashCommandTests.swift
@@ -1,4 +1,5 @@
 import Testing
+import Foundation
 import ArgumentParser
 @testable import BashInterpreter
 @testable import BashCommandKit
@@ -57,6 +58,19 @@ private struct Nameless: ParsableBashCommand {
     mutating func execute() async throws -> ExitStatus {
         Shell.bashCurrent.stdout("\(word)\n")
         return .success
+    }
+}
+
+/// Throws a `Sandbox.Denial` mid-execution. Stand-in for the
+/// real-world case where a SwiftPorts command (e.g. `gh`) tries to
+/// access a path outside the embedder's sandbox root.
+private struct DenyingCommand: ParsableBashCommand {
+    static let configuration = CommandConfiguration(commandName: "deny")
+    mutating func execute() async throws -> ExitStatus {
+        throw Sandbox.Denial(
+            url: URL(fileURLWithPath: "/secret/host/path/Documents/Untitled.ibash"),
+            reason: "file URL is outside sandbox root",
+            suggestion: URL(fileURLWithPath: "/secret/host/path/Documents/Untitled.ibash/home"))
     }
 }
 
@@ -157,6 +171,27 @@ private struct Nameless: ParsableBashCommand {
         cap.shell.register(GreetCommand.self)
         let status = try await cap.shell.run("greet --count notanumber oliver")
         #expect(!status.isSuccess)
+    }
+
+    /// `Sandbox.Denial` is a plain struct whose default
+    /// `String(describing:)` would dump the host file URL and the
+    /// "would-have-landed-at" suggestion — both of which leak the
+    /// embedder's sandbox root path. The bridge must catch the
+    /// denial and surface ONLY the reason, so a `gh issue list` from
+    /// inside an iOS-app-as-sandbox doesn't end up showing
+    /// `/Users/.../Containers/.../Documents/Untitled.ibash/home`
+    /// in stderr.
+    @Test func sandboxDenialDoesNotLeakHostPath() async throws {
+        let cap = CapturingShell()
+        cap.shell.register(DenyingCommand.self)
+        let status = try await cap.shell.run("deny")
+        #expect(!status.isSuccess)
+        #expect(cap.stderr.contains("file URL is outside sandbox root"),
+                "expected reason in stderr, got:\n\(cap.stderr)")
+        #expect(!cap.stderr.contains("/secret/host/path"),
+                "host path leaked into stderr:\n\(cap.stderr)")
+        #expect(!cap.stderr.contains("suggestion"),
+                "suggestion field leaked into stderr:\n\(cap.stderr)")
     }
 
     // MARK: Repeated parsed arguments


### PR DESCRIPTION
## Summary
- A registered `ParsableBashCommand` that throws `Sandbox.Denial` (e.g. SwiftPorts' `gh issue list` calling `Shell.authorize(workingDirectory)` when the cwd isn't under the embedder's sandbox root) used to render via ArgumentParser's `fullMessage(for:)`. That path falls through to `String(describing: error)` for unrecognised types and dumps every field of `Denial` — including the `suggestion: URL?`, which is the embedder's host sandbox root joined with the requested path.
- For an iOS-app-as-sandbox embedder this leaked the full container path (`/Users/.../Containers/.../Documents/Untitled.ibash/home`) into stderr on a single `gh issue list`.
- Catch `Sandbox.Denial` ahead of the generic catch in `ParsableCommandBridge` and surface only `denial.reason`, prefixed with the command name. Same shape as the existing JS-bridge handling in `SandboxBridge.throwSandboxDenial`.

## Test plan
- [x] `swift test --filter ParsableBashCommandTests` (16/16 passing)
- [x] New regression: `sandboxDenialDoesNotLeakHostPath` — fakes a `Denial` whose `url`/`suggestion` both point at `/secret/host/path/...` and asserts the rendered stderr contains the reason but not the host path or the literal `suggestion` field name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)