### PR TITLE
Add compgen builtin + public completion sources

### DIFF
--- a/Sources/BashInterpreter/API/Shell+Completion.swift
+++ b/Sources/BashInterpreter/API/Shell+Completion.swift
@@ -1,0 +1,133 @@
+import Foundation
+import ShellKit
+
+extension Shell {
+
+    /// Public completion-source surface — the same data the `compgen`
+    /// builtin needs, exposed so embedders (an IDE, a REPL, an iOS
+    /// terminal app) can drive Tab completion against this shell
+    /// without reaching into private state.
+    ///
+    /// The struct holds an unowned reference to its shell; only call
+    /// it while that shell is alive. Each call snapshots the data it
+    /// returns — mutations on the shell after the call don't affect
+    /// the returned array.
+    public var completionSources: CompletionSources {
+        CompletionSources(shell: self)
+    }
+}
+
+/// Snapshot view of the runtime state Tab completion cares about.
+///
+/// Built on demand from a ``Shell`` reference. Three kinds of methods:
+///
+/// - Catalog enumeration: ``listCommands(kind:)``, ``listFunctions()``,
+///   ``listAliases()``.
+/// - Variable enumeration: ``listVariables(scope:)``.
+/// - Filesystem enumeration: ``listDirectory(_:)``.
+///
+/// The shape mirrors what `compgen` needs but is intentionally
+/// usable on its own — embedders that want Tab completion in their
+/// own UI call these directly rather than spawning `compgen` and
+/// parsing its stdout.
+public struct CompletionSources {
+
+    /// Sub-kind filter for ``listCommands(kind:)``.
+    public enum CommandKind: Sendable {
+        /// Every command in the registry — builtins, registered
+        /// SwiftPorts CLIs, user-defined functions. Today this is the
+        /// same answer a sandboxed bash gives, since there is no PATH
+        /// to walk.
+        case all
+        /// Only commands that aren't user-defined shell functions.
+        /// Once builtin vs. external tagging exists, this will narrow
+        /// further to true builtins.
+        case builtin
+        /// Only user-defined shell functions.
+        case function
+    }
+
+    /// Sub-kind filter for ``listVariables(scope:)``.
+    public enum VariableScope: Sendable {
+        /// Scalar variables only (`name=value`).
+        case scalar
+        /// Indexed arrays only (`name=(a b c)`).
+        case array
+        /// Associative arrays only (`declare -A name`).
+        case associative
+        /// Every name across all three buckets, deduplicated.
+        case all
+    }
+
+    private unowned let shell: Shell
+
+    init(shell: Shell) {
+        self.shell = shell
+    }
+
+    /// Names of commands currently registered on the shell. Sorted
+    /// alphabetically.
+    public func listCommands(kind: CommandKind = .all) -> [String] {
+        let entries = shell.commands
+        switch kind {
+        case .all:
+            return entries.keys.sorted()
+        case .builtin:
+            return entries
+                .filter { !($0.value is FunctionCommand) }
+                .keys
+                .sorted()
+        case .function:
+            return entries
+                .filter { $0.value is FunctionCommand }
+                .keys
+                .sorted()
+        }
+    }
+
+    /// Convenience for ``listCommands(kind:)`` with `.function`. Kept
+    /// as a dedicated entry point because real bash's `compgen -A
+    /// function` is the most common consumer.
+    public func listFunctions() -> [String] {
+        listCommands(kind: .function)
+    }
+
+    /// Names of registered aliases. Empty until SwiftBash grows an
+    /// alias system — returning an empty list lets `compgen -a` and
+    /// `compgen -A alias` work without erroring.
+    public func listAliases() -> [String] {
+        []
+    }
+
+    /// Names of variables on this shell. Sorted alphabetically.
+    public func listVariables(scope: VariableScope = .all) -> [String] {
+        let env = shell.environment
+        switch scope {
+        case .scalar:
+            return env.variables.keys.sorted()
+        case .array:
+            return env.arrays.keys.sorted()
+        case .associative:
+            return env.associativeArrays.keys.sorted()
+        case .all:
+            var names = Set(env.variables.keys)
+            names.formUnion(env.arrays.keys)
+            names.formUnion(env.associativeArrays.keys)
+            return names.sorted()
+        }
+    }
+
+    /// Directory entries under `path` (resolved against the shell's
+    /// working directory via ``Shell/resolvePath(_:)``). Returns an
+    /// empty array if the path doesn't exist, isn't a directory, or
+    /// the filesystem otherwise refuses to list it — completion is a
+    /// best-effort surface and shouldn't throw at the caller.
+    public func listDirectory(_ path: String) async -> [FileEntry] {
+        let resolved = shell.resolvePath(path.isEmpty ? "." : path)
+        do {
+            return try await shell.fileSystem.list(resolved)
+        } catch {
+            return []
+        }
+    }
+}

--- a/Sources/BashInterpreter/API/Shell.swift
+++ b/Sources/BashInterpreter/API/Shell.swift
@@ -430,6 +430,7 @@ public final class Shell: ShellKit.Shell, @unchecked Sendable {
             PrintfCommand(),
             TrapCommand(),
             GetoptsCommand(),
+            CompgenCommand(),
             BashCommand(name: "bash"),
             BashCommand(name: "sh"),
             BashCommand(name: "dash")

--- a/Sources/BashInterpreter/Builtins/CompgenCommand.swift
+++ b/Sources/BashInterpreter/Builtins/CompgenCommand.swift
@@ -65,7 +65,15 @@ public struct CompgenCommand: Command {
             candidates = candidates.map { $0 + suffix }
         }
 
-        guard !candidates.isEmpty else { return ExitStatus(1) }
+        if candidates.isEmpty {
+            // Real bash returns 1 only when an action / wordlist was
+            // specified and produced no matches. A bare `compgen` (no
+            // generating options) is a no-op that succeeds — scripts
+            // sometimes use it as a probe, so don't fail them.
+            let hadGenerator = !options.actions.isEmpty
+                || options.wordList != nil
+            return hadGenerator ? ExitStatus(1) : .success
+        }
         for candidate in candidates {
             shell.stdout("\(candidate)\n")
         }
@@ -159,7 +167,15 @@ extension CompgenCommand {
             case "-o", "-F", "-C", "-G":
                 // Accepted-and-ignored: -o is compopt fluff, -F/-C/-G
                 // need the `complete` registry that hasn't landed yet.
+                // Still bash-strict about argument presence — these
+                // flags require a value, and dotfile completion code
+                // distinguishes usage-error status 2 from "no matches".
                 index += 1
+                guard index < argv.count else {
+                    Shell.bashCurrent.stderr(
+                        "compgen: \(arg): option requires an argument\n")
+                    return .failure(ExitStatus(2))
+                }
             default:
                 Shell.bashCurrent.stderr("compgen: \(arg): invalid option\n")
                 return .failure(ExitStatus(2))
@@ -275,9 +291,64 @@ extension CompgenCommand {
 
 extension CompgenCommand {
 
-    fileprivate func splitWordList(_ raw: String) -> [String] {
-        raw.split(whereSeparator: { $0 == " " || $0 == "\t" || $0 == "\n" })
-            .map(String.init)
+    /// Tokenize a `-W` word list the way bash does: whitespace-
+    /// separated, with single quotes preserving literal contents,
+    /// double quotes preserving contents (minus escape processing),
+    /// and `\` escaping the next character outside quotes. Outer
+    /// quotes have already been stripped by the shell parser before
+    /// argv hits us, so what we receive here is the inner list — the
+    /// quoting we still see is intentional.
+    fileprivate func splitWordList(_ raw: String) -> [String] { // swiftlint:disable:this cyclomatic_complexity
+        var tokens: [String] = []
+        var current = ""
+        var inSingle = false
+        var inDouble = false
+        var hasToken = false
+
+        var iter = raw.makeIterator()
+        while let char = iter.next() {
+            if inSingle {
+                if char == "'" { inSingle = false } else { current.append(char) }
+                continue
+            }
+            if inDouble {
+                if char == "\"" {
+                    inDouble = false
+                } else if char == "\\" {
+                    if let next = iter.next() {
+                        // In bash, only $`"\\ and newline are special
+                        // after backslash inside double quotes; keep
+                        // it simple — pass the next char through.
+                        current.append(next)
+                    }
+                } else {
+                    current.append(char)
+                }
+                continue
+            }
+            switch char {
+            case " ", "\t", "\n":
+                if hasToken {
+                    tokens.append(current)
+                    current = ""
+                    hasToken = false
+                }
+            case "'":
+                inSingle = true
+                hasToken = true
+            case "\"":
+                inDouble = true
+                hasToken = true
+            case "\\":
+                if let next = iter.next() { current.append(next) }
+                hasToken = true
+            default:
+                current.append(char)
+                hasToken = true
+            }
+        }
+        if hasToken { tokens.append(current) }
+        return tokens
     }
 
     /// Minimal fnmatch for `-X` patterns — supports `*` and `?`,

--- a/Sources/BashInterpreter/Builtins/CompgenCommand.swift
+++ b/Sources/BashInterpreter/Builtins/CompgenCommand.swift
@@ -1,0 +1,318 @@
+import Foundation
+
+/// `compgen [option]... [word]` — generate possible completion
+/// matches for `word`.
+///
+/// The builtin is a thin argument-parser on top of
+/// ``CompletionSources``: action flags choose which catalog to
+/// enumerate (`-c` commands, `-d` directories, `-f` files, `-v`
+/// variables, …), modifier flags filter and transform the result
+/// (`-W` word list, `-X` exclude pattern, `-P` prefix, `-S` suffix).
+///
+/// Exit status: `0` when at least one candidate was printed, `1`
+/// when no candidates matched, `2` on a usage error. This matches
+/// real bash, including the "no matches = non-zero" convention that
+/// dotfile completion scripts rely on (`compgen … || return`).
+///
+/// Not implemented (silently treated as no-op / empty):
+/// - `-F function` / `-C command` — invoking a completion function
+///   to populate `COMPREPLY`. Will land alongside `complete -F`.
+/// - `-G globpat` — pathname-glob action.
+/// - `-o option` — compopt-style options. Accepted and ignored so
+///   `compgen -o nospace …` from a dotfile doesn't error.
+public struct CompgenCommand: Command {
+    public let name = "compgen"
+    public init() {}
+
+    // Reserved words for `-k` / `-A keyword`. Bash lists shell
+    // grammar tokens; we expose the ones SwiftBash actually parses.
+    private static let reservedWords: [String] = [
+        "!", "[[", "]]", "{", "}",
+        "case", "do", "done", "elif", "else", "esac", "fi",
+        "for", "function", "if", "in", "select", "then",
+        "time", "until", "while"
+    ]
+
+    public func run(_ argv: [String]) async throws -> ExitStatus {
+        var options = ParsedOptions()
+        switch parse(argv, into: &options) {
+        case .success: break
+        case .failure(let status): return status
+        }
+
+        let shell = Shell.bashCurrent
+        var candidates = await gather(options: options, shell: shell)
+
+        if let raw = options.wordList {
+            candidates.append(contentsOf: splitWordList(raw))
+        }
+
+        let word = options.word ?? ""
+        if !word.isEmpty {
+            // Path-completion actions already filtered by basename;
+            // for non-path candidates apply the prefix filter here.
+            candidates = candidates.filter { $0.hasPrefix(word) }
+        }
+
+        if let pattern = options.excludePattern, !pattern.isEmpty {
+            candidates = candidates.filter { !fnmatch(pattern, $0) }
+        }
+
+        if let prefix = options.prefix, !prefix.isEmpty {
+            candidates = candidates.map { prefix + $0 }
+        }
+        if let suffix = options.suffix, !suffix.isEmpty {
+            candidates = candidates.map { $0 + suffix }
+        }
+
+        guard !candidates.isEmpty else { return ExitStatus(1) }
+        for candidate in candidates {
+            shell.stdout("\(candidate)\n")
+        }
+        return .success
+    }
+}
+
+// MARK: - Argument parsing
+
+extension CompgenCommand {
+
+    struct ParsedOptions {
+        var actions: Set<Action> = []
+        var wordList: String?
+        var excludePattern: String?
+        var prefix: String?
+        var suffix: String?
+        var word: String?
+    }
+
+    enum Action: Hashable {
+        case alias, builtin, command, directory, exported, file,
+             group, job, keyword, service, user, variable, function
+    }
+
+    enum ParseResult {
+        case success
+        case failure(ExitStatus)
+    }
+
+    // swiftlint:disable:next cyclomatic_complexity function_body_length
+    func parse(_ argv: [String], into options: inout ParsedOptions) -> ParseResult {
+        var index = 1
+        while index < argv.count {
+            let arg = argv[index]
+            if arg == "--" {
+                index += 1
+                break
+            }
+            guard arg.hasPrefix("-"), arg.count > 1 else { break }
+
+            switch arg {
+            case "-a": options.actions.insert(.alias)
+            case "-b": options.actions.insert(.builtin)
+            case "-c": options.actions.insert(.command)
+            case "-d": options.actions.insert(.directory)
+            case "-e": options.actions.insert(.exported)
+            case "-f": options.actions.insert(.file)
+            case "-g": options.actions.insert(.group)
+            case "-j": options.actions.insert(.job)
+            case "-k": options.actions.insert(.keyword)
+            case "-s": options.actions.insert(.service)
+            case "-u": options.actions.insert(.user)
+            case "-v": options.actions.insert(.variable)
+            case "-A":
+                index += 1
+                guard index < argv.count,
+                      let action = Self.action(forName: argv[index]) else {
+                    Shell.bashCurrent.stderr("compgen: -A: invalid action name\n")
+                    return .failure(ExitStatus(2))
+                }
+                options.actions.insert(action)
+            case "-W":
+                index += 1
+                guard index < argv.count else {
+                    Shell.bashCurrent.stderr("compgen: -W: option requires an argument\n")
+                    return .failure(ExitStatus(2))
+                }
+                options.wordList = argv[index]
+            case "-X":
+                index += 1
+                guard index < argv.count else {
+                    Shell.bashCurrent.stderr("compgen: -X: option requires an argument\n")
+                    return .failure(ExitStatus(2))
+                }
+                options.excludePattern = argv[index]
+            case "-P":
+                index += 1
+                guard index < argv.count else {
+                    Shell.bashCurrent.stderr("compgen: -P: option requires an argument\n")
+                    return .failure(ExitStatus(2))
+                }
+                options.prefix = argv[index]
+            case "-S":
+                index += 1
+                guard index < argv.count else {
+                    Shell.bashCurrent.stderr("compgen: -S: option requires an argument\n")
+                    return .failure(ExitStatus(2))
+                }
+                options.suffix = argv[index]
+            case "-o", "-F", "-C", "-G":
+                // Accepted-and-ignored: -o is compopt fluff, -F/-C/-G
+                // need the `complete` registry that hasn't landed yet.
+                index += 1
+            default:
+                Shell.bashCurrent.stderr("compgen: \(arg): invalid option\n")
+                return .failure(ExitStatus(2))
+            }
+            index += 1
+        }
+        if index < argv.count {
+            options.word = argv[index]
+        }
+        return .success
+    }
+
+    // swiftlint:disable:next cyclomatic_complexity
+    private static func action(forName name: String) -> Action? {
+        switch name {
+        case "alias":     return .alias
+        case "builtin":   return .builtin
+        case "command":   return .command
+        case "directory": return .directory
+        case "export", "exported": return .exported
+        case "file":      return .file
+        case "function":  return .function
+        case "group":     return .group
+        case "job":       return .job
+        case "keyword":   return .keyword
+        case "service":   return .service
+        case "user":      return .user
+        case "variable":  return .variable
+        default: return nil
+        }
+    }
+}
+
+// MARK: - Candidate gathering
+
+extension CompgenCommand {
+
+    // swiftlint:disable:next cyclomatic_complexity
+    fileprivate func gather(options: ParsedOptions, shell: Shell) async -> [String] {
+        let sources = shell.completionSources
+        var out: [String] = []
+        let word = options.word ?? ""
+
+        // Stable iteration order so output is deterministic when
+        // multiple actions are combined.
+        let ordered = options.actions.sorted {
+            String(describing: $0) < String(describing: $1)
+        }
+        for action in ordered {
+            switch action {
+            case .alias:
+                out.append(contentsOf: sources.listAliases())
+            case .builtin:
+                out.append(contentsOf: sources.listCommands(kind: .builtin))
+            case .command:
+                out.append(contentsOf: sources.listCommands(kind: .all))
+            case .function:
+                out.append(contentsOf: sources.listCommands(kind: .function))
+            case .keyword:
+                out.append(contentsOf: Self.reservedWords)
+            case .variable:
+                out.append(contentsOf: sources.listVariables(scope: .all))
+            case .exported:
+                out.append(contentsOf: sources.listVariables(scope: .scalar))
+            case .user:
+                out.append(shell.hostInfo.userName)
+            case .directory:
+                out.append(contentsOf: await pathMatches(
+                    prefix: word, shell: shell, directoriesOnly: true))
+            case .file:
+                out.append(contentsOf: await pathMatches(
+                    prefix: word, shell: shell, directoriesOnly: false))
+            case .group, .job, .service:
+                break
+            }
+        }
+        return out
+    }
+
+    /// Filesystem-backed completion for `-d` / `-f`.
+    ///
+    /// Splits `prefix` into (directory, basename) like real bash does:
+    /// `/usr/lo` → list `/usr/`, filter entries starting with `lo`,
+    /// then prepend `/usr/` so callers see `/usr/local` rather than
+    /// just `local`. A bare prefix without a slash lists the shell's
+    /// working directory.
+    private func pathMatches(prefix: String, shell: Shell,
+                             directoriesOnly: Bool) async -> [String] {
+        let dirPart: String
+        let basePart: String
+        if let slash = prefix.lastIndex(of: "/") {
+            let after = prefix.index(after: slash)
+            dirPart = String(prefix[...slash])
+            basePart = String(prefix[after...])
+        } else {
+            dirPart = ""
+            basePart = prefix
+        }
+
+        let listing = await shell.completionSources.listDirectory(
+            dirPart.isEmpty ? "." : dirPart)
+        var hits: [String] = []
+        for entry in listing {
+            if directoriesOnly && entry.metadata.kind != .directory { continue }
+            if !basePart.isEmpty && !entry.name.hasPrefix(basePart) { continue }
+            hits.append(dirPart + entry.name)
+        }
+        return hits.sorted()
+    }
+}
+
+// MARK: - Helpers
+
+extension CompgenCommand {
+
+    fileprivate func splitWordList(_ raw: String) -> [String] {
+        raw.split(whereSeparator: { $0 == " " || $0 == "\t" || $0 == "\n" })
+            .map(String.init)
+    }
+
+    /// Minimal fnmatch for `-X` patterns — supports `*` and `?`,
+    /// anchored to the whole word (bash anchors `-X` patterns to the
+    /// full candidate). A leading `!` inverts the match, matching
+    /// bash's `-X '!*.o'` "keep only `*.o`" idiom.
+    fileprivate func fnmatch(_ pattern: String, _ value: String) -> Bool {
+        if pattern.hasPrefix("!") {
+            return !globMatch(Array(pattern.dropFirst()), 0, Array(value), 0)
+        }
+        return globMatch(Array(pattern), 0, Array(value), 0)
+    }
+
+    private func globMatch(_ pat: [Character], _ patIdx: Int,
+                           _ val: [Character], _ valIdx: Int) -> Bool {
+        if patIdx == pat.count { return valIdx == val.count }
+        let pchar = pat[patIdx]
+        if pchar == "*" {
+            if patIdx + 1 == pat.count { return true }
+            for split in valIdx...val.count
+                where globMatch(pat, patIdx + 1, val, split) {
+                return true
+            }
+            return false
+        }
+        if valIdx == val.count { return false }
+        if pchar == "?" || pchar == val[valIdx] {
+            return globMatch(pat, patIdx + 1, val, valIdx + 1)
+        }
+        return false
+    }
+}
+
+// `-W "list"` filter coexists with the `word` trailing prefix in
+// real bash: the wordlist is split, then the prefix filter applies
+// to all candidates (including those from -W). The `run` method
+// above implements that order — gather first, append -W, prefix
+// filter, exclude, then prefix/suffix wrap.

--- a/Tests/BashInterpreterTests/CompgenCommandTests.swift
+++ b/Tests/BashInterpreterTests/CompgenCommandTests.swift
@@ -112,6 +112,30 @@ import Testing
         #expect(cap.shell.lastExitStatus.isSuccess)
     }
 
+    @Test func ignoredModifierMissingArgIsUsageError() async throws {
+        let cap = makeShell()
+        try await cap.shell.run("compgen -F")
+        // -F still requires a value; bare `compgen -F` is status 2.
+        #expect(cap.shell.lastExitStatus.code == 2)
+        #expect(cap.stderr.contains("option requires an argument"))
+    }
+
+    @Test func bareCompgenSucceeds() async throws {
+        let cap = makeShell()
+        try await cap.shell.run("compgen")
+        // No generator → no-op success, not a "no matches" failure.
+        #expect(cap.stdout == "")
+        #expect(cap.shell.lastExitStatus.isSuccess)
+    }
+
+    @Test func wordListHonorsQuoting() async throws {
+        let cap = makeShell()
+        try await cap.shell.run(#"compgen -W "alpha 'foo bar' beta""#)
+        // The middle token has an internal space — should survive as
+        // one candidate, not split into two.
+        #expect(cap.stdout == "alpha\nfoo bar\nbeta\n")
+    }
+
     // MARK: completion sources
 
     @Test func completionSourcesListCommandsAll() async throws {

--- a/Tests/BashInterpreterTests/CompgenCommandTests.swift
+++ b/Tests/BashInterpreterTests/CompgenCommandTests.swift
@@ -1,0 +1,144 @@
+import Testing
+@testable import BashInterpreter
+
+@Suite(.timeLimit(.minutes(1))) struct CompgenCommandTests {
+
+    private func makeShell() -> CapturingShell { CapturingShell() }
+
+    // MARK: word-list action
+
+    @Test func wordListPrefixFilter() async throws {
+        let cap = makeShell()
+        try await cap.shell.run(#"compgen -W "alpha beta apple" a"#)
+        #expect(cap.stdout == "alpha\napple\n")
+        #expect(cap.shell.lastExitStatus.isSuccess)
+    }
+
+    @Test func wordListNoMatchExitsOne() async throws {
+        let cap = makeShell()
+        try await cap.shell.run(#"compgen -W "alpha beta" zz"#)
+        #expect(cap.stdout == "")
+        #expect(!cap.shell.lastExitStatus.isSuccess)
+    }
+
+    @Test func wordListWithPrefixAndSuffix() async throws {
+        let cap = makeShell()
+        try await cap.shell.run(#"compgen -P "[" -S "]" -W "x y" """#)
+        #expect(cap.stdout == "[x]\n[y]\n")
+    }
+
+    @Test func wordListExcludePattern() async throws {
+        let cap = makeShell()
+        try await cap.shell.run(#"compgen -W "foo.o bar.c baz.o" -X "*.o""#)
+        #expect(cap.stdout == "bar.c\n")
+    }
+
+    // MARK: command actions
+
+    @Test func commandsIncludesEcho() async throws {
+        let cap = makeShell()
+        try await cap.shell.run("compgen -c ec")
+        #expect(cap.stdout.contains("echo\n"))
+    }
+
+    @Test func builtinsExcludeUserFunctions() async throws {
+        let cap = makeShell()
+        try await cap.shell.run("""
+            myfunc() { :; }
+            compgen -A function
+            """)
+        #expect(cap.stdout == "myfunc\n")
+    }
+
+    @Test func builtinsExcludeFunctionsInBuiltinAction() async throws {
+        let cap = makeShell()
+        try await cap.shell.run("""
+            myfunc() { :; }
+            compgen -b my
+            """)
+        // `myfunc` is a function, so `-b` (builtin) must skip it.
+        #expect(cap.stdout == "")
+    }
+
+    // MARK: variable actions
+
+    @Test func variablesIncludeScalar() async throws {
+        let cap = makeShell()
+        try await cap.shell.run("""
+            FOO=1
+            FOOBAR=2
+            BAR=3
+            compgen -v FOO
+            """)
+        let lines = Set(cap.stdout.split(separator: "\n").map(String.init))
+        #expect(lines.contains("FOO"))
+        #expect(lines.contains("FOOBAR"))
+        #expect(!lines.contains("BAR"))
+    }
+
+    @Test func variablesIncludeArrays() async throws {
+        let cap = makeShell()
+        try await cap.shell.run("""
+            declare -A myassoc
+            myarr=(a b c)
+            compgen -v my
+            """)
+        let lines = Set(cap.stdout.split(separator: "\n").map(String.init))
+        #expect(lines.contains("myarr"))
+        #expect(lines.contains("myassoc"))
+    }
+
+    // MARK: long-form action
+
+    @Test func actionLongFormCommand() async throws {
+        let cap = makeShell()
+        try await cap.shell.run("compgen -A command ec")
+        #expect(cap.stdout.contains("echo\n"))
+    }
+
+    @Test func actionInvalidName() async throws {
+        let cap = makeShell()
+        try await cap.shell.run("compgen -A bogus")
+        #expect(!cap.shell.lastExitStatus.isSuccess)
+        #expect(cap.stderr.contains("invalid action"))
+    }
+
+    // MARK: ignored modifiers
+
+    @Test func ignoredModifiersDoNotError() async throws {
+        let cap = makeShell()
+        try await cap.shell.run(#"compgen -o nospace -F _foo -W "x y" x"#)
+        #expect(cap.stdout == "x\n")
+        #expect(cap.shell.lastExitStatus.isSuccess)
+    }
+
+    // MARK: completion sources
+
+    @Test func completionSourcesListCommandsAll() async throws {
+        let cap = makeShell()
+        let names = cap.shell.completionSources.listCommands(kind: .all)
+        #expect(names.contains("echo"))
+        #expect(names.contains("compgen"))
+    }
+
+    @Test func completionSourcesListFunctionsAfterDefinition() async throws {
+        let cap = makeShell()
+        try await cap.shell.run("greet() { :; }")
+        #expect(cap.shell.completionSources.listFunctions() == ["greet"])
+    }
+
+    @Test func completionSourcesListVariablesScopes() async throws {
+        let cap = makeShell()
+        try await cap.shell.run("""
+            FOO=1
+            arr=(a b)
+            declare -A assoc
+            """)
+        let scalar = cap.shell.completionSources.listVariables(scope: .scalar)
+        let array = cap.shell.completionSources.listVariables(scope: .array)
+        let assoc = cap.shell.completionSources.listVariables(scope: .associative)
+        #expect(scalar.contains("FOO"))
+        #expect(array.contains("arr"))
+        #expect(assoc.contains("assoc"))
+    }
+}


### PR DESCRIPTION
## Summary

Closes the "no `compgen`" bullet of #35 and lays the public completion layer that issue called for.

- New `Shell.completionSources` accessor returns a `CompletionSources` struct with `listCommands(kind:)`, `listFunctions()`, `listAliases()`, `listVariables(scope:)`, and `listDirectory(_:)`. Embedders that want Tab completion now call this instead of reaching into the command registry / filesystem directly.
- New `CompgenCommand` builtin (registered in `Shell.defaultCommands()`) layered on top of that API. Supports action flags `-a -b -c -d -e -f -k -u -v`, the long-form `-A action`, and modifiers `-W -X -P -S`. `-o -F -C -G` are accepted-and-ignored so dotfile invocations don't error before the `complete` registry lands. Exit status follows bash (0 on matches, 1 on none, 2 on usage error).

## Out of scope (follow-ups from #35)

- `-F function` / `-C command` modifiers that invoke a completion function to populate `COMPREPLY` — needs the `complete` registry.
- `-G globpat` action.
- `complete -F func cmd` / `complete -W list cmd` per-command registry.

## Test plan
- [x] `swift build` clean
- [x] `swift test --filter CompgenCommandTests` — 15 new tests pass (word-list filter, prefix/suffix wrap, `-X` exclude, command/function/variable enumeration, long-form `-A`, ignored modifiers, direct `completionSources` API)
- [x] `swiftlint --strict` clean on touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)