### PR TITLE
BashCommandKit: uniform --version across builtins (#36)

### DIFF
--- a/Sources/BashCommandKit/API/ParsableCommandBridge.swift
+++ b/Sources/BashCommandKit/API/ParsableCommandBridge.swift
@@ -18,10 +18,15 @@ struct ParsableCommandBridge<Parsed: ParsableBashCommand>: Command {
         // "unknown option" instead of printing a banner. Catch the
         // flag in the bridge and emit a generic in-process marker
         // when the command itself didn't override.
-        if args.contains("--version") {
+        // Only short-circuit when `--version` is the leading argument.
+        // A laxer `args.contains("--version")` swallows the flag when
+        // it's meant for a different tool — `command find --version`
+        // would otherwise print `command`'s banner instead of routing
+        // the flag to `find`.
+        if args.first == "--version" {
             let configured = Parsed.configuration.version
             let banner = configured.isEmpty
-                ? "\(name) (swift-bash built-in)"
+                ? "\(name) (SwiftBash) \(SwiftBashVersion.packageVersion)"
                 : configured
             Shell.bashCurrent.stdout(banner + "\n")
             return .success

--- a/Sources/BashCommandKit/Commands/FindCommand.swift
+++ b/Sources/BashCommandKit/Commands/FindCommand.swift
@@ -57,6 +57,10 @@ public struct FindCommand: Command {
     public init() {}
 
     public func run(_ argv: [String]) async throws -> ExitStatus {
+        if argv.dropFirst().contains("--version") {
+            Shell.bashCurrent.stdout("find (SwiftBash) \(SwiftBashVersion.packageVersion)\n")
+            return .success
+        }
         let parsed: Parsed
         do {
             parsed = try Self.parse(argv: Array(argv.dropFirst()))

--- a/Sources/BashCommandKit/Commands/FindCommand.swift
+++ b/Sources/BashCommandKit/Commands/FindCommand.swift
@@ -57,7 +57,12 @@ public struct FindCommand: Command {
     public init() {}
 
     public func run(_ argv: [String]) async throws -> ExitStatus {
-        if argv.dropFirst().contains("--version") {
+        // Only intercept when `--version` is `find`'s own leading
+        // argument. A laxer `contains` would swallow tokens that
+        // legitimately appear inside an expression (e.g.
+        // `find . -name --version` uses `--version` as `-name`'s
+        // operand).
+        if argv.dropFirst().first == "--version" {
             Shell.bashCurrent.stdout("find (SwiftBash) \(SwiftBashVersion.packageVersion)\n")
             return .success
         }

--- a/Sources/BashCommandKit/Commands/TimeCommands.swift
+++ b/Sources/BashCommandKit/Commands/TimeCommands.swift
@@ -60,6 +60,7 @@ public struct TimeoutCommand: Command {
     public let name = "timeout"
     public init() {}
 
+    // swiftlint:disable:next cyclomatic_complexity - argv prefix loop + version short-circuit
     public func run(_ argv: [String]) async throws -> ExitStatus {
         var args = Array(argv.dropFirst())
         // `timeout --version` only — once we're past the wrapper's

--- a/Sources/BashCommandKit/Commands/TimeCommands.swift
+++ b/Sources/BashCommandKit/Commands/TimeCommands.swift
@@ -12,7 +12,10 @@ public struct TimeCommand: Command {
 
     public func run(_ argv: [String]) async throws -> ExitStatus {
         let args = Array(argv.dropFirst())
-        if args.contains("--version") {
+        // Match only `time --version`. `time cmd --version` must
+        // forward `--version` to the wrapped command instead of
+        // printing the timing wrapper's banner.
+        if args.first == "--version" {
             Shell.bashCurrent.stdout("time (SwiftBash) \(SwiftBashVersion.packageVersion)\n")
             return .success
         }
@@ -59,7 +62,11 @@ public struct TimeoutCommand: Command {
 
     public func run(_ argv: [String]) async throws -> ExitStatus {
         var args = Array(argv.dropFirst())
-        if args.contains("--version") {
+        // `timeout --version` only — once we're past the wrapper's
+        // own flags + DURATION, every remaining token belongs to
+        // the managed command (e.g. `timeout 5 cmd --version` must
+        // pass `--version` through to `cmd`).
+        if args.first == "--version" {
             Shell.bashCurrent.stdout("timeout (SwiftBash) \(SwiftBashVersion.packageVersion)\n")
             return .success
         }

--- a/Sources/BashCommandKit/Commands/TimeCommands.swift
+++ b/Sources/BashCommandKit/Commands/TimeCommands.swift
@@ -12,6 +12,10 @@ public struct TimeCommand: Command {
 
     public func run(_ argv: [String]) async throws -> ExitStatus {
         let args = Array(argv.dropFirst())
+        if args.contains("--version") {
+            Shell.bashCurrent.stdout("time (SwiftBash) \(SwiftBashVersion.packageVersion)\n")
+            return .success
+        }
         guard !args.isEmpty else {
             Shell.bashCurrent.stderr("time: usage: time COMMAND [ARG...]\n")
             return ExitStatus(2)
@@ -55,6 +59,10 @@ public struct TimeoutCommand: Command {
 
     public func run(_ argv: [String]) async throws -> ExitStatus {
         var args = Array(argv.dropFirst())
+        if args.contains("--version") {
+            Shell.bashCurrent.stdout("timeout (SwiftBash) \(SwiftBashVersion.packageVersion)\n")
+            return .success
+        }
         // Skip the GNU --foreground / --preserve-status / -k flags
         // we don't honour.
         while let first = args.first {

--- a/Sources/BashInterpreter/API/SwiftBashVersion.swift
+++ b/Sources/BashInterpreter/API/SwiftBashVersion.swift
@@ -10,6 +10,13 @@ import Foundation
 /// than expanding to empty.
 public enum SwiftBashVersion {
 
+    /// SwiftBash package version. Surfaced through every builtin's
+    /// `--version` banner via ``ParsableCommandBridge`` and the
+    /// fallbacks inside the few non-`ParsableBashCommand` builtins
+    /// (find / time / timeout). Bump on release; the bash-semantics
+    /// version below is independent.
+    public static let packageVersion = "0.1.0"
+
     /// `BASH_VERSION` value — major.minor.patch[(build)]-release form,
     /// matching what `/bin/bash` reports. The major/minor advertise
     /// the bash semantics we target (4.x), not the SwiftBash package

--- a/Tests/BashCommandKitTests/VersionFlagTests.swift
+++ b/Tests/BashCommandKitTests/VersionFlagTests.swift
@@ -35,6 +35,30 @@ import Testing
         #expect(cap.stderr.isEmpty)
     }
 
+    /// `--version` in a child-command's argv must pass through —
+    /// `time` / `timeout` are wrappers, and consuming `--version` at
+    /// the wrapper level would skip the wrapped command entirely.
+    @Test func timeoutForwardsVersionToWrappedCommand() async throws {
+        let cap = makeShell()
+        try await cap.shell.run("timeout 5 cat --version")
+        // cat's banner, not timeout's.
+        #expect(cap.stdout.contains("cat (SwiftBash)"))
+        #expect(!cap.stdout.contains("timeout (SwiftBash)"))
+    }
+
+    /// `find` expressions can contain literal `--version` tokens
+    /// (e.g. `-name --version`). The version guard must not swallow
+    /// them.
+    @Test func findExpressionWithVersionTokenIsNotIntercepted() async throws {
+        let cap = makeShell()
+        // Pointed at an empty path so the walker has no matches —
+        // we only care that `find` runs the expression instead of
+        // printing the version banner.
+        try await cap.shell.run("find /nonexistent-path-zzz -name --version; echo done=$?")
+        #expect(!cap.stdout.contains("find (SwiftBash)"))
+        #expect(cap.stdout.contains("done="))
+    }
+
     /// Spot-check a handful of bridge-routed builtins from the parsers
     /// the issue explicitly called out — they should pick up the
     /// banner from `ParsableCommandBridge` without per-command work.

--- a/Tests/BashCommandKitTests/VersionFlagTests.swift
+++ b/Tests/BashCommandKitTests/VersionFlagTests.swift
@@ -1,0 +1,48 @@
+import Testing
+@testable import BashInterpreter
+@testable import BashCommandKit
+
+/// `<tool> --version` should exit 0 and print a one-line identifier on
+/// stdout for every builtin in the catalog. Covers the
+/// `ParsableCommandBridge` short-circuit and the per-command fallbacks
+/// in the few raw `Command` types (`find`, `time`, `timeout`). Tracks
+/// the convention asked for in issue #36.
+@Suite(.timeLimit(.minutes(1))) struct VersionFlagTests {
+
+    private func makeShell() -> CapturingShell {
+        let cap = CapturingShell()
+        cap.shell.registerStandardCommands()
+        return cap
+    }
+
+    /// The non-`ParsableBashCommand` builtins each grew an explicit
+    /// short-circuit; assert they all respond.
+    @Test(arguments: ["find", "time", "timeout"])
+    func rawCommandTypesPrintVersion(_ tool: String) async throws {
+        let cap = makeShell()
+        // Bypass the bash parser — `time` is a reserved keyword that
+        // the tokenizer routes to pipeline-timing semantics rather
+        // than dispatching as a builtin. Going through the command
+        // table directly exercises the same code path as a quoted
+        // `\time --version`.
+        let command = try #require(cap.shell.commands[tool])
+        let status = try await Shell.$bashCurrent.withValue(cap.shell) {
+            try await command.run([tool, "--version"])
+        }
+        #expect(status == .success)
+        #expect(cap.stdout.contains(tool))
+        #expect(cap.stdout.contains("SwiftBash"))
+        #expect(cap.stderr.isEmpty)
+    }
+
+    /// Spot-check a handful of bridge-routed builtins from the parsers
+    /// the issue explicitly called out — they should pick up the
+    /// banner from `ParsableCommandBridge` without per-command work.
+    @Test(arguments: ["cat", "grep", "sed", "curl", "xargs", "ls"])
+    func bridgeCommandsPrintVersion(_ tool: String) async throws {
+        let cap = makeShell()
+        try await cap.shell.run("\(tool) --version")
+        #expect(cap.stdout.contains("SwiftBash"))
+        #expect(cap.stderr.isEmpty)
+    }
+}


### PR DESCRIPTION
## Summary
- Every BashCommandKit builtin now responds to `--version` with a one-line `<tool> (SwiftBash) <version>` banner and exit 0.
- The three raw `Command` types that bypass `ParsableCommandBridge` (`find`, `time`, `timeout`) each gate `--version` themselves.
- Tightened the bridge's match from `args.contains("--version")` to `args.first == "--version"` so `command find --version` routes the flag to `find` instead of swallowing it at the `command` builtin.
- Added `SwiftBashVersion.packageVersion` (single source of truth) and a parameterised sweep test covering both raw and bridge paths.

Closes #36.

## Test plan
- [x] `swift test --filter VersionFlagTests` — 9 cases (3 raw + 6 bridge) pass
- [x] `swift test --filter AgentReportFixesTests` — 11 cases pass, including the existing `sedVersion` regression test

🤖 Generated with [Claude Code](https://claude.com/claude-code)