### PR TITLE
CLI bug roundup: xargs/find/cmp/paste + swift-bash exec sandbox gate

### DIFF
--- a/Sources/BashCommandKit/Commands/CmpCommand.swift
+++ b/Sources/BashCommandKit/Commands/CmpCommand.swift
@@ -4,6 +4,9 @@ import Foundation
 
 /// `cmp [-s] FILE1 FILE2` — byte-by-byte comparison. Exit 0 if equal,
 /// 1 if different, 2 on error. With `-s`, no output.
+///
+/// Either FILE argument may be `-`, which reads from standard input.
+/// Only one `-` is allowed per invocation; stdin can't be replayed.
 public struct CmpCommand: ParsableBashCommand {
     public static let configuration = CommandConfiguration(
         commandName: "cmp",
@@ -14,7 +17,7 @@ public struct CmpCommand: ParsableBashCommand {
           help: "Suppress output; exit status only.")
     public var silent: Bool = false
 
-    @Argument(help: "FILE1 FILE2")
+    @Argument(help: "FILE1 FILE2 (use - for stdin)")
     public var files: [String] = []
 
     public init() {}
@@ -24,10 +27,14 @@ public struct CmpCommand: ParsableBashCommand {
             Shell.bashCurrent.stderr("cmp: usage: cmp [-s] FILE1 FILE2\n")
             return ExitStatus(2)
         }
+        if files[0] == "-" && files[1] == "-" {
+            Shell.bashCurrent.stderr("cmp: standard input can only be used once\n")
+            return ExitStatus(2)
+        }
         let dataA: Data, dataB: Data
         do {
-            dataA = try await Shell.bashCurrent.readDataAtPath(files[0])
-            dataB = try await Shell.bashCurrent.readDataAtPath(files[1])
+            dataA = try await readOperand(files[0])
+            dataB = try await readOperand(files[1])
         } catch {
             Shell.bashCurrent.stderr("cmp: \(error)\n")
             return ExitStatus(2)
@@ -51,5 +58,12 @@ public struct CmpCommand: ParsableBashCommand {
             return ExitStatus(1)
         }
         return .success
+    }
+
+    private func readOperand(_ path: String) async throws -> Data {
+        if path == "-" {
+            return await Shell.bashCurrent.stdin.readAllData()
+        }
+        return try await Shell.bashCurrent.readDataAtPath(path)
     }
 }

--- a/Sources/BashCommandKit/Commands/FindCommand.swift
+++ b/Sources/BashCommandKit/Commands/FindCommand.swift
@@ -961,14 +961,20 @@ public struct FindCommand: Command {
         return PermResult(mode: mode, match: match)
     }
 
-    // MARK: -printf formatting
+    // MARK: - printf format interpreter
     //
-    // GNU find-compatible format string interpreter. Supports the
-    // mainstream directives users actually reach for; rarer ones
-    // (`%a` access-time variants, `%c` ctime, `%A@`, `%C@`, format
-    // flags like `%-20p`) are not yet implemented and pass through
-    // as the original two characters so a typo still gets debugged.
+    // GNU find-compatible format string interpreter for `-printf`.
+    // Supports the mainstream directives users actually reach for;
+    // rarer ones (`%a` access-time variants, `%c` ctime, `%A@`, `%C@`,
+    // format flags like `%-20p`) are not yet implemented and pass
+    // through as the original two characters so a typo still gets
+    // debugged.
 
+    // Single-pass tokenizer over the format string. The `\X` escape
+    // and `%X` / `%TX` directive switches each contribute several
+    // cyclomatic branches; splitting them out for the linter's sake
+    // would just rename the dispatch table.
+    // swiftlint:disable:next cyclomatic_complexity
     static func formatPrintf(_ format: String, node nodeAny: Any) -> String {
         // `nodeAny` is `NodeInfo` — accepted as `Any` so this helper
         // can stay static without exposing the private NodeInfo type.
@@ -1021,6 +1027,9 @@ public struct FindCommand: Command {
         return out
     }
 
+    // Dispatch table — one branch per directive. Same shape as the
+    // other find-side switches we already exempt.
+    // swiftlint:disable:next cyclomatic_complexity
     private static func printfField(_ directive: Character, node: NodeInfo) -> String? {
         switch directive {
         case "%": return "%"

--- a/Sources/BashCommandKit/Commands/FindCommand.swift
+++ b/Sources/BashCommandKit/Commands/FindCommand.swift
@@ -180,6 +180,7 @@ public struct FindCommand: Command {
         let node = NodeInfo(displayPath: displayPath,
                             absolutePath: absolutePath,
                             startingPath: startingPath,
+                            depth: depth,
                             meta: meta)
 
         // Pre-order: evaluate this node first, then descend.
@@ -466,6 +467,7 @@ public struct FindCommand: Command {
         let displayPath: String
         let absolutePath: String
         let startingPath: String
+        let depth: Int
         let meta: FileMetadata
     }
 
@@ -1046,7 +1048,7 @@ public struct FindCommand: Command {
         case "U": return String(node.meta.uid)
         case "G": return String(node.meta.gid)
         case "n": return String(node.meta.linkCount)
-        case "d": return "0"  // depth — not threaded into NodeInfo
+        case "d": return String(node.depth)
         default: return nil
         }
     }

--- a/Sources/BashCommandKit/Commands/FindCommand.swift
+++ b/Sources/BashCommandKit/Commands/FindCommand.swift
@@ -91,7 +91,7 @@ public struct FindCommand: Command {
           -size [+-]N[ckMG]        -perm [-/]MODE
 
         ACTIONS:
-          -print (default)         -print0
+          -print (default)         -print0          -printf FORMAT
           -prune                   -delete
           -exec CMD ... ;          -exec CMD ... {} +
 
@@ -142,6 +142,7 @@ public struct FindCommand: Command {
             do {
                 try await walk(displayPath: path,
                                absolutePath: resolved,
+                               startingPath: path,
                                depth: 0,
                                ctx: ctx)
             } catch {
@@ -162,6 +163,7 @@ public struct FindCommand: Command {
 
     private func walk(displayPath: String,
                       absolutePath: String,
+                      startingPath: String,
                       depth: Int,
                       ctx: EvalContext) async throws {
         // Per-entry cancellation check — `find /` against a huge tree
@@ -177,6 +179,7 @@ public struct FindCommand: Command {
             && (ctx.opts.maxDepth.map { depth <= $0 } ?? true)
         let node = NodeInfo(displayPath: displayPath,
                             absolutePath: absolutePath,
+                            startingPath: startingPath,
                             meta: meta)
 
         // Pre-order: evaluate this node first, then descend.
@@ -237,6 +240,7 @@ public struct FindCommand: Command {
             let childDisplay = Self.joinPath(node.displayPath, name)
             try await walk(displayPath: childDisplay,
                            absolutePath: childAbs,
+                           startingPath: node.startingPath,
                            depth: depth + 1,
                            ctx: ctx)
         }
@@ -378,6 +382,9 @@ public struct FindCommand: Command {
         case .print0:
             Shell.bashCurrent.stdout(node.displayPath + "\u{0}")
             return EvalResult(matched: true)
+        case .printf(let format):
+            Shell.bashCurrent.stdout(Self.formatPrintf(format, node: node))
+            return EvalResult(matched: true)
         case .prune:
             // Returns true; the walker reads `pruned` to skip descent.
             // No effect under `-depth` (already descended) — matches
@@ -458,6 +465,7 @@ public struct FindCommand: Command {
     private struct NodeInfo {
         let displayPath: String
         let absolutePath: String
+        let startingPath: String
         let meta: FileMetadata
     }
 
@@ -521,6 +529,7 @@ public struct FindCommand: Command {
     enum Action: Sendable {
         case print
         case print0
+        case printf(String)
         case prune
         case delete
         case execEach([String])
@@ -689,7 +698,7 @@ public struct FindCommand: Command {
         switch expr {
         case .action(let action):
             switch action {
-            case .print, .print0, .delete, .execEach, .execBatch: return true
+            case .print, .print0, .printf, .delete, .execEach, .execBatch: return true
             case .prune: return false
             }
         case .test: return false
@@ -840,6 +849,8 @@ public struct FindCommand: Command {
                 return .action(.print)
             case "-print0":
                 return .action(.print0)
+            case "-printf":
+                return .action(.printf(try value(for: flag)))
             case "-prune":
                 return .action(.prune)
             case "-delete":
@@ -946,6 +957,149 @@ public struct FindCommand: Command {
             throw ParseError(message: "-perm: bad mode: \(raw)")
         }
         return PermResult(mode: mode, match: match)
+    }
+
+    // MARK: -printf formatting
+    //
+    // GNU find-compatible format string interpreter. Supports the
+    // mainstream directives users actually reach for; rarer ones
+    // (`%a` access-time variants, `%c` ctime, `%A@`, `%C@`, format
+    // flags like `%-20p`) are not yet implemented and pass through
+    // as the original two characters so a typo still gets debugged.
+
+    static func formatPrintf(_ format: String, node nodeAny: Any) -> String {
+        // `nodeAny` is `NodeInfo` — accepted as `Any` so this helper
+        // can stay static without exposing the private NodeInfo type.
+        guard let node = nodeAny as? NodeInfo else { return "" }
+        var out = ""
+        let chars = Array(format)
+        var idx = 0
+        while idx < chars.count {
+            let char = chars[idx]
+            if char == "\\", idx + 1 < chars.count {
+                switch chars[idx + 1] {
+                case "n": out.append("\n")
+                case "t": out.append("\t")
+                case "r": out.append("\r")
+                case "\\": out.append("\\")
+                case "0": out.append("\u{0}")
+                case "a": out.append("\u{07}")
+                case "b": out.append("\u{08}")
+                case "f": out.append("\u{0C}")
+                case "v": out.append("\u{0B}")
+                default:
+                    out.append(chars[idx + 1])
+                }
+                idx += 2
+                continue
+            }
+            if char == "%", idx + 1 < chars.count {
+                let directive = chars[idx + 1]
+                // `%T<X>` is two characters of suffix; everything else
+                // is a single character.
+                if directive == "T", idx + 2 < chars.count {
+                    out.append(printfTimeField(chars[idx + 2], date: node.meta.modifiedAt))
+                    idx += 3
+                    continue
+                }
+                if let rendered = printfField(directive, node: node) {
+                    out.append(rendered)
+                    idx += 2
+                    continue
+                }
+                // Unknown directive — emit the two characters as-is.
+                out.append(char)
+                out.append(directive)
+                idx += 2
+                continue
+            }
+            out.append(char)
+            idx += 1
+        }
+        return out
+    }
+
+    private static func printfField(_ directive: Character, node: NodeInfo) -> String? {
+        switch directive {
+        case "%": return "%"
+        case "p": return node.displayPath
+        case "P": return relativeToStart(displayPath: node.displayPath,
+                                          startingPath: node.startingPath)
+        case "f": return (node.displayPath as NSString).lastPathComponent
+        case "h":
+            let parent = (node.displayPath as NSString).deletingLastPathComponent
+            return parent.isEmpty ? "." : parent
+        case "s": return String(node.meta.size)
+        case "m": return String(node.meta.mode & 0o7777, radix: 8)
+        case "M":
+            // ls-style mode string ("-rw-r--r--", "drwxr-xr-x", ...).
+            return modeString(kind: node.meta.kind, mode: node.meta.mode)
+        case "y":
+            switch node.meta.kind {
+            case .file: return "f"
+            case .directory: return "d"
+            case .symlink: return "l"
+            case .other: return "?"
+            }
+        case "u": return String(node.meta.uid)
+        case "g": return String(node.meta.gid)
+        case "U": return String(node.meta.uid)
+        case "G": return String(node.meta.gid)
+        case "n": return String(node.meta.linkCount)
+        case "d": return "0"  // depth — not threaded into NodeInfo
+        default: return nil
+        }
+    }
+
+    private static func printfTimeField(_ directive: Character, date: Date) -> String {
+        if directive == "@" {
+            return String(format: "%.10f", date.timeIntervalSince1970)
+        }
+        let calendar = Calendar(identifier: .gregorian)
+        let comps = calendar.dateComponents(
+            [.year, .month, .day, .hour, .minute, .second, .weekday],
+            from: date)
+        func pad(_ value: Int?, width: Int) -> String {
+            String(format: "%0\(width)d", value ?? 0)
+        }
+        switch directive {
+        case "Y": return pad(comps.year, width: 4)
+        case "m": return pad(comps.month, width: 2)
+        case "d": return pad(comps.day, width: 2)
+        case "H": return pad(comps.hour, width: 2)
+        case "M": return pad(comps.minute, width: 2)
+        case "S": return pad(comps.second, width: 2)
+        case "j":
+            let day = calendar.ordinality(of: .day, in: .year, for: date) ?? 0
+            return String(format: "%03d", day)
+        default: return "%T\(directive)"
+        }
+    }
+
+    private static func relativeToStart(displayPath: String, startingPath: String) -> String {
+        if displayPath == startingPath { return "" }
+        let prefix = startingPath.hasSuffix("/") ? startingPath : startingPath + "/"
+        if displayPath.hasPrefix(prefix) {
+            return String(displayPath.dropFirst(prefix.count))
+        }
+        return displayPath
+    }
+
+    private static func modeString(kind: FileMetadata.Kind, mode: UInt16) -> String {
+        let kindChar: Character
+        switch kind {
+        case .file: kindChar = "-"
+        case .directory: kindChar = "d"
+        case .symlink: kindChar = "l"
+        case .other: kindChar = "?"
+        }
+        func triplet(_ shift: Int) -> String {
+            let bits = (mode >> shift) & 0o7
+            return "\(bits & 0o4 != 0 ? "r" : "-")"
+                 + "\(bits & 0o2 != 0 ? "w" : "-")"
+                 + "\(bits & 0o1 != 0 ? "x" : "-")"
+        }
+        return "\(kindChar)\(triplet(6))\(triplet(3))\(triplet(0))"
     }
 
     // MARK: Glob matching

--- a/Sources/BashCommandKit/Commands/PasteCommand.swift
+++ b/Sources/BashCommandKit/Commands/PasteCommand.swift
@@ -42,7 +42,7 @@ public struct PasteCommand: ParsableBashCommand {
 
         // Read every input fully up front. paste needs random access
         // across files for its row-by-row interleaving.
-        switch await readInputs(files: files) {
+        switch await readInputs(files: files, serial: serial) {
         case .failure(let exit): return exit
         case .success(let inputs):
             emitOutput(inputs: inputs, delimChars: delimChars, serial: serial)
@@ -90,10 +90,14 @@ public struct PasteCommand: ParsableBashCommand {
         return nil
     }
 
-    private func readInputs(files: [String]) async -> InputResult {
-        // GNU/BSD `paste` with multiple `-` operands reads stdin once
-        // and round-robins its lines across the dash slots: with N
-        // dashes, slot k gets stdin lines k, k+N, k+2N, ...
+    private func readInputs(files: [String], serial: Bool) async -> InputResult {
+        // GNU/BSD `paste`:
+        // * Default mode with multiple `-` operands reads stdin once
+        //   and round-robins its lines across the dash slots — with N
+        //   dashes, slot k gets stdin lines k, k+N, k+2N, ...
+        // * Serial mode (`-s`) is processed file-by-file in argv
+        //   order, so the first `-` drains stdin entirely and any
+        //   subsequent `-` sees an empty stream.
         let dashCount = files.filter { $0 == "-" }.count
         var stdinLines: [String] = []
         if dashCount > 0 {
@@ -108,10 +112,14 @@ public struct PasteCommand: ParsableBashCommand {
                 let slot = dashSeen
                 dashSeen += 1
                 var lines: [String] = []
-                var idx = slot
-                while idx < stdinLines.count {
-                    lines.append(stdinLines[idx])
-                    idx += dashCount
+                if serial {
+                    if slot == 0 { lines = stdinLines }
+                } else {
+                    var idx = slot
+                    while idx < stdinLines.count {
+                        lines.append(stdinLines[idx])
+                        idx += dashCount
+                    }
                 }
                 inputs.append(lines)
             } else {

--- a/Sources/BashCommandKit/Commands/PasteCommand.swift
+++ b/Sources/BashCommandKit/Commands/PasteCommand.swift
@@ -91,17 +91,28 @@ public struct PasteCommand: ParsableBashCommand {
     }
 
     private func readInputs(files: [String]) async -> InputResult {
+        // GNU/BSD `paste` with multiple `-` operands reads stdin once
+        // and round-robins its lines across the dash slots: with N
+        // dashes, slot k gets stdin lines k, k+N, k+2N, ...
+        let dashCount = files.filter { $0 == "-" }.count
+        var stdinLines: [String] = []
+        if dashCount > 0 {
+            for await line in Shell.bashCurrent.stdin.lines {
+                stdinLines.append(line)
+            }
+        }
+        var dashSeen = 0
         var inputs: [[String]] = []
-        var stdinUsed = false
         for file in files {
             if file == "-" {
-                guard !stdinUsed else {
-                    Shell.bashCurrent.stderr("paste: stdin can only be used once\n")
-                    return .failure(.failure)
-                }
-                stdinUsed = true
+                let slot = dashSeen
+                dashSeen += 1
                 var lines: [String] = []
-                for await line in Shell.bashCurrent.stdin.lines { lines.append(line) }
+                var idx = slot
+                while idx < stdinLines.count {
+                    lines.append(stdinLines[idx])
+                    idx += dashCount
+                }
                 inputs.append(lines)
             } else {
                 do {

--- a/Sources/BashCommandKit/Commands/XargsCommand.swift
+++ b/Sources/BashCommandKit/Commands/XargsCommand.swift
@@ -48,6 +48,9 @@ public struct XargsCommand: ParsableBashCommand {
                 }
                 replaceStr = rawArgv[idx + 1]; idx += 2; cmdStart = idx; continue
             }
+            if arg.hasPrefix("-I") && arg.count > 2 {
+                replaceStr = String(arg.dropFirst(2)); idx += 1; cmdStart = idx; continue
+            }
             if arg.hasPrefix("--replace=") {
                 replaceStr = String(arg.dropFirst("--replace=".count)); idx += 1; cmdStart = idx; continue
             }
@@ -57,11 +60,30 @@ public struct XargsCommand: ParsableBashCommand {
                 }
                 delimiter = unescape(rawArgv[idx + 1]); idx += 2; cmdStart = idx; continue
             }
+            if arg.hasPrefix("-d") && arg.count > 2 {
+                delimiter = unescape(String(arg.dropFirst(2))); idx += 1; cmdStart = idx; continue
+            }
+            if arg.hasPrefix("--delimiter=") {
+                delimiter = unescape(String(arg.dropFirst("--delimiter=".count)))
+                idx += 1; cmdStart = idx; continue
+            }
             if arg == "-n" || arg == "--max-args" {
                 guard idx + 1 < rawArgv.count, let num = Int(rawArgv[idx + 1]) else {
                     Shell.bashCurrent.stderr("xargs: -n requires N\n"); return ExitStatus(2)
                 }
                 maxArgs = num; idx += 2; cmdStart = idx; continue
+            }
+            if arg.hasPrefix("-n") && arg.count > 2 {
+                guard let num = Int(arg.dropFirst(2)) else {
+                    Shell.bashCurrent.stderr("xargs: -n requires N\n"); return ExitStatus(2)
+                }
+                maxArgs = num; idx += 1; cmdStart = idx; continue
+            }
+            if arg.hasPrefix("--max-args=") {
+                guard let num = Int(arg.dropFirst("--max-args=".count)) else {
+                    Shell.bashCurrent.stderr("xargs: -n requires N\n"); return ExitStatus(2)
+                }
+                maxArgs = num; idx += 1; cmdStart = idx; continue
             }
             if arg == "-P" || arg == "--max-procs" {
                 // Accept but ignore; we run sequentially.
@@ -69,6 +91,12 @@ public struct XargsCommand: ParsableBashCommand {
                     Shell.bashCurrent.stderr("xargs: -P requires N\n"); return ExitStatus(2)
                 }
                 idx += 2; cmdStart = idx; continue
+            }
+            if arg.hasPrefix("-P") && arg.count > 2 {
+                idx += 1; cmdStart = idx; continue
+            }
+            if arg.hasPrefix("--max-procs=") {
+                idx += 1; cmdStart = idx; continue
             }
             if arg == "-0" || arg == "--null" {
                 nullSep = true; idx += 1; cmdStart = idx; continue

--- a/Sources/swift-bash/ExecCommand.swift
+++ b/Sources/swift-bash/ExecCommand.swift
@@ -156,14 +156,20 @@ struct ExecCommand: AsyncParsableCommand {
         // `fileSystem` overlay above; ShellKit-aware bridges
         // (the registered SwiftPorts CLIs and the SwiftScript
         // interpreter) consult `Shell.sandbox` instead.
-        // Bind the same physical root so both confinements stay
-        // in lock-step and a `--sandbox` invocation actually
-        // confines a Swift script the same way it confines a
-        // bash one. Migration target (#10): retire the legacy
-        // `fileSystem` overlay and have bash consult the URL
+        //
+        // Root the URL gate at the *virtual* workspace path, not the
+        // host directory: SwiftPorts CLIs (fd, rg, jq, …) and the
+        // SwiftScript interpreter all see paths from
+        // `Shell.currentDirectory` / `Shell.resolve(_:)`, which return
+        // the bash-side virtual cwd (`workspace`). Anchoring the gate
+        // at the host path put it in a different namespace from those
+        // callers — `fd file .` always tripped "file URL is outside
+        // sandbox root" because `/batch/.` (virtual) wasn't under
+        // `/Users/.../host-root`. Migration target (#10): retire the
+        // legacy `fileSystem` overlay and have bash consult the URL
         // gate too.
         let urlSandbox = ShellKit.Sandbox.rooted(
-            at: URL(fileURLWithPath: sandboxRoot),
+            at: URL(fileURLWithPath: workspace),
             allowedHosts: [])
         return ShellSetup(
             environment: env,

--- a/Tests/BashCommandKitTests/EasyBatchTests.swift
+++ b/Tests/BashCommandKitTests/EasyBatchTests.swift
@@ -146,6 +146,20 @@ import Foundation
         #expect(cap.stdout == "a,b,c\n1,2,3\n")
     }
 
+    @Test func pasteDoubleDashSplitsStdinAcrossColumns() async throws {
+        let (cap, dir) = try makeShell(); defer { cleanup(dir) }
+        try await cap.shell.run("printf 'a\\nb\\nc\\nd\\ne\\n' | paste - -")
+        // GNU paste: with two `-`s, stdin lines fan out round-robin
+        // → row 0: "a\tb", row 1: "c\td", row 2: "e\t" (slot empty).
+        #expect(cap.stdout == "a\tb\nc\td\ne\t\n")
+    }
+
+    @Test func pasteTripleDashSplitsStdinAcrossThreeColumns() async throws {
+        let (cap, dir) = try makeShell(); defer { cleanup(dir) }
+        try await cap.shell.run("printf 'a\\nb\\nc\\nd\\ne\\nf\\n' | paste - - -")
+        #expect(cap.stdout == "a\tb\tc\nd\te\tf\n")
+    }
+
     // MARK: comm
 
     @Test func commProducesThreeColumns() async throws {

--- a/Tests/BashCommandKitTests/EasyBatchTests.swift
+++ b/Tests/BashCommandKitTests/EasyBatchTests.swift
@@ -160,6 +160,14 @@ import Foundation
         #expect(cap.stdout == "a\tb\tc\nd\te\tf\n")
     }
 
+    @Test func pasteSerialDashConsumesAllStdin() async throws {
+        let (cap, dir) = try makeShell(); defer { cleanup(dir) }
+        // Serial mode walks files in command-line order: the first
+        // `-` drains stdin, the second sees EOF.
+        try await cap.shell.run("printf 'a\\nb\\nc\\n' | paste -s - -")
+        #expect(cap.stdout == "a\tb\tc\n\n")
+    }
+
     // MARK: comm
 
     @Test func commProducesThreeColumns() async throws {

--- a/Tests/BashCommandKitTests/FindCommandTests.swift
+++ b/Tests/BashCommandKitTests/FindCommandTests.swift
@@ -336,6 +336,24 @@ import Foundation
         #expect(cap.stdout == "./a")
     }
 
+    @Test func printfDepthMatchesWalker() async throws {
+        let (cap, dir) = try makeShell(); defer { cleanup(dir) }
+        try await cap.shell.run("mkdir -p a/b/c")
+        try await cap.shell.run("touch a/x a/b/y a/b/c/z")
+        try await cap.shell.run("find . -printf '%d %p\\n'")
+        // Pre-order traversal: each line carries its walker depth.
+        #expect(cap.stdout == """
+            0 .
+            1 ./a
+            2 ./a/b
+            3 ./a/b/c
+            4 ./a/b/c/z
+            3 ./a/b/y
+            2 ./a/x
+
+            """)
+    }
+
     // MARK: - prune
 
     @Test func pruneSkipsDirectoryDescent() async throws {

--- a/Tests/BashCommandKitTests/FindCommandTests.swift
+++ b/Tests/BashCommandKitTests/FindCommandTests.swift
@@ -310,6 +310,32 @@ import Foundation
         #expect(cap.stdout == "./a\u{0}./b\u{0}")
     }
 
+    // MARK: - printf
+
+    @Test func printfWithPathAndType() async throws {
+        let (cap, dir) = try makeShell(); defer { cleanup(dir) }
+        try await cap.shell.run("touch a b")
+        try await cap.shell.run("find . -type f -printf '%p %y\\n'")
+        #expect(cap.stdout == "./a f\n./b f\n")
+    }
+
+    @Test func printfRelativePathAndBasename() async throws {
+        let (cap, dir) = try makeShell(); defer { cleanup(dir) }
+        try await cap.shell.run("mkdir -p sub")
+        try await cap.shell.run("touch sub/a")
+        try await cap.shell.run("find . -type f -printf '%P|%f\\n'")
+        #expect(cap.stdout == "sub/a|a\n")
+    }
+
+    @Test func printfHasNoImplicitNewline() async throws {
+        let (cap, dir) = try makeShell(); defer { cleanup(dir) }
+        try await cap.shell.run("touch a")
+        // Two matches: . and ./a. Without a trailing \n the output
+        // joins without separation.
+        try await cap.shell.run("find . -type f -printf '%p'")
+        #expect(cap.stdout == "./a")
+    }
+
     // MARK: - prune
 
     @Test func pruneSkipsDirectoryDescent() async throws {

--- a/Tests/BashCommandKitTests/SystemInfoCommandsTests.swift
+++ b/Tests/BashCommandKitTests/SystemInfoCommandsTests.swift
@@ -109,6 +109,23 @@ import Foundation
         #expect(status == ExitStatus(1))
         #expect(cap.stdout == "")
     }
+
+    @Test func cmpDashReadsStdin() async throws {
+        let cap = makeShell()
+        let dir = NSTemporaryDirectory() + "cmp-\(UUID())"
+        try FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(atPath: dir) }
+        try "abc".write(toFile: dir + "/a", atomically: true, encoding: .utf8)
+        let status = try await cap.shell.run("printf abc | cmp -s - \(dir)/a")
+        #expect(status == .success)
+    }
+
+    @Test func cmpDashRejectedTwice() async throws {
+        let cap = makeShell()
+        let status = try await cap.shell.run("printf abc | cmp -s - -")
+        #expect(status == ExitStatus(2))
+        #expect(cap.stderr.contains("standard input"))
+    }
     #endif
 
 }

--- a/Tests/BashCommandKitTests/XargsCommandTests.swift
+++ b/Tests/BashCommandKitTests/XargsCommandTests.swift
@@ -30,6 +30,24 @@ import Foundation
         #expect(cap.stdout == "a b\nc d\n")
     }
 
+    @Test func dashNAttached() async throws {
+        let cap = makeShell()
+        try await cap.shell.run("printf 'a b c\\n' | xargs -n1 echo")
+        #expect(cap.stdout == "a\nb\nc\n")
+    }
+
+    @Test func dashDAttached() async throws {
+        let cap = makeShell()
+        try await cap.shell.run("printf 'a:b:c\\n' | xargs -d: echo")
+        #expect(cap.stdout == "a b c\n")
+    }
+
+    @Test func dashIAttached() async throws {
+        let cap = makeShell()
+        try await cap.shell.run("printf 'a\\nb\\n' | xargs -IX echo got X done")
+        #expect(cap.stdout == "got a done\ngot b done\n")
+    }
+
     @Test func dashI() async throws {
         let cap = makeShell()
         try await cap.shell.run("printf 'a\\nb\\n' | xargs -I X echo got X done")


### PR DESCRIPTION
## Summary

Five independent fixes the user hit while exercising the CLI surface, split into one commit each for review.

- **xargs:** accept attached-value short options (`-n1`, `-d:`, `-IX`, `-P4`). The parser only matched the standalone tokens so `xargs -n1` fell through to the combined-boolean branch and rejected `-n`.
- **find:** add `-printf FORMAT` action covering the mainstream `%p %P %f %h %s %m %M %y %u %g %U %G %n %T@ %TY %Tm %Td %TH %TM %TS %Tj %%` directives plus `\n \t \r \\ \0 \a \b \f \v` escapes.
- **cmp:** accept `-` as stdin (either operand). `cmp - -` is rejected up front since stdin can't be replayed.
- **paste:** `paste - -` (and more `-`s) now reads stdin once and fans lines round-robin across the dash slots, matching GNU/BSD semantics.
- **swift-bash exec `--sandbox`:** root the URL gate at the virtual `--workspace` path so `fd` / `rg` / SwiftScript stop tripping "file URL is outside sandbox root" against virtual-cwd paths. (Follow-up at [Cocoanetics/SwiftPorts#39](https://github.com/Cocoanetics/SwiftPorts/issues/39) covers the deeper `FileManager.default` bypass.)

Pairs with [Cocoanetics/SwiftPorts#40](https://github.com/Cocoanetics/SwiftPorts/pull/40), which carries the matching `git log -<n>` SwiftBash-builtin fix and the `Shell.sandbox` audit on the port-CLI side.

## Test plan

- [x] `swift build` (clean)
- [x] `swift test --filter "FindCommandTests|XargsCommandTests"` — all pass (incl. 3 new `-printf` tests + 3 new attached-value xargs tests)
- [x] `swift test --filter "SystemInfoCommandsTests|EasyBatchTests"` — all pass (incl. `cmpDashReadsStdin`, `cmpDashRejectedTwice`, `pasteDoubleDashSplitsStdinAcrossColumns`, `pasteTripleDashSplitsStdinAcrossThreeColumns`)
- [x] End-to-end: `fd file .` inside `swift-bash exec --sandbox /tmp/x` no longer reports "outside sandbox root" (returns the next-level error documented at SwiftPorts#39 instead)
- [x] Full `swift test` — only the usual flaky pipeline-timing suites failed; clean re-run

🤖 Generated with [Claude Code](https://claude.com/claude-code)