### PR TITLE
Register node/bun/swift/swift-js as top-level commands (fixes #37)

### DIFF
--- a/Sources/BashSwiftScript/Shell+SwiftScript.swift
+++ b/Sources/BashSwiftScript/Shell+SwiftScript.swift
@@ -1,17 +1,29 @@
 import BashInterpreter
+import Foundation
+import SwiftScriptInterpreter
 
 extension Shell {
 
-    /// Register SwiftScript under each of `names` so a path-invoked
-    /// script with a matching `#!`-shebang routes through it.
-    /// Defaults to `["swift-script", "swift"]` — both
-    /// `#!/usr/bin/env swift-script` and `#!/usr/bin/env swift`
-    /// shebangs go to the same backend.
+    /// Register SwiftScript under each of `names` as both a top-level
+    /// command AND a shebang interpreter.
+    ///
+    /// Two registrations per name:
+    ///
+    ///   * **Command** — handles a bare `swift`/`swift-script`
+    ///     invocation: `--version`, `-e <expr>`, and
+    ///     `<script.swift> [args...]`. Mirrors the surface of the
+    ///     standalone `swift-script` CLI.
+    ///
+    ///   * **ScriptInterpreter** — handles
+    ///     `#!/usr/bin/env swift-script` / `#!/usr/bin/env swift`
+    ///     when a path-invoked script triggers shebang dispatch.
     ///
     /// ```swift
     /// let shell = Shell()
     /// shell.registerStandardCommands()   // BashCommandKit
     /// shell.registerSwiftScript()        // BashSwiftScript
+    /// try await shell.run("swift --version")
+    /// try await shell.run("swift -e 'print(1 + 2)'")
     /// try await shell.run("/abs/script.swift one two")
     /// ```
     ///
@@ -26,6 +38,126 @@ extension Shell {
     ) {
         for name in names {
             registerScriptInterpreter(SwiftScriptShellInterpreter(name: name))
+
+            let invokedAs = name
+            register(name: name) { argv in
+                await runSwiftScriptCommand(invokedAs: invokedAs, argv: argv)
+            }
         }
+    }
+}
+
+/// Argv-shape dispatcher for the `swift` / `swift-script` commands.
+/// Mirrors the standalone `swift-script` CLI but routes through the
+/// bound ``Shell`` (IO via `shell.stdout/stderr`, script reads via
+/// `shell.fileSystem` so virtualised mounts work).
+private func runSwiftScriptCommand(
+    invokedAs: String,
+    argv: [String]
+) async -> ExitStatus {
+    let shell = Shell.bashCurrent
+    let userArgs = Array(argv.dropFirst())
+
+    func usage() {
+        shell.stderr("""
+            usage: \(invokedAs) <file.swift> [args...]
+                   \(invokedAs) -e <expression>
+                   \(invokedAs) --version
+
+            """)
+    }
+
+    guard let first = userArgs.first else {
+        usage()
+        return ExitStatus(2)
+    }
+
+    if first == "--version" || first == "-v" {
+        // Match the upstream `swift --version` shape closely enough
+        // that scripts which sniff "Swift" still recognise us.
+        shell.stdout("swift-script 0.1 (SwiftBash embedded)\n")
+        return .success
+    }
+
+    if first == "-h" || first == "--help" {
+        usage()
+        return ExitStatus(2)
+    }
+
+    let interpreter = Interpreter()
+
+    if first == "-e" {
+        guard userArgs.count >= 2 else {
+            usage()
+            return ExitStatus(2)
+        }
+        let source = userArgs[1]
+        let extra = Array(userArgs.dropFirst(2))
+        interpreter.scriptArguments = ["<expression>"] + extra
+        do {
+            let result = try await interpreter.eval(
+                source, fileName: "<expression>")
+            if case .void = result {
+                // nothing to print
+            } else {
+                shell.stdout(result.description + "\n")
+            }
+            return .success
+        } catch let parseError as ParseError {
+            interpreter.error(parseError.formatted)
+            if !parseError.formatted.hasSuffix("\n") {
+                interpreter.error("\n")
+            }
+            return ExitStatus(1)
+        } catch let scriptExit as ScriptExit {
+            return scriptExit.status
+        } catch is CancellationError {
+            return ExitStatus(143)
+        } catch {
+            interpreter.error(interpreter.renderRuntimeError(error))
+            return ExitStatus(1)
+        }
+    }
+
+    // Script file path — read through shell.fileSystem so virtualised
+    // mounts work.
+    let scriptPath = first
+    let scriptArgs = Array(userArgs.dropFirst())
+    let resolved: String
+    do {
+        resolved = try await shell.fileSystem.canonicalize(
+            scriptPath, allowMissing: false)
+    } catch {
+        shell.stderr("\(invokedAs): \(scriptPath): No such file or directory\n")
+        return ExitStatus(127)
+    }
+    let data: Data
+    do {
+        data = try await shell.fileSystem.readData(resolved)
+    } catch {
+        shell.stderr("\(invokedAs): \(scriptPath): \(error.localizedDescription)\n")
+        return ExitStatus(1)
+    }
+    // swiftlint:disable:next optional_data_string_conversion
+    var source = String(decoding: data, as: UTF8.self)
+    // Rewrite a leading `#!` to `//` so the parser is happy; preserve
+    // byte offsets so diagnostics still line up.
+    if source.hasPrefix("#!") {
+        source = "//" + source.dropFirst(2)
+    }
+    interpreter.scriptArguments = [resolved] + scriptArgs
+    do {
+        return try await interpreter.evalScript(source, fileName: resolved)
+    } catch let parseError as ParseError {
+        interpreter.error(parseError.formatted)
+        if !parseError.formatted.hasSuffix("\n") {
+            interpreter.error("\n")
+        }
+        return ExitStatus(1)
+    } catch is CancellationError {
+        return ExitStatus(143)
+    } catch {
+        interpreter.error(interpreter.renderRuntimeError(error))
+        return ExitStatus(1)
     }
 }

--- a/Sources/BashSwiftScript/Shell+SwiftScript.swift
+++ b/Sources/BashSwiftScript/Shell+SwiftScript.swift
@@ -149,10 +149,14 @@ private func runSwiftScriptFile(
     // Read through shell.fileSystem so virtualised mounts work.
     let scriptPath = userArgs[0]
     let scriptArgs = Array(userArgs.dropFirst())
+    // Resolve relative paths against the shell's cwd (not the host
+    // process cwd) so `swift foo.swift` works after an in-shell `cd`
+    // and honours virtualised filesystem roots.
+    let absolute = shell.resolvePath(scriptPath)
     let resolved: String
     do {
         resolved = try await shell.fileSystem.canonicalize(
-            scriptPath, allowMissing: false)
+            absolute, allowMissing: false)
     } catch {
         shell.stderr("\(invokedAs): \(scriptPath): No such file or directory\n")
         return ExitStatus(127)

--- a/Sources/BashSwiftScript/Shell+SwiftScript.swift
+++ b/Sources/BashSwiftScript/Shell+SwiftScript.swift
@@ -58,17 +58,8 @@ private func runSwiftScriptCommand(
     let shell = Shell.bashCurrent
     let userArgs = Array(argv.dropFirst())
 
-    func usage() {
-        shell.stderr("""
-            usage: \(invokedAs) <file.swift> [args...]
-                   \(invokedAs) -e <expression>
-                   \(invokedAs) --version
-
-            """)
-    }
-
     guard let first = userArgs.first else {
-        usage()
+        shell.stderr(swiftScriptUsage(invokedAs: invokedAs))
         return ExitStatus(2)
     }
 
@@ -80,48 +71,83 @@ private func runSwiftScriptCommand(
     }
 
     if first == "-h" || first == "--help" {
-        usage()
+        shell.stderr(swiftScriptUsage(invokedAs: invokedAs))
         return ExitStatus(2)
     }
 
-    let interpreter = Interpreter()
-
     if first == "-e" {
-        guard userArgs.count >= 2 else {
-            usage()
-            return ExitStatus(2)
-        }
-        let source = userArgs[1]
-        let extra = Array(userArgs.dropFirst(2))
-        interpreter.scriptArguments = ["<expression>"] + extra
-        do {
-            let result = try await interpreter.eval(
-                source, fileName: "<expression>")
-            if case .void = result {
-                // nothing to print
-            } else {
-                shell.stdout(result.description + "\n")
-            }
-            return .success
-        } catch let parseError as ParseError {
-            interpreter.error(parseError.formatted)
-            if !parseError.formatted.hasSuffix("\n") {
-                interpreter.error("\n")
-            }
-            return ExitStatus(1)
-        } catch let scriptExit as ScriptExit {
-            return scriptExit.status
-        } catch is CancellationError {
-            return ExitStatus(143)
-        } catch {
-            interpreter.error(interpreter.renderRuntimeError(error))
-            return ExitStatus(1)
-        }
+        return await runSwiftScriptEval(
+            invokedAs: invokedAs, userArgs: userArgs, shell: shell)
     }
 
-    // Script file path — read through shell.fileSystem so virtualised
-    // mounts work.
-    let scriptPath = first
+    return await runSwiftScriptFile(
+        invokedAs: invokedAs, userArgs: userArgs, shell: shell)
+}
+
+private func swiftScriptUsage(invokedAs: String) -> String {
+    """
+    usage: \(invokedAs) <file.swift> [args...]
+           \(invokedAs) -e <expression>
+           \(invokedAs) --version
+
+    """
+}
+
+private func renderSwiftScriptError(
+    _ error: Error,
+    interpreter: Interpreter
+) -> ExitStatus {
+    switch error {
+    case let parseError as ParseError:
+        interpreter.error(parseError.formatted)
+        if !parseError.formatted.hasSuffix("\n") {
+            interpreter.error("\n")
+        }
+        return ExitStatus(1)
+    case is CancellationError:
+        return ExitStatus(143)
+    default:
+        interpreter.error(interpreter.renderRuntimeError(error))
+        return ExitStatus(1)
+    }
+}
+
+private func runSwiftScriptEval(
+    invokedAs: String,
+    userArgs: [String],
+    shell: Shell
+) async -> ExitStatus {
+    guard userArgs.count >= 2 else {
+        shell.stderr(swiftScriptUsage(invokedAs: invokedAs))
+        return ExitStatus(2)
+    }
+    let source = userArgs[1]
+    let extra = Array(userArgs.dropFirst(2))
+    let interpreter = Interpreter()
+    interpreter.scriptArguments = ["<expression>"] + extra
+    do {
+        let result = try await interpreter.eval(
+            source, fileName: "<expression>")
+        if case .void = result {
+            // nothing to print
+        } else {
+            shell.stdout(result.description + "\n")
+        }
+        return .success
+    } catch let scriptExit as ScriptExit {
+        return scriptExit.status
+    } catch {
+        return renderSwiftScriptError(error, interpreter: interpreter)
+    }
+}
+
+private func runSwiftScriptFile(
+    invokedAs: String,
+    userArgs: [String],
+    shell: Shell
+) async -> ExitStatus {
+    // Read through shell.fileSystem so virtualised mounts work.
+    let scriptPath = userArgs[0]
     let scriptArgs = Array(userArgs.dropFirst())
     let resolved: String
     do {
@@ -145,19 +171,11 @@ private func runSwiftScriptCommand(
     if source.hasPrefix("#!") {
         source = "//" + source.dropFirst(2)
     }
+    let interpreter = Interpreter()
     interpreter.scriptArguments = [resolved] + scriptArgs
     do {
         return try await interpreter.evalScript(source, fileName: resolved)
-    } catch let parseError as ParseError {
-        interpreter.error(parseError.formatted)
-        if !parseError.formatted.hasSuffix("\n") {
-            interpreter.error("\n")
-        }
-        return ExitStatus(1)
-    } catch is CancellationError {
-        return ExitStatus(143)
     } catch {
-        interpreter.error(interpreter.renderRuntimeError(error))
-        return ExitStatus(1)
+        return renderSwiftScriptError(error, interpreter: interpreter)
     }
 }

--- a/Sources/SwiftJSCore/Shell+SwiftJS.swift
+++ b/Sources/SwiftJSCore/Shell+SwiftJS.swift
@@ -172,10 +172,14 @@ private func runSwiftJSScript(
     // same reason the shebang path doesn't use `runtime.runFile`.
     let scriptPath = userArgs[0]
     let scriptArgs = Array(userArgs.dropFirst())
+    // Resolve relative paths against the shell's cwd (not the host
+    // process cwd) so `node foo.js` works after an in-shell `cd` and
+    // honours virtualised filesystem roots.
+    let absolute = shell.resolvePath(scriptPath)
     let resolved: String
     do {
         resolved = try await shell.fileSystem.canonicalize(
-            scriptPath, allowMissing: false)
+            absolute, allowMissing: false)
     } catch {
         shell.stderr("\(invokedAs): \(scriptPath): No such file or directory\n")
         return ExitStatus(127)

--- a/Sources/SwiftJSCore/Shell+SwiftJS.swift
+++ b/Sources/SwiftJSCore/Shell+SwiftJS.swift
@@ -4,34 +4,42 @@ import BashInterpreter
 
 extension Shell {
 
-    /// Register `swift-js`, `node`, and `bun` as shebang interpreters
-    /// so a path-invoked script with `#!/usr/bin/env swift-js`
-    /// (or `#!/usr/bin/env node`) runs in-process via `JSRuntime`.
+    /// Register `swift-js`, `node`, and `bun` as both top-level
+    /// commands AND shebang interpreters.
     ///
-    /// Mirrors ``Shell/registerBashShebang()`` and
-    /// ``Shell/registerSwiftScript()``: one call wires the entire
-    /// JavaScript shebang surface, with stdout / stderr routed
-    /// through the calling shell's sinks, argv pinned to
-    /// ``ShellArgvProvider``, env to ``ShellEnvProvider``, and
-    /// `child_process` left in-process so JS spawns route back into
-    /// SwiftBash's command registry rather than fork/exec.
+    /// Two registrations per name:
+    ///
+    ///   * **Command** — handles a bare `node`/`bun`/`swift-js`
+    ///     invocation, including `--version`, `-e <expr>`,
+    ///     `-p`/`--print <expr>`, and `<script.js> [args...]`.
+    ///     Mirrors the argv-shape of the standalone `swift-js`
+    ///     binary (``Sources/swift-js/main.swift``), but stays
+    ///     in-process so it works inside iOS App Sandbox and
+    ///     virtualised file systems.
+    ///
+    ///   * **ScriptInterpreter** — handles the
+    ///     `#!/usr/bin/env node` shebang path so a path-invoked
+    ///     `./hello.js` still routes here.
+    ///
+    /// Apple-platforms only — JavaScriptCore isn't available on
+    /// Linux / Windows / Android. The whole file is gated on
+    /// `canImport(JavaScriptCore)`.
     ///
     /// ```swift
     /// let shell = Shell()
     /// shell.registerStandardCommands()
     /// shell.registerSwiftScript()        // .swift via SwiftScript
     /// shell.registerSwiftJS()            // .js   via SwiftJSCore
+    /// try await shell.run("node --version")
+    /// try await shell.run("node -e 'console.log(2+2)'")
     /// try await shell.run("./hello.js Alice")
     /// ```
-    ///
-    /// Apple-platforms only — JavaScriptCore isn't available on
-    /// Linux / Windows / Android. The whole file is gated on
-    /// `canImport(JavaScriptCore)`.
     public func registerSwiftJS(
         names: [String] = ["swift-js", "node", "bun"]
     ) {
         for name in names {
             let interpreterName = name
+            // Shebang path: `#!/usr/bin/env node` against a file.
             registerScriptInterpreter(ClosureScriptInterpreter(name: name) { context in
                 let shell = Shell.bashCurrent
                 let runtime = JSRuntime(
@@ -54,7 +62,124 @@ extension Shell {
                 runtime.fireExitListeners()
                 return ExitStatus(Int32(runtime.exitCode))
             })
+
+            // Top-level command path: `node --version`, `node -e ...`,
+            // `node script.js`. Same surface as the standalone
+            // `swift-js` binary.
+            register(name: name) { argv in
+                await runSwiftJSCommand(interpreter: interpreterName,
+                                        argv: argv)
+            }
         }
     }
+}
+
+/// Argv-shape dispatcher shared by the `node` / `bun` / `swift-js`
+/// commands. Mirrors ``Sources/swift-js/main.swift`` but routes IO
+/// through the bound ``Shell`` and reads scripts through
+/// ``Shell/fileSystem`` so virtualised mounts work.
+private func runSwiftJSCommand(
+    interpreter: String,
+    argv: [String]
+) async -> ExitStatus {
+    let shell = Shell.bashCurrent
+    let invokedAs = (interpreter as NSString).lastPathComponent.lowercased()
+    let isNodeAlias = invokedAs == "node" || invokedAs == "nodejs"
+    let isBunAlias  = invokedAs == "bun"
+
+    // argv[0] is the command name; user args start at argv[1].
+    let userArgs = Array(argv.dropFirst())
+
+    guard let first = userArgs.first else {
+        let usage: String
+        if isNodeAlias || isBunAlias {
+            usage = "usage: \(invokedAs) <script.js> [args...]\n"
+                  + "       \(invokedAs) -e <expr>\n"
+                  + "       \(invokedAs) --version\n"
+        } else {
+            usage = "usage: \(invokedAs) <script.js> [args...]\n"
+                  + "       \(invokedAs) -e|-p <expr>\n"
+                  + "       \(invokedAs) --version\n"
+        }
+        shell.stderr(usage)
+        return ExitStatus(2)
+    }
+
+    if first == "--version" || first == "-v" {
+        let version = isNodeAlias ? "v22.0.0-swiftjs"
+                    : isBunAlias  ? "1.3.0-swiftjs"
+                                  : "swift-js 0.2"
+        shell.stdout("\(version)\n")
+        return .success
+    }
+
+    if first == "-e" || first == "-p" || first == "--print" {
+        guard userArgs.count >= 2 else {
+            shell.stderr("\(invokedAs): \(first) requires an expression\n")
+            return ExitStatus(2)
+        }
+        let expr = userArgs[1]
+        let extra = Array(userArgs.dropFirst(2))
+        // Argv for inline eval: [interpreter, "[eval]", ...extra].
+        // Mirrors node's behaviour where argv[1] is the script slot
+        // even when there is no script file. Use StaticArgvProvider
+        // because there's no script path to anchor a ShellArgvProvider.
+        let runtime = JSRuntime(
+            argv: [interpreter, "[eval]"] + extra,
+            envProvider: ShellEnvProvider(shell),
+            childShell: .inProcess,
+            stdout: { shell.stdout($0) },
+            stderr: { shell.stderr($0) })
+        let result = runtime.run(expr, name: "[eval]")
+        let shouldPrint = (first == "-p" || first == "--print")
+        if shouldPrint, runtime.exitCode == 0,
+           let result, !result.isUndefined, !result.isNull {
+            shell.stdout((result.toString() ?? "") + "\n")
+        }
+        runtime.fireExitListeners()
+        return ExitStatus(runtime.exitCode)
+    }
+
+    // Anything else is treated as a script path. Read through the
+    // shell's file system so virtualised mounts work — same reason
+    // the shebang path doesn't use `runtime.runFile`.
+    let scriptPath = first
+    let scriptArgs = Array(userArgs.dropFirst())
+    let resolved: String
+    do {
+        resolved = try await shell.fileSystem.canonicalize(
+            scriptPath, allowMissing: false)
+    } catch {
+        shell.stderr("\(invokedAs): \(scriptPath): No such file or directory\n")
+        return ExitStatus(127)
+    }
+    let data: Data
+    do {
+        data = try await shell.fileSystem.readData(resolved)
+    } catch {
+        shell.stderr("\(invokedAs): \(scriptPath): \(error.localizedDescription)\n")
+        return ExitStatus(1)
+    }
+    // swiftlint:disable:next optional_data_string_conversion
+    let source = String(decoding: data, as: UTF8.self)
+
+    // Stash scriptArgs as positional parameters so ShellArgvProvider
+    // picks them up the same way the shebang path does.
+    let savedPositional = shell.positionalParameters
+    shell.positionalParameters = scriptArgs
+    defer { shell.positionalParameters = savedPositional }
+
+    let runtime = JSRuntime(
+        argvProvider: ShellArgvProvider(
+            shell,
+            interpreter: interpreter,
+            scriptPath: resolved),
+        envProvider: ShellEnvProvider(shell),
+        childShell: .inProcess,
+        stdout: { shell.stdout($0) },
+        stderr: { shell.stderr($0) })
+    _ = runtime.run(source, name: resolved)
+    runtime.fireExitListeners()
+    return ExitStatus(Int32(runtime.exitCode))
 }
 #endif

--- a/Sources/SwiftJSCore/Shell+SwiftJS.swift
+++ b/Sources/SwiftJSCore/Shell+SwiftJS.swift
@@ -84,66 +84,93 @@ private func runSwiftJSCommand(
 ) async -> ExitStatus {
     let shell = Shell.bashCurrent
     let invokedAs = (interpreter as NSString).lastPathComponent.lowercased()
-    let isNodeAlias = invokedAs == "node" || invokedAs == "nodejs"
-    let isBunAlias  = invokedAs == "bun"
-
-    // argv[0] is the command name; user args start at argv[1].
     let userArgs = Array(argv.dropFirst())
 
     guard let first = userArgs.first else {
-        let usage: String
-        if isNodeAlias || isBunAlias {
-            usage = "usage: \(invokedAs) <script.js> [args...]\n"
-                  + "       \(invokedAs) -e <expr>\n"
-                  + "       \(invokedAs) --version\n"
-        } else {
-            usage = "usage: \(invokedAs) <script.js> [args...]\n"
-                  + "       \(invokedAs) -e|-p <expr>\n"
-                  + "       \(invokedAs) --version\n"
-        }
-        shell.stderr(usage)
+        shell.stderr(swiftJSUsage(invokedAs: invokedAs))
         return ExitStatus(2)
     }
 
     if first == "--version" || first == "-v" {
-        let version = isNodeAlias ? "v22.0.0-swiftjs"
-                    : isBunAlias  ? "1.3.0-swiftjs"
-                                  : "swift-js 0.2"
-        shell.stdout("\(version)\n")
+        shell.stdout("\(swiftJSVersion(invokedAs: invokedAs))\n")
         return .success
     }
 
     if first == "-e" || first == "-p" || first == "--print" {
-        guard userArgs.count >= 2 else {
-            shell.stderr("\(invokedAs): \(first) requires an expression\n")
-            return ExitStatus(2)
-        }
-        let expr = userArgs[1]
-        let extra = Array(userArgs.dropFirst(2))
-        // Argv for inline eval: [interpreter, "[eval]", ...extra].
-        // Mirrors node's behaviour where argv[1] is the script slot
-        // even when there is no script file. Use StaticArgvProvider
-        // because there's no script path to anchor a ShellArgvProvider.
-        let runtime = JSRuntime(
-            argv: [interpreter, "[eval]"] + extra,
-            envProvider: ShellEnvProvider(shell),
-            childShell: .inProcess,
-            stdout: { shell.stdout($0) },
-            stderr: { shell.stderr($0) })
-        let result = runtime.run(expr, name: "[eval]")
-        let shouldPrint = (first == "-p" || first == "--print")
-        if shouldPrint, runtime.exitCode == 0,
-           let result, !result.isUndefined, !result.isNull {
-            shell.stdout((result.toString() ?? "") + "\n")
-        }
-        runtime.fireExitListeners()
-        return ExitStatus(runtime.exitCode)
+        return runSwiftJSEval(
+            interpreter: interpreter, invokedAs: invokedAs,
+            flag: first, userArgs: userArgs, shell: shell)
     }
 
-    // Anything else is treated as a script path. Read through the
-    // shell's file system so virtualised mounts work — same reason
-    // the shebang path doesn't use `runtime.runFile`.
-    let scriptPath = first
+    return await runSwiftJSScript(
+        interpreter: interpreter, invokedAs: invokedAs,
+        userArgs: userArgs, shell: shell)
+}
+
+private func swiftJSUsage(invokedAs: String) -> String {
+    let isAlias = invokedAs == "node" || invokedAs == "nodejs"
+                  || invokedAs == "bun"
+    if isAlias {
+        return "usage: \(invokedAs) <script.js> [args...]\n"
+             + "       \(invokedAs) -e <expr>\n"
+             + "       \(invokedAs) --version\n"
+    }
+    return "usage: \(invokedAs) <script.js> [args...]\n"
+         + "       \(invokedAs) -e|-p <expr>\n"
+         + "       \(invokedAs) --version\n"
+}
+
+private func swiftJSVersion(invokedAs: String) -> String {
+    switch invokedAs {
+    case "node", "nodejs": return "v22.0.0-swiftjs"
+    case "bun":            return "1.3.0-swiftjs"
+    default:               return "swift-js 0.2"
+    }
+}
+
+private func runSwiftJSEval(
+    interpreter: String,
+    invokedAs: String,
+    flag: String,
+    userArgs: [String],
+    shell: Shell
+) -> ExitStatus {
+    guard userArgs.count >= 2 else {
+        shell.stderr("\(invokedAs): \(flag) requires an expression\n")
+        return ExitStatus(2)
+    }
+    let expr = userArgs[1]
+    let extra = Array(userArgs.dropFirst(2))
+    // Argv for inline eval: [interpreter, "[eval]", ...extra].
+    // Mirrors node's behaviour where argv[1] is the script slot
+    // even when there is no script file. Use StaticArgvProvider
+    // because there's no script path to anchor a ShellArgvProvider.
+    let runtime = JSRuntime(
+        argv: [interpreter, "[eval]"] + extra,
+        envProvider: ShellEnvProvider(shell),
+        childShell: .inProcess,
+        stdout: { shell.stdout($0) },
+        stderr: { shell.stderr($0) })
+    let result = runtime.run(expr, name: "[eval]")
+    let shouldPrint = (flag == "-p" || flag == "--print")
+    if shouldPrint, runtime.exitCode == 0,
+       let result, !result.isUndefined, !result.isNull {
+        shell.stdout((result.toString() ?? "") + "\n")
+    }
+    runtime.fireExitListeners()
+    return ExitStatus(runtime.exitCode)
+}
+
+private func runSwiftJSScript(
+    interpreter: String,
+    invokedAs: String,
+    userArgs: [String],
+    shell: Shell
+) async -> ExitStatus {
+    // Anything that isn't a flag is treated as a script path. Read
+    // through the shell's file system so virtualised mounts work —
+    // same reason the shebang path doesn't use `runtime.runFile`.
+    let scriptPath = userArgs[0]
     let scriptArgs = Array(userArgs.dropFirst())
     let resolved: String
     do {

--- a/Tests/BashSwiftScriptTests/BashSwiftScriptTests.swift
+++ b/Tests/BashSwiftScriptTests/BashSwiftScriptTests.swift
@@ -329,52 +329,6 @@ import ShellKit
 
     // MARK: identity
 
-    // MARK: top-level command surface (issue #37)
-
-    @Test func swiftVersionFlagRunsInProcess() async throws {
-        let (shell, cap) = makeShell()
-        let status = try await shell.run("swift --version")
-        #expect(status.code == 0)
-        #expect(cap.stdout.contains("swift-script"))
-    }
-
-    @Test func swiftScriptVersionFlagRunsInProcess() async throws {
-        let (shell, cap) = makeShell()
-        let status = try await shell.run("swift-script --version")
-        #expect(status.code == 0)
-        #expect(cap.stdout.contains("swift-script"))
-    }
-
-    @Test func swiftDashEEvaluatesExpression() async throws {
-        let (shell, cap) = makeShell()
-        let status = try await shell.run("swift -e 'print(2 + 3)'")
-        #expect(status.code == 0)
-        #expect(cap.stdout == "5\n")
-    }
-
-    @Test func swiftDashENoExpressionReportsUsage() async throws {
-        let (shell, cap) = makeShell()
-        let status = try await shell.run("swift -e")
-        #expect(status.code == 2)
-        #expect(cap.stderr.contains("usage:"))
-    }
-
-    @Test func swiftWithScriptPathStillWorks() async throws {
-        // The command path should also handle a script-file invocation
-        // (no shebang) — `swift script.swift` with no `#!` line.
-        let (shell, cap) = makeShell()
-        let script = try writeScript("""
-            print("hi from file")
-            """)
-        defer { try? FileManager.default.removeItem(atPath: script.dir) }
-
-        let status = try await shell.run("swift \(Self.bashQuote(script.path))")
-        #expect(status.code == 0)
-        #expect(cap.stdout == "hi from file\n")
-    }
-
-    // MARK: identity
-
     @Test func swiftScriptSeesSandboxIdentity() async throws {
         var info = HostInfo.synthetic
         info.userName = "agent"

--- a/Tests/BashSwiftScriptTests/BashSwiftScriptTests.swift
+++ b/Tests/BashSwiftScriptTests/BashSwiftScriptTests.swift
@@ -329,6 +329,52 @@ import ShellKit
 
     // MARK: identity
 
+    // MARK: top-level command surface (issue #37)
+
+    @Test func swiftVersionFlagRunsInProcess() async throws {
+        let (shell, cap) = makeShell()
+        let status = try await shell.run("swift --version")
+        #expect(status.code == 0)
+        #expect(cap.stdout.contains("swift-script"))
+    }
+
+    @Test func swiftScriptVersionFlagRunsInProcess() async throws {
+        let (shell, cap) = makeShell()
+        let status = try await shell.run("swift-script --version")
+        #expect(status.code == 0)
+        #expect(cap.stdout.contains("swift-script"))
+    }
+
+    @Test func swiftDashEEvaluatesExpression() async throws {
+        let (shell, cap) = makeShell()
+        let status = try await shell.run("swift -e 'print(2 + 3)'")
+        #expect(status.code == 0)
+        #expect(cap.stdout == "5\n")
+    }
+
+    @Test func swiftDashENoExpressionReportsUsage() async throws {
+        let (shell, cap) = makeShell()
+        let status = try await shell.run("swift -e")
+        #expect(status.code == 2)
+        #expect(cap.stderr.contains("usage:"))
+    }
+
+    @Test func swiftWithScriptPathStillWorks() async throws {
+        // The command path should also handle a script-file invocation
+        // (no shebang) — `swift script.swift` with no `#!` line.
+        let (shell, cap) = makeShell()
+        let script = try writeScript("""
+            print("hi from file")
+            """)
+        defer { try? FileManager.default.removeItem(atPath: script.dir) }
+
+        let status = try await shell.run("swift \(Self.bashQuote(script.path))")
+        #expect(status.code == 0)
+        #expect(cap.stdout == "hi from file\n")
+    }
+
+    // MARK: identity
+
     @Test func swiftScriptSeesSandboxIdentity() async throws {
         var info = HostInfo.synthetic
         info.userName = "agent"

--- a/Tests/BashSwiftScriptTests/SwiftScriptCommandSurfaceTests.swift
+++ b/Tests/BashSwiftScriptTests/SwiftScriptCommandSurfaceTests.swift
@@ -54,6 +54,26 @@ import ShellKit
         #expect(cap.stderr.contains("usage:"))
     }
 
+    @Test func swiftResolvesRelativePathAgainstShellCwd() async throws {
+        // Regression for codex P1 review: `swift script.swift` after an
+        // in-shell `cd` must resolve against the shell's working
+        // directory, not the host process cwd.
+        let (shell, cap) = makeShell()
+        let dir = NSTemporaryDirectory()
+            + "swift-script-relcwd-\(UUID().uuidString)"
+        try FileManager.default.createDirectory(
+            atPath: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(atPath: dir) }
+        let path = dir + "/rel.swift"
+        try "print(\"from cwd\")\n"
+            .write(toFile: path, atomically: true, encoding: .utf8)
+
+        let status = try await shell.run(
+            "cd \(Self.bashQuote(dir)) && swift rel.swift")
+        #expect(status.code == 0)
+        #expect(cap.stdout == "from cwd\n")
+    }
+
     @Test func swiftWithScriptPathStillWorks() async throws {
         // The command path should also handle a script-file invocation
         // (no shebang) — `swift script.swift` with no `#!` line.

--- a/Tests/BashSwiftScriptTests/SwiftScriptCommandSurfaceTests.swift
+++ b/Tests/BashSwiftScriptTests/SwiftScriptCommandSurfaceTests.swift
@@ -1,0 +1,76 @@
+import Testing
+import Foundation
+import ShellKit
+@testable import BashInterpreter
+@testable import BashSwiftScript
+
+/// Issue #37: in-process `swift` / `swift-script` must accept the
+/// same argv shape as the standalone CLI — `--version`, `-e <expr>`,
+/// and `<script.swift>`. Before the fix these names were only
+/// registered as `ScriptInterpreter`s (for `#!/usr/bin/env`
+/// shebangs), so a bare `swift --version` invocation failed.
+@Suite(.timeLimit(.minutes(1))) struct SwiftScriptCommandSurfaceTests {
+
+    private func makeShell() -> (BashInterpreter.Shell, TestCapture) {
+        let capture = TestCapture()
+        let shell = BashInterpreter.Shell(
+            stdout: capture.stdoutSink,
+            stderr: capture.stderrSink,
+            environment: Environment(),
+            commands: BashInterpreter.Shell.defaultCommands())
+        shell.registerSwiftScript()
+        return (shell, capture)
+    }
+
+    private static func bashQuote(_ path: String) -> String {
+        "'" + path.replacingOccurrences(of: "'", with: "'\\''") + "'"
+    }
+
+    @Test func swiftVersionFlagRunsInProcess() async throws {
+        let (shell, cap) = makeShell()
+        let status = try await shell.run("swift --version")
+        #expect(status.code == 0)
+        #expect(cap.stdout.contains("swift-script"))
+    }
+
+    @Test func swiftScriptVersionFlagRunsInProcess() async throws {
+        let (shell, cap) = makeShell()
+        let status = try await shell.run("swift-script --version")
+        #expect(status.code == 0)
+        #expect(cap.stdout.contains("swift-script"))
+    }
+
+    @Test func swiftDashEEvaluatesExpression() async throws {
+        let (shell, cap) = makeShell()
+        let status = try await shell.run("swift -e 'print(2 + 3)'")
+        #expect(status.code == 0)
+        #expect(cap.stdout == "5\n")
+    }
+
+    @Test func swiftDashENoExpressionReportsUsage() async throws {
+        let (shell, cap) = makeShell()
+        let status = try await shell.run("swift -e")
+        #expect(status.code == 2)
+        #expect(cap.stderr.contains("usage:"))
+    }
+
+    @Test func swiftWithScriptPathStillWorks() async throws {
+        // The command path should also handle a script-file invocation
+        // (no shebang) — `swift script.swift` with no `#!` line.
+        let (shell, cap) = makeShell()
+        let dir = NSTemporaryDirectory()
+            + "swift-script-cmd-\(UUID().uuidString)"
+        try FileManager.default.createDirectory(
+            atPath: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(atPath: dir) }
+        let path = dir + "/script.swift"
+        try "print(\"hi from file\")\n"
+            .write(toFile: path, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o755], ofItemAtPath: path)
+
+        let status = try await shell.run("swift \(Self.bashQuote(path))")
+        #expect(status.code == 0)
+        #expect(cap.stdout == "hi from file\n")
+    }
+}

--- a/Tests/SwiftJSCoreTests/SwiftJSCommandSurfaceTests.swift
+++ b/Tests/SwiftJSCoreTests/SwiftJSCommandSurfaceTests.swift
@@ -1,16 +1,22 @@
 #if canImport(JavaScriptCore)
-import XCTest
-@testable import SwiftJSCore
-import BashInterpreter
-import BashCommandKit
+import Testing
 import Foundation
+import ShellKit
+@testable import SwiftJSCore
+@testable import BashInterpreter
+import BashCommandKit
 
 /// Issue #37: in-process `node` / `bun` / `swift-js` must accept the
 /// same argv shape as the standalone CLI — `--version`, `-e <expr>`,
 /// `-p <expr>`, and `<script.js>`. Before the fix these only worked
 /// via the script-interpreter (shebang) path, so a bare
 /// `node --version` invocation failed.
-final class SwiftJSCommandSurfaceTests: XCTestCase {
+///
+/// Uses Swift Testing rather than XCTest because mixing JSC + XCTest
+/// + bash pipeline dispatch crashes swift-corelibs-xctest's signal
+/// handler on Linux during teardown; the Swift Testing path is
+/// unaffected.
+@Suite(.timeLimit(.minutes(1))) struct SwiftJSCommandSurfaceTests {
 
     private final class StringBox: @unchecked Sendable {
         private let lock = NSLock()
@@ -42,69 +48,72 @@ final class SwiftJSCommandSurfaceTests: XCTestCase {
         }
     }
 
-    private func makeShell() -> (Shell, Capture) {
+    private func makeShell() -> (BashInterpreter.Shell, Capture) {
         let cap = Capture()
-        let shell = Shell(
+        let shell = BashInterpreter.Shell(
             stdout: cap.stdoutSink,
             stderr: cap.stderrSink,
             environment: Environment(),
-            commands: Shell.defaultCommands())
+            commands: BashInterpreter.Shell.defaultCommands())
         shell.registerSwiftJS()
         return (shell, cap)
     }
 
-    func testNodeVersionFlag() async throws {
+    private static func bashQuote(_ path: String) -> String {
+        "'" + path.replacingOccurrences(of: "'", with: "'\\''") + "'"
+    }
+
+    @Test func nodeVersionFlag() async throws {
         let (shell, cap) = makeShell()
         let status = try await shell.run("node --version")
-        XCTAssertEqual(status.code, 0)
-        XCTAssertTrue(cap.stdout.contains("v22"),
-                      "unexpected version output: \(cap.stdout)")
+        #expect(status.code == 0)
+        #expect(cap.stdout.contains("v22"))
     }
 
-    func testBunVersionFlag() async throws {
+    @Test func bunVersionFlag() async throws {
         let (shell, cap) = makeShell()
         let status = try await shell.run("bun --version")
-        XCTAssertEqual(status.code, 0)
-        XCTAssertFalse(cap.stdout.isEmpty)
+        #expect(status.code == 0)
+        #expect(!cap.stdout.isEmpty)
     }
 
-    func testSwiftJsVersionFlag() async throws {
+    @Test func swiftJsVersionFlag() async throws {
         let (shell, cap) = makeShell()
         let status = try await shell.run("swift-js --version")
-        XCTAssertEqual(status.code, 0)
-        XCTAssertTrue(cap.stdout.contains("swift-js"))
+        #expect(status.code == 0)
+        #expect(cap.stdout.contains("swift-js"))
     }
 
-    func testNodeDashE() async throws {
+    @Test func nodeDashE() async throws {
         let (shell, cap) = makeShell()
         let status = try await shell.run("node -e 'console.log(2 + 3)'")
-        XCTAssertEqual(status.code, 0)
-        XCTAssertEqual(cap.stdout, "5\n")
+        #expect(status.code == 0)
+        #expect(cap.stdout == "5\n")
     }
 
-    func testNodeDashPPrintsExpression() async throws {
+    @Test func nodeDashPPrintsExpression() async throws {
         let (shell, cap) = makeShell()
         // `-p` evaluates and prints the resulting expression value.
         let status = try await shell.run("node -p '40 + 2'")
-        XCTAssertEqual(status.code, 0)
-        XCTAssertEqual(cap.stdout, "42\n")
+        #expect(status.code == 0)
+        #expect(cap.stdout == "42\n")
     }
 
-    func testBunDashE() async throws {
+    @Test func bunDashE() async throws {
         let (shell, cap) = makeShell()
         let status = try await shell.run("bun -e 'console.log(\"hi\")'")
-        XCTAssertEqual(status.code, 0)
-        XCTAssertEqual(cap.stdout, "hi\n")
+        #expect(status.code == 0)
+        #expect(cap.stdout == "hi\n")
     }
 
-    func testNodeDashEWithoutExpressionReportsError() async throws {
+    @Test func nodeDashEWithoutExpressionReportsError() async throws {
         let (shell, cap) = makeShell()
         let status = try await shell.run("node -e")
-        XCTAssertEqual(status.code, 2)
-        XCTAssertTrue(cap.stderr.contains("requires an expression"))
+        #expect(status.code == 2)
+        #expect(cap.stderr.contains("requires an expression"))
     }
 
-    func testNodeResolvesRelativePathAgainstShellCwd() async throws {
+    @Test func nodeResolvesRelativePathAgainstShellCwd() async throws {
         // Regression for codex P1 review: `node foo.js` after an
         // in-shell `cd` must resolve against the shell's working
         // directory, not the host process cwd.
@@ -118,16 +127,13 @@ final class SwiftJSCommandSurfaceTests: XCTestCase {
             .write(toFile: path, atomically: true, encoding: .utf8)
 
         let (shell, cap) = makeShell()
-        let quoted = "'" + dir.replacingOccurrences(of: "'", with: "'\\''") + "'"
-        let status = try await shell.run("cd \(quoted) && node rel.js")
-        XCTAssertEqual(status.code, 0)
-        XCTAssertEqual(cap.stdout, "from cwd\n")
+        let status = try await shell.run(
+            "cd \(Self.bashQuote(dir)) && node rel.js")
+        #expect(status.code == 0)
+        #expect(cap.stdout == "from cwd\n")
     }
 
-    func testNodeWithScriptPath() async throws {
-        // The Command path also handles `node script.js` for files
-        // without a shebang — covers the case where `node` is invoked
-        // explicitly rather than via `./script.js`.
+    @Test func nodeWithScriptPath() async throws {
         let dir = NSTemporaryDirectory()
             + "swift-js-cmd-\(UUID().uuidString)"
         try FileManager.default.createDirectory(
@@ -138,10 +144,9 @@ final class SwiftJSCommandSurfaceTests: XCTestCase {
             .write(toFile: path, atomically: true, encoding: .utf8)
 
         let (shell, cap) = makeShell()
-        let quoted = "'" + path.replacingOccurrences(of: "'", with: "'\\''") + "'"
-        let status = try await shell.run("node \(quoted)")
-        XCTAssertEqual(status.code, 0)
-        XCTAssertEqual(cap.stdout, "hello from file\n")
+        let status = try await shell.run("node \(Self.bashQuote(path))")
+        #expect(status.code == 0)
+        #expect(cap.stdout == "hello from file\n")
     }
 }
 #endif

--- a/Tests/SwiftJSCoreTests/SwiftJSCommandSurfaceTests.swift
+++ b/Tests/SwiftJSCoreTests/SwiftJSCommandSurfaceTests.swift
@@ -1,0 +1,127 @@
+#if canImport(JavaScriptCore)
+import XCTest
+@testable import SwiftJSCore
+import BashInterpreter
+import BashCommandKit
+import Foundation
+
+/// Issue #37: in-process `node` / `bun` / `swift-js` must accept the
+/// same argv shape as the standalone CLI — `--version`, `-e <expr>`,
+/// `-p <expr>`, and `<script.js>`. Before the fix these only worked
+/// via the script-interpreter (shebang) path, so a bare
+/// `node --version` invocation failed.
+final class SwiftJSCommandSurfaceTests: XCTestCase {
+
+    private final class StringBox: @unchecked Sendable {
+        private let lock = NSLock()
+        private var value = ""
+        func append(_ data: Data) {
+            // swiftlint:disable:next optional_data_string_conversion
+            let text = String(decoding: data, as: UTF8.self)
+            lock.lock(); defer { lock.unlock() }
+            value.append(text)
+        }
+        func read() -> String {
+            lock.lock(); defer { lock.unlock() }
+            return value
+        }
+    }
+
+    private final class Capture: @unchecked Sendable {
+        let stdoutSink: OutputSink
+        let stderrSink: OutputSink
+        private let outBox = StringBox()
+        private let errBox = StringBox()
+        var stdout: String { outBox.read() }
+        var stderr: String { errBox.read() }
+        init() {
+            let out = outBox
+            let err = errBox
+            self.stdoutSink = OutputSink(onWrite: { out.append($0) })
+            self.stderrSink = OutputSink(onWrite: { err.append($0) })
+        }
+    }
+
+    private func makeShell() -> (Shell, Capture) {
+        let cap = Capture()
+        let shell = Shell(
+            stdout: cap.stdoutSink,
+            stderr: cap.stderrSink,
+            environment: Environment(),
+            commands: Shell.defaultCommands())
+        shell.registerSwiftJS()
+        return (shell, cap)
+    }
+
+    func testNodeVersionFlag() async throws {
+        let (shell, cap) = makeShell()
+        let status = try await shell.run("node --version")
+        XCTAssertEqual(status.code, 0)
+        XCTAssertTrue(cap.stdout.contains("v22"),
+                      "unexpected version output: \(cap.stdout)")
+    }
+
+    func testBunVersionFlag() async throws {
+        let (shell, cap) = makeShell()
+        let status = try await shell.run("bun --version")
+        XCTAssertEqual(status.code, 0)
+        XCTAssertFalse(cap.stdout.isEmpty)
+    }
+
+    func testSwiftJsVersionFlag() async throws {
+        let (shell, cap) = makeShell()
+        let status = try await shell.run("swift-js --version")
+        XCTAssertEqual(status.code, 0)
+        XCTAssertTrue(cap.stdout.contains("swift-js"))
+    }
+
+    func testNodeDashE() async throws {
+        let (shell, cap) = makeShell()
+        let status = try await shell.run("node -e 'console.log(2 + 3)'")
+        XCTAssertEqual(status.code, 0)
+        XCTAssertEqual(cap.stdout, "5\n")
+    }
+
+    func testNodeDashPPrintsExpression() async throws {
+        let (shell, cap) = makeShell()
+        // `-p` evaluates and prints the resulting expression value.
+        let status = try await shell.run("node -p '40 + 2'")
+        XCTAssertEqual(status.code, 0)
+        XCTAssertEqual(cap.stdout, "42\n")
+    }
+
+    func testBunDashE() async throws {
+        let (shell, cap) = makeShell()
+        let status = try await shell.run("bun -e 'console.log(\"hi\")'")
+        XCTAssertEqual(status.code, 0)
+        XCTAssertEqual(cap.stdout, "hi\n")
+    }
+
+    func testNodeDashEWithoutExpressionReportsError() async throws {
+        let (shell, cap) = makeShell()
+        let status = try await shell.run("node -e")
+        XCTAssertEqual(status.code, 2)
+        XCTAssertTrue(cap.stderr.contains("requires an expression"))
+    }
+
+    func testNodeWithScriptPath() async throws {
+        // The Command path also handles `node script.js` for files
+        // without a shebang — covers the case where `node` is invoked
+        // explicitly rather than via `./script.js`.
+        let dir = NSTemporaryDirectory()
+            + "swift-js-cmd-\(UUID().uuidString)"
+        try FileManager.default.createDirectory(
+            atPath: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(atPath: dir) }
+        let path = dir + "/hello.js"
+        try "console.log('hello from file')\n"
+            .write(toFile: path, atomically: true, encoding: .utf8)
+
+        let (shell, cap) = makeShell()
+        let quoted = "'" + path.replacingOccurrences(of: "'", with: "'\\''") + "'"
+        let status = try await shell.run("node \(quoted)")
+        XCTAssertEqual(status.code, 0)
+        XCTAssertEqual(cap.stdout, "hello from file\n")
+    }
+}
+#endif

--- a/Tests/SwiftJSCoreTests/SwiftJSCommandSurfaceTests.swift
+++ b/Tests/SwiftJSCoreTests/SwiftJSCommandSurfaceTests.swift
@@ -104,6 +104,26 @@ final class SwiftJSCommandSurfaceTests: XCTestCase {
         XCTAssertTrue(cap.stderr.contains("requires an expression"))
     }
 
+    func testNodeResolvesRelativePathAgainstShellCwd() async throws {
+        // Regression for codex P1 review: `node foo.js` after an
+        // in-shell `cd` must resolve against the shell's working
+        // directory, not the host process cwd.
+        let dir = NSTemporaryDirectory()
+            + "swift-js-relcwd-\(UUID().uuidString)"
+        try FileManager.default.createDirectory(
+            atPath: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(atPath: dir) }
+        let path = dir + "/rel.js"
+        try "console.log('from cwd')\n"
+            .write(toFile: path, atomically: true, encoding: .utf8)
+
+        let (shell, cap) = makeShell()
+        let quoted = "'" + dir.replacingOccurrences(of: "'", with: "'\\''") + "'"
+        let status = try await shell.run("cd \(quoted) && node rel.js")
+        XCTAssertEqual(status.code, 0)
+        XCTAssertEqual(cap.stdout, "from cwd\n")
+    }
+
     func testNodeWithScriptPath() async throws {
         // The Command path also handles `node script.js` for files
         // without a shebang — covers the case where `node` is invoked


### PR DESCRIPTION
## Summary

- Embedded `node --version`, `node -e ...`, `bun -e ...`, `swift --version`, and `swift -e ...` now work in-process. Previously these names were only registered as `ScriptInterpreter`s (for `#!/usr/bin/env node` shebangs), so a bare top-level invocation never saw argv and there was no path for `-e <expr>` / `--version` to reach the runtime.
- `registerSwiftJS()` and `registerSwiftScript()` now also register each name as a `Command` that mirrors the argv surface of the standalone CLIs: `--version`/`-v`, `-e`/`-p`/`--print <expr>`, and bare `<script> [args...]`. Script reads route through `shell.fileSystem` so virtualised mounts keep working.
- Shebang-interpreter registrations are unchanged — path-invoked scripts (`./hello.js`) still route the same way.

Fixes #37.

## Test plan

- [x] `swift build`
- [x] New tests in `Tests/SwiftJSCoreTests/SwiftJSCommandSurfaceTests.swift` (8 tests covering `--version`, `-e`, `-p`, missing-expr error, script-path) all pass.
- [x] New tests in `Tests/BashSwiftScriptTests/BashSwiftScriptTests.swift` (`swift --version`, `swift-script --version`, `swift -e`, missing-expr usage, `swift script.swift`) all pass.
- [x] Existing shebang tests still pass — both registrations coexist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)