### PR TITLE
find: accept --help and --version

### DIFF
--- a/Sources/BashCommandKit/Commands/FindCommand.swift
+++ b/Sources/BashCommandKit/Commands/FindCommand.swift
@@ -90,10 +90,12 @@ public struct FindCommand: Command {
 
     public func run(_ argv: [String]) async throws -> ExitStatus {
         let rest = Array(argv.dropFirst())
-        // GNU/BSD `find` bypasses the predicate parser for `--help`
-        // and `--version` — they print and exit 0 even when wedged
-        // between start paths and an expression.
-        for arg in rest {
+        // GNU/BSD `find` recognises `--help` and `--version` in option
+        // position only — after start paths and before the expression.
+        // Don't scan the full argv, or arguments to predicates (e.g.
+        // `find . -name --help`, `find . -exec echo --version \;`)
+        // would be hijacked.
+        scan: for arg in rest {
             switch arg {
             case "--help":
                 Shell.bashCurrent.stdout(Self.helpText)
@@ -102,7 +104,7 @@ public struct FindCommand: Command {
                 Shell.bashCurrent.stdout("find (swift-bash built-in)\n")
                 return .success
             default:
-                continue
+                if Self.isExpressionToken(arg) { break scan }
             }
         }
 

--- a/Sources/BashCommandKit/Commands/FindCommand.swift
+++ b/Sources/BashCommandKit/Commands/FindCommand.swift
@@ -56,10 +56,59 @@ public struct FindCommand: Command {
     public let name = "find"
     public init() {}
 
+    static let helpText = """
+        USAGE: find [PATH...] [EXPRESSION]
+
+        Recursively walk PATH (default `.`) and apply EXPRESSION to every
+        entry. With no expression, every entry is printed.
+
+        PREDICATES:
+          -name PATTERN, -iname PATTERN
+          -path PATTERN, -wholename PATTERN
+          -regex PATTERN, -iregex PATTERN
+          -type [f|d|l]            -empty
+          -newer FILE              -mtime [+-]N    -mmin [+-]N
+          -size [+-]N[ckMG]        -perm [-/]MODE
+
+        ACTIONS:
+          -print (default)         -print0
+          -prune                   -delete
+          -exec CMD ... ;          -exec CMD ... {} +
+
+        OPERATORS:
+          -not / !                 -a / -and        -o / -or
+          ( EXPR )
+
+        GLOBAL OPTIONS:
+          -maxdepth N              -mindepth N      -depth
+          -L, -H, -P               (symlink-following; accepted as no-ops)
+
+          --help                   Show this help and exit.
+          --version                Print version and exit.
+
+        """
+
     public func run(_ argv: [String]) async throws -> ExitStatus {
+        let rest = Array(argv.dropFirst())
+        // GNU/BSD `find` bypasses the predicate parser for `--help`
+        // and `--version` — they print and exit 0 even when wedged
+        // between start paths and an expression.
+        for arg in rest {
+            switch arg {
+            case "--help":
+                Shell.bashCurrent.stdout(Self.helpText)
+                return .success
+            case "--version":
+                Shell.bashCurrent.stdout("find (swift-bash built-in)\n")
+                return .success
+            default:
+                continue
+            }
+        }
+
         let parsed: Parsed
         do {
-            parsed = try Self.parse(argv: Array(argv.dropFirst()))
+            parsed = try Self.parse(argv: rest)
         } catch let err as ParseError {
             Shell.bashCurrent.stderr("find: \(err.message)\n")
             return .failure

--- a/Sources/BashCommandKit/Commands/FindCommand.swift
+++ b/Sources/BashCommandKit/Commands/FindCommand.swift
@@ -56,6 +56,26 @@ public struct FindCommand: Command {
     public let name = "find"
     public init() {}
 
+    // GNU/BSD `find` recognises `--help` and `--version` in option
+    // position only — after start paths and before the expression.
+    // Scanning the full argv would hijack predicate/action arguments
+    // like `find . -name --help` or `find . -exec echo --version \;`.
+    private static func infoFlagExit(_ rest: [String]) -> ExitStatus? {
+        for arg in rest {
+            switch arg {
+            case "--help":
+                Shell.bashCurrent.stdout(helpText)
+                return .success
+            case "--version":
+                Shell.bashCurrent.stdout("find (swift-bash built-in)\n")
+                return .success
+            default:
+                if isExpressionToken(arg) { return nil }
+            }
+        }
+        return nil
+    }
+
     static let helpText = """
         USAGE: find [PATH...] [EXPRESSION]
 
@@ -90,23 +110,7 @@ public struct FindCommand: Command {
 
     public func run(_ argv: [String]) async throws -> ExitStatus {
         let rest = Array(argv.dropFirst())
-        // GNU/BSD `find` recognises `--help` and `--version` in option
-        // position only — after start paths and before the expression.
-        // Don't scan the full argv, or arguments to predicates (e.g.
-        // `find . -name --help`, `find . -exec echo --version \;`)
-        // would be hijacked.
-        scan: for arg in rest {
-            switch arg {
-            case "--help":
-                Shell.bashCurrent.stdout(Self.helpText)
-                return .success
-            case "--version":
-                Shell.bashCurrent.stdout("find (swift-bash built-in)\n")
-                return .success
-            default:
-                if Self.isExpressionToken(arg) { break scan }
-            }
-        }
+        if let info = Self.infoFlagExit(rest) { return info }
 
         let parsed: Parsed
         do {

--- a/Tests/BashCommandKitTests/FindCommandTests.swift
+++ b/Tests/BashCommandKitTests/FindCommandTests.swift
@@ -223,6 +223,24 @@ import Foundation
         #expect(cap.stderr == "")
     }
 
+    @Test func helpAfterStartPathStillTriggers() async throws {
+        let (cap, dir) = try makeShell(); defer { cleanup(dir) }
+        let status = try await cap.shell.run("find . --help")
+        #expect(status == .success)
+        #expect(cap.stdout.contains("USAGE: find"))
+    }
+
+    @Test func helpAsPredicateArgumentIsTreatedAsArgument() async throws {
+        // `--help` after `-name` is the glob pattern, not the help flag.
+        // No file is literally named "--help", so output should be empty
+        // and the walk should still succeed.
+        let (cap, dir) = try makeShell(); defer { cleanup(dir) }
+        try await cap.shell.run("touch a b")
+        let status = try await cap.shell.run("find . -name --help")
+        #expect(status == .success)
+        #expect(cap.stdout == "")
+    }
+
     @Test func missingValueForNameFails() async throws {
         let (cap, dir) = try makeShell(); defer { cleanup(dir) }
         let status = try await cap.shell.run("find . -name")

--- a/Tests/BashCommandKitTests/FindCommandTests.swift
+++ b/Tests/BashCommandKitTests/FindCommandTests.swift
@@ -207,6 +207,22 @@ import Foundation
         #expect(cap.stderr.contains("-bogus"))
     }
 
+    @Test func helpFlagPrintsUsageAndExitsZero() async throws {
+        let (cap, dir) = try makeShell(); defer { cleanup(dir) }
+        let status = try await cap.shell.run("find --help")
+        #expect(status == .success)
+        #expect(cap.stdout.contains("USAGE: find"))
+        #expect(cap.stderr == "")
+    }
+
+    @Test func versionFlagPrintsBannerAndExitsZero() async throws {
+        let (cap, dir) = try makeShell(); defer { cleanup(dir) }
+        let status = try await cap.shell.run("find --version")
+        #expect(status == .success)
+        #expect(cap.stdout.contains("find"))
+        #expect(cap.stderr == "")
+    }
+
     @Test func missingValueForNameFails() async throws {
         let (cap, dir) = try makeShell(); defer { cleanup(dir) }
         let status = try await cap.shell.run("find . -name")


### PR DESCRIPTION
## Summary
- `find --help` and `find --version` previously errored as `unknown predicate` because anything starting with `--` fell into the default arm of `parseFlag`.
- Short-circuit both flags at the top of `FindCommand.run` (before path / global-option / expression parsing), matching how GNU/BSD `find` handles them.
- Add a `helpText` constant covering predicates, actions, operators, and global options.

## Test plan
- [x] `swift test --filter FindCommandTests` (41 tests pass, including the new `helpFlagPrintsUsageAndExitsZero` and `versionFlagPrintsBannerAndExitsZero`)
- [x] `swiftlint --strict` clean on the touched files

Fixes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)