### PR TITLE
swift-bash exec --sandbox: also accept /tmp in the URL gate (fixes #48)

### DIFF
--- a/Sources/BashInterpreter/API/Sandbox+BashWorkspace.swift
+++ b/Sources/BashInterpreter/API/Sandbox+BashWorkspace.swift
@@ -1,0 +1,68 @@
+import Foundation
+import ShellKit
+
+extension ShellKit.Sandbox {
+
+    /// Build the URL gate the SwiftBash sandbox CLI pairs with a
+    /// ``SandboxedOverlayFileSystem`` mounted at `workspace`.
+    ///
+    /// The gate accepts two virtual roots: the `workspace` mount point
+    /// itself and the in-memory `/tmp` scratch the overlay seeds by
+    /// default. SwiftPorts CLIs (fd, rg, jq, …) and the SwiftScript
+    /// interpreter resolve paths through ``Shell/currentDirectory`` and
+    /// ``Shell/resolve(_:)``, both of which return the bash-side
+    /// virtual cwd — `cd /tmp; fd X` lands at virtual `/tmp`. Without
+    /// the `/tmp` carve-out, every such call would trip
+    /// "file URL is outside sandbox root" even though the bash side
+    /// (which consults the overlay, not the URL gate) is fine with the
+    /// access (#48). FileManager still walks the host's real `/tmp`
+    /// after authorize succeeds, so the in-memory scratch isn't
+    /// actually searchable by those CLIs — same shape as the workspace
+    /// case where authorize succeeds but the virtual path doesn't
+    /// exist on real disk (tracked at Cocoanetics/SwiftPorts#39 and
+    /// the existing #10 migration note).
+    ///
+    /// The returned sandbox's `temporaryDirectory` is `/tmp` (the
+    /// virtual path scripts see via `$TMPDIR`), not the default
+    /// `<workspace>/tmp` that ``rooted(at:allowedHosts:)`` would
+    /// produce — that keeps ``Shell/temporaryDirectory`` aligned with
+    /// the path bash code actually uses.
+    public static func bashWorkspace(workspace: String) -> ShellKit.Sandbox {
+        let workspaceURL = URL(fileURLWithPath: workspace,
+                               isDirectory: true)
+        let tmpURL = URL(fileURLWithPath: "/tmp", isDirectory: true)
+        let baseSandbox = ShellKit.Sandbox.rooted(
+            at: workspaceURL,
+            allowedHosts: [])
+        return ShellKit.Sandbox(
+            documentsDirectory: baseSandbox.documentsDirectory,
+            downloadsDirectory: baseSandbox.downloadsDirectory,
+            libraryDirectory: baseSandbox.libraryDirectory,
+            moviesDirectory: baseSandbox.moviesDirectory,
+            musicDirectory: baseSandbox.musicDirectory,
+            picturesDirectory: baseSandbox.picturesDirectory,
+            sharedPublicDirectory: baseSandbox.sharedPublicDirectory,
+            temporaryDirectory: tmpURL,
+            trashDirectory: baseSandbox.trashDirectory,
+            userDirectory: baseSandbox.userDirectory,
+            cachesDirectory: baseSandbox.cachesDirectory,
+            homeDirectory: baseSandbox.homeDirectory,
+            authorize: { url in
+                do {
+                    try await baseSandbox.authorize(url)
+                } catch let denial as ShellKit.Sandbox.Denial {
+                    // Allow virtual `/tmp` paths. Compare against the
+                    // unresolved standardized path because callers
+                    // feed virtual paths (`/tmp/foo`), not realpath'd
+                    // host paths (`/private/tmp/foo` on macOS).
+                    if url.isFileURL {
+                        let path = url.standardizedFileURL.path
+                        if path == "/tmp" || path.hasPrefix("/tmp/") {
+                            return
+                        }
+                    }
+                    throw denial
+                }
+            })
+    }
+}

--- a/Sources/swift-bash/ExecCommand.swift
+++ b/Sources/swift-bash/ExecCommand.swift
@@ -157,20 +157,19 @@ struct ExecCommand: AsyncParsableCommand {
         // (the registered SwiftPorts CLIs and the SwiftScript
         // interpreter) consult `Shell.sandbox` instead.
         //
-        // Root the URL gate at the *virtual* workspace path, not the
-        // host directory: SwiftPorts CLIs (fd, rg, jq, …) and the
-        // SwiftScript interpreter all see paths from
-        // `Shell.currentDirectory` / `Shell.resolve(_:)`, which return
-        // the bash-side virtual cwd (`workspace`). Anchoring the gate
-        // at the host path put it in a different namespace from those
-        // callers — `fd file .` always tripped "file URL is outside
-        // sandbox root" because `/batch/.` (virtual) wasn't under
-        // `/Users/.../host-root`. Migration target (#10): retire the
-        // legacy `fileSystem` overlay and have bash consult the URL
-        // gate too.
-        let urlSandbox = ShellKit.Sandbox.rooted(
-            at: URL(fileURLWithPath: workspace),
-            allowedHosts: [])
+        // `bashWorkspace(workspace:)` accepts both the virtual
+        // workspace path (where the overlay is mounted) and `/tmp`
+        // (where the overlay seeds its in-memory scratch). Without
+        // the `/tmp` carve-out, a script's `cd /tmp; fd X` trips
+        // "file URL is outside sandbox root" — the bash side
+        // considers `/tmp` valid but the URL gate, rooted only at
+        // the workspace, doesn't (#48). FileManager still walks the
+        // host's real `/tmp` after authorize succeeds, so the in-
+        // memory scratch isn't searchable from SwiftPorts CLIs — the
+        // gate error just stops being misleading. Migration target
+        // (#10): retire the legacy `fileSystem` overlay and have
+        // bash consult the URL gate too.
+        let urlSandbox = ShellKit.Sandbox.bashWorkspace(workspace: workspace)
         return ShellSetup(
             environment: env,
             fileSystem: fileSystem,

--- a/Tests/BashInterpreterTests/BashWorkspaceSandboxTests.swift
+++ b/Tests/BashInterpreterTests/BashWorkspaceSandboxTests.swift
@@ -1,0 +1,79 @@
+import Testing
+import Foundation
+import ShellKit
+@testable import BashInterpreter
+
+/// Coverage for `Sandbox.bashWorkspace(workspace:)` — the URL gate
+/// the SwiftBash `--sandbox` CLI pairs with `SandboxedOverlayFileSystem`.
+/// The gate accepts the virtual workspace mount point plus `/tmp` (where
+/// the overlay seeds its in-memory scratch), so SwiftPorts CLIs and the
+/// SwiftScript interpreter authorize the same paths the bash side
+/// considers valid. Regression coverage for #48.
+@Suite(.timeLimit(.minutes(1))) struct BashWorkspaceSandboxTests {
+
+    @Test func authorizesWorkspaceRoot() async throws {
+        let sandbox = ShellKit.Sandbox.bashWorkspace(workspace: "/batch")
+        try await sandbox.authorize(
+            URL(fileURLWithPath: "/batch/file.txt"))
+        try await sandbox.authorize(
+            URL(fileURLWithPath: "/batch/nested/dir/file"))
+    }
+
+    @Test func authorizesTmpScratchRoot() async throws {
+        // The bash overlay seeds `/tmp` as in-memory scratch and a
+        // script's `cd /tmp; fd X` lands at virtual `/tmp` —
+        // without the carve-out, every SwiftPorts CLI invocation
+        // from there tripped "file URL is outside sandbox root" (#48).
+        let sandbox = ShellKit.Sandbox.bashWorkspace(workspace: "/batch")
+        try await sandbox.authorize(URL(fileURLWithPath: "/tmp"))
+        try await sandbox.authorize(
+            URL(fileURLWithPath: "/tmp/retest_fd_repro"))
+        try await sandbox.authorize(
+            URL(fileURLWithPath: "/tmp/retest_fd_repro/data.txt"))
+    }
+
+    @Test func deniesPathsOutsideBothRoots() async throws {
+        let sandbox = ShellKit.Sandbox.bashWorkspace(workspace: "/batch")
+        await #expect(throws: ShellKit.Sandbox.Denial.self) {
+            try await sandbox.authorize(
+                URL(fileURLWithPath: "/etc/passwd"))
+        }
+        await #expect(throws: ShellKit.Sandbox.Denial.self) {
+            try await sandbox.authorize(
+                URL(fileURLWithPath: "/Users/someone/Documents"))
+        }
+    }
+
+    @Test func deniesPrefixSiblings() async throws {
+        // The classic prefix-collision bug: `/tmpfile` (no trailing
+        // slash) must not be treated as inside `/tmp`. Same for
+        // workspace prefix overlap.
+        let sandbox = ShellKit.Sandbox.bashWorkspace(workspace: "/batch")
+        await #expect(throws: ShellKit.Sandbox.Denial.self) {
+            try await sandbox.authorize(
+                URL(fileURLWithPath: "/tmpfile"))
+        }
+        await #expect(throws: ShellKit.Sandbox.Denial.self) {
+            try await sandbox.authorize(
+                URL(fileURLWithPath: "/batchwork/foo"))
+        }
+    }
+
+    @Test func deniesNonFileURLs() async throws {
+        // Non-file URLs go through the host allowlist (empty here).
+        let sandbox = ShellKit.Sandbox.bashWorkspace(workspace: "/batch")
+        await #expect(throws: ShellKit.Sandbox.Denial.self) {
+            try await sandbox.authorize(
+                URL(string: "https://example.com/")!)
+        }
+    }
+
+    @Test func temporaryDirectoryIsVirtualTmp() {
+        // `Shell.temporaryDirectory` reads `sandbox.temporaryDirectory`.
+        // Bash sets `TMPDIR=/tmp`; the sandbox must agree so SwiftJSCore's
+        // `os.tmpdir()` and similar consumers return the same virtual
+        // path the bash environment exposes.
+        let sandbox = ShellKit.Sandbox.bashWorkspace(workspace: "/batch")
+        #expect(sandbox.temporaryDirectory.path == "/tmp")
+    }
+}


### PR DESCRIPTION
## Summary

Fixes [#48](https://github.com/Cocoanetics/SwiftBash/issues/48). Under `swift-bash exec --sandbox`, the URL gate was rooted only at the virtual workspace (`/batch`). The bash overlay also seeds `/tmp` as in-memory scratch, so a script's `cd /tmp; fd X` lands `Shell.currentDirectory` at virtual `/tmp` — but the URL gate rejected every path there with `file URL is outside sandbox root`, even though the bash side considered `/tmp` valid for `mkdir`, `echo >`, and the rest of the overlay-served builtins.

New `Sandbox.bashWorkspace(workspace:)` factory in [Sandbox+BashWorkspace.swift](Sources/BashInterpreter/API/Sandbox+BashWorkspace.swift) wraps `Sandbox.rooted` to also authorize virtual `/tmp` paths, and aligns `temporaryDirectory` with the bash `TMPDIR=/tmp` (rather than the default `<workspace>/tmp`). [ExecCommand.swift:172](Sources/swift-bash/ExecCommand.swift:172) now calls it.

## Before / after

Reproduction from the issue:
```bash
$ cd /tmp
$ mkdir -p retest_fd_repro
$ echo x > retest_fd_repro/data.txt
$ fd data retest_fd_repro
```

- **Before:** `fd: file URL is outside sandbox root` (exit 2) — misleading; `/tmp` *is* writable from the bash side.
- **After:** `fd: 'retest_fd_repro' is not a directory or file` (exit 2) — honest about the architectural gap (FileManager walks real disk, where the in-memory scratch doesn't exist). Same shape as the `/batch` case from the previous fix in [#45](https://github.com/Cocoanetics/SwiftBash/pull/45).

The deeper issue — `FileManager.default` bypasses the overlay so SwiftPorts CLIs can't actually search the in-memory scratch — is still tracked at Cocoanetics/SwiftPorts#39 and the existing #10 migration note. Off-root host paths (`/etc`, `/Users`) still deny correctly; the carve-out is scoped to `/tmp` only.

## Test plan

- [x] New `BashWorkspaceSandboxTests` covers: workspace allow, `/tmp` allow, off-root deny (`/etc`, `/Users`), prefix-collision deny (`/tmpfile`, `/batchwork`), non-file URL deny, `temporaryDirectory == /tmp`.
- [x] `swift test --filter "BashWorkspaceSandboxTests|SandboxedOverlayFileSystemTests|ParsableBashCommandTests"` — 36 tests pass.
- [x] End-to-end smoke against the built `swift-bash` binary reproduces the issue's script and verifies the new error shape.
- [x] `swiftlint lint --strict` — 0 violations across 466 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)