### PR TITLE
CurlCommand: accept -m as short alias for --max-time

### DIFF
--- a/Sources/BashCommandKit/Commands/CurlCommand+Helpers.swift
+++ b/Sources/BashCommandKit/Commands/CurlCommand+Helpers.swift
@@ -213,7 +213,7 @@ allow-list rejects every URL with `Network access denied`.
   -A AGENT          User-Agent
   -e URL            Referer
   -w FORMAT         Print FORMAT after the response
-  --max-time SEC    Override the configured timeout
+  -m, --max-time SEC  Override the configured timeout
 
 Exit codes follow curl's CURLE_* convention (7 = denied, 22 = HTTP
 error with -f, 28 = timeout, 47 = too many redirects, 56 = response

--- a/Sources/BashCommandKit/Commands/CurlCommand.swift
+++ b/Sources/BashCommandKit/Commands/CurlCommand.swift
@@ -333,7 +333,7 @@ extension CurlCommand {
             case "-w", "--write-out":
                 opts.writeOut = try requireArg(argv, idx, name: arg)
                 idx += 2
-            case "--max-time":
+            case "-m", "--max-time":
                 let raw = try requireArg(argv, idx, name: arg)
                 if let val = TimeInterval(raw) { opts.maxTimeSeconds = val }
                 idx += 2


### PR DESCRIPTION
## Summary
- Adds `-m` to the existing `--max-time` arm in `CurlCommand`'s option parser so `curl -m 5 https://example.com` matches upstream curl's documented alias.
- Updates the embedded help text to advertise the short form.

Closes #33.

## Notes
I re-grepped the parser for other long flags missing their documented short alias; among the options this port actually implements, `--max-time` was the only gap — every other recognized long flag already lists its short form in the same `case` arm.

## Test plan
- [x] `swift build`
- [ ] Manual: `curl -m 5 https://example.com` is accepted (does not error with "unknown option").

🤖 Generated with [Claude Code](https://claude.com/claude-code)