### PR TITLE
sandbox: route /tmp + workspace to real disk so SwiftPorts tools work (fixes #49)

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -214,9 +214,12 @@ jobs:
   build-android:
     runs-on: ubuntu-latest
     # First cold run = ~25 min (SDK + NDK + emulator boot dominates);
-    # cached subsequent runs are ~5 min. 30 min covers both with a
-    # comfortable margin.
-    timeout-minutes: 30
+    # cached subsequent runs are ~5 min. The original 30 min ceiling
+    # was a near-miss for cold runs and we kept clipping it on hosted
+    # runners under load (three consecutive cancellations at exactly
+    # 30:10–30:14 on PR #52). 60 min gives the cold path real headroom
+    # while still capping a stuck emulator.
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v6
       # Bun's Android-targeted JSC archive. Cross-build from the

--- a/Docs/Sandboxing.md
+++ b/Docs/Sandboxing.md
@@ -104,7 +104,10 @@ shell.hostInfo = HostInfo.real()
 The `swift-bash` CLI's `exec --sandbox PATH` flag enforces all four
 axes at once:
 
-- `fileSystem = SandboxedOverlayFileSystem(.init(root: PATH, mountPoint: "/batch"))`
+- `fileSystem = MountedFileSystem` with two mounts:
+  - virtual `/batch` (or `--workspace`) → host `PATH` (read-write)
+  - virtual `/tmp` → host `/tmp` (read-write, shared with the host)
+- `urlSandbox` confines file URLs to those two roots
 - `networkConfig = nil` (deny-all)
 - `hostInfo = .synthetic`
 - Process table is always virtual (no flag needed)
@@ -114,9 +117,15 @@ $ swift-bash exec --sandbox /tmp/work script.sh
 ```
 
 The script sees `/batch` as its workspace, can `cd /batch && ls`,
-write files there, but can't reach `/Users/`, `~/Documents`,
-`/etc/passwd`, or anything else on the host. It can't make network
-requests. `whoami` says "user". `hostname` says "sandbox".
+write files there (and they persist at `/tmp/work` on the host), and
+can also use `/tmp` for scratch space. It can't reach `/Users/`,
+`~/Documents`, `/etc/passwd`, or anything else on the host. It can't
+make network requests. `whoami` says "user". `hostname` says "sandbox".
+
+The `/tmp` mount routes to the host's real `/tmp` (not an in-memory
+scratch) so SwiftPorts CLIs (`gzip`, `gunzip`, `fd`, `rg`, …) that
+read through Foundation's `Data(contentsOf:)` actually find the
+files bash builtins wrote there. Issues #48 / #49.
 
 For embedders not using the CLI, mirror the same setup:
 
@@ -127,13 +136,23 @@ let shell = Shell(
         env.workingDirectory = "/batch"
         return env
     }(),
-    fileSystem: try SandboxedOverlayFileSystem(.init(
-        root: NSHomeDirectory() + "/Documents/scratch",
-        mountPoint: "/batch"))
+    fileSystem: MountedFileSystem(
+        mounts: [
+            .init(virtual: "/batch",
+                  host: NSHomeDirectory() + "/Documents/scratch"),
+            .init(virtual: "/tmp", host: "/tmp"),
+        ],
+        backing: RealFileSystem())
 )
 shell.registerStandardCommands()
 // hostInfo defaults to .synthetic; networkConfig defaults to nil.
 ```
+
+`SandboxedOverlayFileSystem` is still available for embedders who
+want the COW-in-memory model — script writes captured in RAM, host
+left untouched. Pick that when *auditing* a script matters more than
+*running* one to completion; the CLI's `--sandbox` mode prefers
+running.
 
 ## Threat model
 
@@ -142,12 +161,18 @@ in-process** — the threat is information leakage and unauthorized
 state changes, not memory-level exploitation of the runtime itself.
 
 **In scope:**
-- Reading host files outside the mount point.
-- Writing host files (sandboxed → all writes captured in memory).
+- Reading host files outside the mount points.
+- Writing host files outside the mount points (workspace + `/tmp`).
 - Discovering host identity (uid, username, hostname, machine).
 - Seeing host processes via `ps` / `pgrep`.
 - Probing the network (default deny; allow-list with segment-safe matching).
 - TOCTOU and symlink-traversal escape attempts.
+
+**Inside the mounts**, writes persist to real disk (the CLI's choice
+for `--sandbox`). The workspace is wherever the user pointed
+`--sandbox`; `/tmp` is the host's real `/tmp`, shared with other
+processes per POSIX. Use `SandboxedOverlayFileSystem` directly if
+you need the legacy in-memory-write capture.
 
 **Out of scope:**
 - Memory-corruption attacks against Swift runtime / Foundation.

--- a/Package.swift
+++ b/Package.swift
@@ -235,6 +235,11 @@ let package = Package(
             dependencies: ["BashCommandKit"],
             path: "Tests/BashCommandKitTests"
         ),
+        .testTarget(
+            name: "SwiftBashTests",
+            dependencies: ["swift-bash"],
+            path: "Tests/SwiftBashTests"
+        ),
 
         // ---- SwiftJS — JavaScript runtime + CLI ----
         // Universal: SwiftJSCore talks to the JSC C API exclusively

--- a/Sources/swift-bash/ExecCommand.swift
+++ b/Sources/swift-bash/ExecCommand.swift
@@ -34,8 +34,9 @@ struct ExecCommand: AsyncParsableCommand {
             help: ArgumentHelp(
                 "Confine the script to a sandboxed view of HOST_DIR. "
                 + "The host directory is mounted at the virtual --workspace "
-                + "path (default /batch); writes are kept in memory and "
-                + "never touch disk. Paths outside the mount return ENOENT."))
+                + "path (default /batch) and writes there persist on disk. "
+                + "`/tmp` is mounted to the host's real /tmp. Paths outside "
+                + "the mounts return ENOENT."))
     var sandbox: String?
 
     @Option(name: .long,
@@ -133,14 +134,18 @@ struct ExecCommand: AsyncParsableCommand {
                 hostInfo: .real(),
                 urlSandbox: nil)
         }
-        let fileSystem: FileSystem
-        do {
-            fileSystem = try SandboxedOverlayFileSystem(.init(
-                root: sandboxRoot,
-                mountPoint: workspace))
-        } catch let err as FileSystemError {
-            throw CLIError("--sandbox: \(err.description)")
+        // Validate the host workspace exists so the user gets a clean
+        // diagnostic up front. `MountedFileSystem` doesn't validate
+        // host paths at init the way `SandboxedOverlayFileSystem` did,
+        // so move the check into the CLI.
+        var isDir: ObjCBool = false
+        guard FileManager.default.fileExists(atPath: sandboxRoot,
+                                             isDirectory: &isDir),
+              isDir.boolValue else {
+            throw CLIError("--sandbox: no such directory: \(sandboxRoot)")
         }
+        let fileSystem = Self.makeFileSystem(
+            workspace: workspace, sandboxRoot: sandboxRoot)
         let hostInfo = HostInfo.synthetic
         var env = Environment.synthetic(hostInfo: hostInfo,
                                         workingDirectory: workspace)
@@ -158,23 +163,51 @@ struct ExecCommand: AsyncParsableCommand {
         // interpreter) consult `Shell.sandbox` instead.
         //
         // `bashWorkspace(workspace:)` accepts both the virtual
-        // workspace path (where the overlay is mounted) and `/tmp`
-        // (where the overlay seeds its in-memory scratch). Without
-        // the `/tmp` carve-out, a script's `cd /tmp; fd X` trips
-        // "file URL is outside sandbox root" — the bash side
-        // considers `/tmp` valid but the URL gate, rooted only at
-        // the workspace, doesn't (#48). FileManager still walks the
-        // host's real `/tmp` after authorize succeeds, so the in-
-        // memory scratch isn't searchable from SwiftPorts CLIs — the
-        // gate error just stops being misleading. Migration target
-        // (#10): retire the legacy `fileSystem` overlay and have
-        // bash consult the URL gate too.
+        // workspace path and `/tmp`. With the FS layer now mounting
+        // `/tmp` to the host's real `/tmp` (above), authorize-allowed
+        // paths under `/tmp` resolve to bytes on disk — `Data(contentsOf:)`
+        // in SwiftPorts CLIs (`gzip`, `gunzip`, `fd`, …) finds the
+        // same files bash builtins wrote. The workspace mount is
+        // similar but `/batch` doesn't exist on real disk so tools
+        // still hit "no such file" there; tracked at Cocoanetics/SwiftPorts#39
+        // and the existing #10 migration note.
         let urlSandbox = ShellKit.Sandbox.bashWorkspace(workspace: workspace)
         return ShellSetup(
             environment: env,
             fileSystem: fileSystem,
             hostInfo: hostInfo,
             urlSandbox: urlSandbox)
+    }
+
+    /// Build the bash overlay for `--sandbox` mode.
+    ///
+    /// Mount the workspace and `/tmp` onto real disk via a
+    /// ``MountedFileSystem``. The legacy ``SandboxedOverlayFileSystem``
+    /// setup captured every write in an in-memory layer (including
+    /// `/tmp`), which broke the SwiftPorts compression / search
+    /// family — `gzip`, `gunzip`, `zcat`, `fd`, etc. — because those
+    /// tools read through Foundation's `Data(contentsOf:)` and never
+    /// see the overlay. The same in-memory model also hid the user's
+    /// actual outputs from `--sandbox`: a script that ran
+    /// `gzip -c file > file.gz` produced bytes only the shell could
+    /// see, and they vanished at exit.
+    ///
+    /// Switching the workspace mount to ``RealFileSystem`` makes
+    /// writes persist where the user passed `--sandbox`, and mounting
+    /// `/tmp` to the host's real `/tmp` lets SwiftPorts tools resolve
+    /// `/tmp/...` to a real fs location they can read and write.
+    /// ``MountedFileSystem``'s prefix confinement + symlink-escape
+    /// check keeps paths outside the mounts (`/etc`, `/Users`, …)
+    /// reporting ENOENT to the script. Issue #49.
+    static func makeFileSystem(workspace: String,
+                               sandboxRoot: String) -> MountedFileSystem {
+        MountedFileSystem(
+            mounts: [
+                MountedFileSystem.Mount(virtual: workspace,
+                                        host: sandboxRoot),
+                MountedFileSystem.Mount(virtual: "/tmp", host: "/tmp")
+            ],
+            backing: RealFileSystem())
     }
 
     /// Apply --allow-url / --allow-method / --dangerous-full-network /

--- a/Tests/SwiftBashTests/ExecCommandFileSystemTests.swift
+++ b/Tests/SwiftBashTests/ExecCommandFileSystemTests.swift
@@ -1,0 +1,99 @@
+import Foundation
+import Testing
+@testable import swift_bash
+import BashInterpreter
+
+/// Verifies the FS layout that `swift-bash exec --sandbox` wires up.
+///
+/// The legacy ``SandboxedOverlayFileSystem`` model captured every
+/// write — workspace AND `/tmp` — in an in-memory layer, so SwiftPorts
+/// CLIs (`gzip`, `gunzip`, `fd`, …) couldn't see them through
+/// `Data(contentsOf:)`. The CLI now uses a ``MountedFileSystem``
+/// that puts both mounts on real disk, so tools that resolve a virtual
+/// path to a host URL actually find the file. Issues #48 / #49.
+@Suite(.timeLimit(.minutes(1))) struct ExecCommandFileSystemTests {
+
+    /// Each test gets its own scratch dir under `NSTemporaryDirectory()`
+    /// to act as the host workspace. `defer`-cleaned in every test.
+    private static func makeScratchDir() throws -> URL {
+        let scratch = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("swift-bash-fstest-\(UUID().uuidString)",
+                                    isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: scratch, withIntermediateDirectories: true)
+        return scratch
+    }
+
+    @Test func workspaceWritesPersistToHost() async throws {
+        let host = try Self.makeScratchDir()
+        defer { try? FileManager.default.removeItem(at: host) }
+
+        let fileSystem = ExecCommand.makeFileSystem(
+            workspace: "/batch", sandboxRoot: host.path)
+        try await fileSystem.writeData(
+            Data("hello\n".utf8), to: "/batch/foo.txt", append: false)
+
+        // File lives on real disk under the host workspace, NOT in an
+        // in-memory layer — Foundation can open it directly.
+        let hostFile = host.appendingPathComponent("foo.txt")
+        let bytes = try Data(contentsOf: hostFile)
+        #expect(String(bytes: bytes, encoding: .utf8) == "hello\n")
+    }
+
+    @Test func tmpWritesPersistToRealTmp() async throws {
+        let host = try Self.makeScratchDir()
+        defer { try? FileManager.default.removeItem(at: host) }
+
+        // Stamp a unique subdir under /tmp so we don't clash with other
+        // runs / leak past the test.
+        let probeName = "swift-bash-tmptest-\(UUID().uuidString)"
+        let hostProbe = URL(fileURLWithPath: "/tmp")
+            .appendingPathComponent(probeName)
+        defer { try? FileManager.default.removeItem(at: hostProbe) }
+
+        let fileSystem = ExecCommand.makeFileSystem(
+            workspace: "/batch", sandboxRoot: host.path)
+        try await fileSystem.createDirectory("/tmp/\(probeName)",
+                                             intermediates: true)
+        try await fileSystem.writeData(
+            Data("scratch\n".utf8),
+            to: "/tmp/\(probeName)/data.txt", append: false)
+
+        // SwiftPorts CLIs use `Data(contentsOf:)` with virtual URLs.
+        // On macOS realpath resolves /tmp -> /private/tmp, so a
+        // file URL spelled `/tmp/.../data.txt` reaches the same inode
+        // we just wrote.
+        let virtualURL = URL(fileURLWithPath:
+            "/tmp/\(probeName)/data.txt")
+        let bytes = try Data(contentsOf: virtualURL)
+        #expect(String(bytes: bytes, encoding: .utf8) == "scratch\n")
+    }
+
+    @Test func pathsOutsideMountsAreMissing() async throws {
+        let host = try Self.makeScratchDir()
+        defer { try? FileManager.default.removeItem(at: host) }
+
+        let fileSystem = ExecCommand.makeFileSystem(
+            workspace: "/batch", sandboxRoot: host.path)
+        // `/etc` and `/Users` exist on the host but aren't mounted.
+        // The FS reports `nil` metadata (not a thrown error) so bash
+        // tests like `[ -f /etc/passwd ]` behave as on a chroot.
+        #expect(try await fileSystem.metadata("/etc/passwd") == nil)
+        #expect(try await fileSystem.metadata("/Users") == nil)
+    }
+
+    @Test func workspaceMountIsRespected() async throws {
+        let host = try Self.makeScratchDir()
+        defer { try? FileManager.default.removeItem(at: host) }
+
+        // Seed a file directly on the host to confirm the workspace
+        // mount surfaces it under the virtual path.
+        let seed = host.appendingPathComponent("seed.txt")
+        try Data("preseed\n".utf8).write(to: seed)
+
+        let fileSystem = ExecCommand.makeFileSystem(
+            workspace: "/batch", sandboxRoot: host.path)
+        let bytes = try await fileSystem.readData("/batch/seed.txt")
+        #expect(String(bytes: bytes, encoding: .utf8) == "preseed\n")
+    }
+}


### PR DESCRIPTION
## Summary

Rebased on top of main after [#53](https://github.com/Cocoanetics/SwiftBash/pull/53) merged. PR #53 opened the URL gate for `/tmp` (fixing #48). This PR completes the picture for #49: it swaps the bash overlay from `SandboxedOverlayFileSystem` (in-memory writes) to `MountedFileSystem` so the workspace AND `/tmp` live on real disk. SwiftPorts CLIs read through Foundation's `Data(contentsOf:)` and now actually find the files bash builtins wrote, so `gzip` / `gunzip` / `fd` / `zcat` round-trip end-to-end inside `--sandbox`.

The existing `Sandbox.bashWorkspace(workspace:)` URL gate from #53 already accepts both roots, so no change to the gate itself.

## Why this is a documented behaviour change

`--sandbox` used to capture every write in RAM via the SOFS overlay. That made the threat-model claim "writes captured in memory" true but also made it impossible for SwiftPorts CLIs (which go straight to the host FS via Foundation) to read files bash had just written. After #53 closed #48, the gate stopped misleadingly denying `/tmp` access, but #49 stayed open because gzip still couldn't actually produce output — it hit "no such file" on the virtual `/tmp` URL.

The new model:
- Writes to the workspace persist at the host directory the user passed `--sandbox` (matches user expectation: the dir they pointed at is where outputs land).
- Writes to `/tmp` go to the host's real `/tmp` (shared with other processes per POSIX).

`SandboxedOverlayFileSystem` is still shipped for embedders who want the COW-in-memory model — Sandboxing.md spells out which to pick.

`MountedFileSystem`'s prefix confinement + symlink-escape check keeps paths outside the two mounts (`/etc`, `/Users`, …) reporting ENOENT to the script, so the chroot guarantee survives the swap.

## Reproduction (from issue #49)

```bash
mkdir -p /tmp/sbtest_root && swift run swift-bash exec --sandbox /tmp/sbtest_root /dev/stdin <<'SCRIPT'
d=/tmp/retest_comp_repro
rm -rf "\$d"; mkdir -p "\$d"
printf 'hello\n' > "\$d/plain.txt"
cd "\$d"
gzip -c plain.txt > plain.txt.gz; echo "gzip=\$?"
gunzip -c plain.txt.gz > out.txt; echo "gunzip=\$?"
cat out.txt
SCRIPT
```

Before: `gzip: file URL is outside sandbox root` → "no such file" after #53.
After this PR: `gzip=0` / `gunzip=0` / `hello`.

## Test plan

- [x] `swift test --no-parallel` — 1941 → 1945 tests (4 new FS tests in `SwiftBashTests`), all green
- [x] `swiftlint lint --strict` on changed files — clean
- [x] Manual repro from `--sandbox`: gzip / gunzip round-trip in `/tmp` end-to-end
- [x] Confinement check: `cat /etc/passwd` / `ls /Users` still report ENOENT inside the sandbox
- [x] Sandboxing.md updated for the FS swap and two-mount layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)