### PR TITLE
MountedFileSystem: stop autofs from rewriting `..` virtual paths

### DIFF
--- a/Sources/BashCommandKit/API/ParsableCommandBridge.swift
+++ b/Sources/BashCommandKit/API/ParsableCommandBridge.swift
@@ -21,6 +21,18 @@ struct ParsableCommandBridge<Parsed: ParsableBashCommand>: Command {
             // CancellationError is and would render it as a stray
             // "Error: CancellationError()" usage diagnostic.
             throw CancellationError()
+        } catch let denial as Sandbox.Denial {
+            // ShellKit's `Sandbox.Denial` is a plain struct with `url`,
+            // `reason`, and `suggestion` fields. Through ArgumentParser's
+            // `fullMessage(for:)` it would land on `String(describing:)`
+            // and dump every field — including `suggestion`, which is
+            // the embedder's host sandbox root + the requested path.
+            // For an iOS-app-as-sandbox embedder that means leaking
+            // the full container path into a `gh issue list`-style
+            // error. Render just the reason; the user already knows
+            // which command they ran.
+            Shell.bashCurrent.stderr("\(name): \(denial.reason)\n")
+            return ExitStatus(1)
         } catch {
             // ArgumentParser uses the error type to convey both real
             // usage errors *and* clean non-error exits like `--help`.

--- a/Sources/BashInterpreter/FileSystems/MountedFileSystem.swift
+++ b/Sources/BashInterpreter/FileSystems/MountedFileSystem.swift
@@ -87,7 +87,16 @@ public final class MountedFileSystem: FileSystem, @unchecked Sendable {
         // Standardise the virtual path so `/tmp/../home/foo` resolves
         // to `/home/foo` BEFORE we route it. Otherwise `..` could
         // escape its mount.
-        let std = (virtual as NSString).standardizingPath
+        //
+        // Use `Shell.normalizePath` (purely lexical) rather than
+        // `NSString.standardizingPath`, which consults the host
+        // filesystem and resolves any symlinks it finds. On macOS
+        // `/home` is an autofs symlink to `/System/Volumes/Data/home`,
+        // so `(/home/..) standardizingPath` yields
+        // `/System/Volumes/Data` and misses the mount table entirely —
+        // breaking any script that lands a `..`-crossing virtual path
+        // here (e.g. tab completion of `cd ../ex` from `/home`).
+        let std = Shell.normalizePath(virtual)
         for mount in mounts {
             if mount.virtual == "/" {
                 // Root mount — every path lands here unless an earlier

--- a/Tests/BashCommandKitTests/MountedFileSystemTests.swift
+++ b/Tests/BashCommandKitTests/MountedFileSystemTests.swift
@@ -110,6 +110,42 @@ struct MountedFileSystemTests {
         #expect(!bench.cap.stdout.contains(bench.sandboxRoot.path))
     }
 
+    @Test("`..` crossing an autofs-shaped virtual name resolves lexically")
+    func dotDotAcrossAutofsName() async throws {
+        let sandbox = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("ibash-mount-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: sandbox,
+                                                withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: sandbox) }
+
+        try "hi".write(
+            to: sandbox.appendingPathComponent("marker.txt"),
+            atomically: true, encoding: .utf8)
+        try FileManager.default.createDirectory(
+            at: sandbox.appendingPathComponent("home"),
+            withIntermediateDirectories: true)
+
+        // Call MountedFileSystem.list directly with a virtual path that
+        // still contains `..`. This mirrors what tab-completion code in
+        // an embedder does — it builds a `virtualDir = "/home/.."`
+        // string and asks the FS to enumerate it, bypassing the shell's
+        // `resolvePath` (which would have normalised lexically first).
+        //
+        // On macOS, the host's real `/home` is an autofs symlink to
+        // `/System/Volumes/Data/home`. With `NSString.standardizingPath`
+        // (which consults the host filesystem), `/home/..` standardises
+        // to `/System/Volumes/Data`, misses the mount table, and the
+        // list returns nothing — every read/list/completion through
+        // that path silently fails. The fix uses `Shell.normalizePath`
+        // for purely lexical normalisation, so `/home/..` stays `/`.
+        let mounted = MountedFileSystem(
+            mounts: [.init(virtual: "/", host: sandbox.path)],
+            backing: RealFileSystem())
+        let entries = try await mounted.list("/home/..").sorted()
+        #expect(entries.contains("marker.txt"))
+        #expect(entries.contains("home"))
+    }
+
     @Test("`cd ..` from `/` stays at `/`")
     func dotDotFromRoot() async throws {
         let bench = try makeBench()

--- a/Tests/BashCommandKitTests/ParsableBashCommandTests.swift
+++ b/Tests/BashCommandKitTests/ParsableBashCommandTests.swift
@@ -1,4 +1,5 @@
 import Testing
+import Foundation
 import ArgumentParser
 @testable import BashInterpreter
 @testable import BashCommandKit
@@ -57,6 +58,19 @@ private struct Nameless: ParsableBashCommand {
     mutating func execute() async throws -> ExitStatus {
         Shell.bashCurrent.stdout("\(word)\n")
         return .success
+    }
+}
+
+/// Throws a `Sandbox.Denial` mid-execution. Stand-in for the
+/// real-world case where a SwiftPorts command (e.g. `gh`) tries to
+/// access a path outside the embedder's sandbox root.
+private struct DenyingCommand: ParsableBashCommand {
+    static let configuration = CommandConfiguration(commandName: "deny")
+    mutating func execute() async throws -> ExitStatus {
+        throw Sandbox.Denial(
+            url: URL(fileURLWithPath: "/secret/host/path/Documents/Untitled.ibash"),
+            reason: "file URL is outside sandbox root",
+            suggestion: URL(fileURLWithPath: "/secret/host/path/Documents/Untitled.ibash/home"))
     }
 }
 
@@ -157,6 +171,27 @@ private struct Nameless: ParsableBashCommand {
         cap.shell.register(GreetCommand.self)
         let status = try await cap.shell.run("greet --count notanumber oliver")
         #expect(!status.isSuccess)
+    }
+
+    /// `Sandbox.Denial` is a plain struct whose default
+    /// `String(describing:)` would dump the host file URL and the
+    /// "would-have-landed-at" suggestion — both of which leak the
+    /// embedder's sandbox root path. The bridge must catch the
+    /// denial and surface ONLY the reason, so a `gh issue list` from
+    /// inside an iOS-app-as-sandbox doesn't end up showing
+    /// `/Users/.../Containers/.../Documents/Untitled.ibash/home`
+    /// in stderr.
+    @Test func sandboxDenialDoesNotLeakHostPath() async throws {
+        let cap = CapturingShell()
+        cap.shell.register(DenyingCommand.self)
+        let status = try await cap.shell.run("deny")
+        #expect(!status.isSuccess)
+        #expect(cap.stderr.contains("file URL is outside sandbox root"),
+                "expected reason in stderr, got:\n\(cap.stderr)")
+        #expect(!cap.stderr.contains("/secret/host/path"),
+                "host path leaked into stderr:\n\(cap.stderr)")
+        #expect(!cap.stderr.contains("suggestion"),
+                "suggestion field leaked into stderr:\n\(cap.stderr)")
     }
 
     // MARK: Repeated parsed arguments


### PR DESCRIPTION
## Summary

- `MountedFileSystem.resolve(_:)` was lexically normalising the virtual path via `NSString.standardizingPath`, which secretly consults the host filesystem and resolves symlinks for any component that exists. On macOS `/home` is an autofs symlink to `/System/Volumes/Data/home`, so a virtual `/home/..` standardised to `/System/Volumes/Data` and missed every entry in the mount table — silently failing every read/list/completion routed through that path.
- Swap to `Shell.normalizePath`, the existing lexical-only helper in `Shell+Path.swift` whose doc comment calls out this exact failure mode.
- Add a `MountedFileSystemTests.dotDotAcrossAutofsName` regression test that hits the FS directly (mirroring iBash's tab-completion path, which bypasses `Shell.resolvePath`'s pre-normalisation).

## Why this hasn't bitten existing tests

The shell layer already runs every user-typed path through `Shell.resolvePath` → `Shell.normalizePath` before handing it to the FS, so the existing `shell.run("…")`-style tests never reach `MountedFileSystem` with raw `..` paths. The bug only surfaces for embedders that call into the FS directly — iBash's tab-completion does this when listing `cd ../ex` candidates, and any other embedder building paths-with-`..` from user input is at the same risk.

## Stacked on #27

This branch is cut from `fix/parsable-denial-host-leak` because `MountedFileSystem.swift` only exists there (it landed in #26 and isn't yet on main). The diff against that base is one commit. When #27 merges, GitHub will auto-rebase this PR onto main.

## Follow-ups intentionally not in this PR

Two more `standardizingPath` calls in the same file are the same bug class but were left alone to keep the diff scoped:

- `Mount.init` line 56 — normalising the *virtual* prefix at config time. Mounting at `/home` on macOS today would silently rewrite the mount to `/System/Volumes/Data/home` and never match.
- `canonicalize()` line 262 — returning a virtual path through `standardizingPath`, which would re-leak `/System/Volumes/Data` into `realpath` output for `..`-crossing inputs.

Happy to bundle them in or do them as a follow-up — let me know.

## Test plan

- [x] `swift test --filter dotDotAcrossAutofsName` passes with the fix
- [x] Same test fails on the parent commit with `no such file: …/sandbox/System/Volumes/Data` (the exact autofs leakage)
- [x] Full MountedFileSystem suite (9 tests) green
- [x] `swift test` — 1801 tests, only 3 pre-existing timing-flaky failures (`stagesRunConcurrently`, `headCancelsSleepingProducer`, `waitAllAwaitsEverything`), all green on the parent commit too

🤖 Generated with [Claude Code](https://claude.com/claude-code)