### PR TITLE
bash: add runIsolated for separate-invocation embedders (fixes #46)

### DIFF
--- a/Docs/BashInterpreter.md
+++ b/Docs/BashInterpreter.md
@@ -91,6 +91,38 @@ sink.finish()
 `OutputSink` exposes both `.lines` (text) and `.bytes` (binary-safe)
 plus an `onWrite` synchronous hook for accumulating callers.
 
+## REPL state vs. isolated invocations
+
+`shell.run(_:)` is REPL-style: mutations a script makes — `cd`,
+`export`, `trap`, `set -e`, function definitions — stick to the
+shell so the next `run(_:)` call sees them. That's the contract
+`source`, `eval`, `find -exec`, `xargs`, and
+`sourceProfileIfPresent` all rely on:
+
+```swift
+let shell = Shell()
+try await shell.run("export FOO=1")
+try await shell.run("echo $FOO")          // → 1
+```
+
+Embedders that want each call to be a **separate invocation** — an
+LLM-agent `bash` tool where one call's `cd /tmp` or `trap … EXIT`
+must not leak into the next — use `runIsolated(_:)` (or its
+capturing variant `runCapturingIsolated(_:)`). It runs the script
+in a fresh `copy()` of this shell, so the in-memory shell state
+(env, cwd, traps, set/shopt options, function definitions) is
+discarded when the call returns:
+
+```swift
+try await shell.runIsolated("cd /tmp; export X=leak")
+try await shell.runIsolated("echo $PWD $X")   // → / (nothing for X)
+```
+
+Side effects that aren't in-memory shell state — filesystem writes,
+network requests, background jobs in `processTable`, output to the
+sinks — still propagate, because the subshell shares those by
+reference. Only the variables, cwd, traps, and option flags reset.
+
 ## The `Shell` is a `@TaskLocal`
 
 `Shell.current` is the active shell during dispatch — every command,

--- a/Sources/BashInterpreter/API/Shell+Isolated.swift
+++ b/Sources/BashInterpreter/API/Shell+Isolated.swift
@@ -1,0 +1,47 @@
+import Foundation
+
+extension Shell {
+
+    /// Execute `source` as if it were a separate bash process
+    /// invocation. State changes a script makes while it runs
+    /// (working directory, exported variables, traps, `set -e`
+    /// flags, `shopt`, function definitions, positional parameters)
+    /// land on a fresh subshell created via ``copy()`` and **do not**
+    /// propagate back to `self`. The next ``runIsolated(_:)`` call
+    /// therefore starts from the same baseline as the first.
+    ///
+    /// Use this when each call is a distinct invocation from the
+    /// embedder's point of view — for example, an LLM-agent `bash`
+    /// tool where one tool call's `cd /tmp` or `trap … EXIT` must
+    /// not leak into the next. The contract matches `bash -c '…'`:
+    /// each invocation is its own shell.
+    ///
+    /// Contrast with ``run(_:)``, which mutates this shell so
+    /// `cd`/`export`/`trap` accumulate across calls — the right
+    /// choice for REPL-style embedders and for `eval` / `source` /
+    /// `.profile` loading paths where state propagation is the
+    /// whole point.
+    ///
+    /// Side effects that aren't shell-local state still propagate
+    /// because they travel through references the subshell shares
+    /// with `self`: filesystem writes (same ``fileSystem``),
+    /// background jobs (same ``processTable``), output (same
+    /// ``stdout`` / ``stderr`` sinks). A script that writes a file
+    /// and registers a trap that touches that file will still see
+    /// the write — only the in-memory trap registration and env
+    /// vars are confined.
+    @discardableResult
+    public func runIsolated(_ source: String) async throws -> ExitStatus {
+        return try await copy().run(source)
+    }
+
+    /// Capturing variant of ``runIsolated(_:)``. Runs `source` in
+    /// a fresh ``copy()`` of this shell with private `stdout` /
+    /// `stderr` sinks, waits for the script to finish, and returns
+    /// the captured text plus the exit status. The parent shell's
+    /// stdio is untouched and no state changes leak back.
+    @discardableResult
+    public func runCapturingIsolated(_ source: String) async throws -> CapturedRun {
+        return try await copy().runCapturing(source)
+    }
+}

--- a/Sources/BashInterpreter/API/Shell.swift
+++ b/Sources/BashInterpreter/API/Shell.swift
@@ -569,6 +569,7 @@ public final class Shell: ShellKit.Shell, @unchecked Sendable {
         bash.currentSource = currentSource
         bash.scriptInterpreters = scriptInterpreters
         bash.interactivePresenter = interactivePresenter
+        bash.interactive = interactive
         bash.stdoutIsTTY = stdoutIsTTY
         bash.stdinIsTTY = stdinIsTTY
         bash.stderrIsTTY = stderrIsTTY

--- a/Sources/BashInterpreter/Execution/Shell+Run.swift
+++ b/Sources/BashInterpreter/Execution/Shell+Run.swift
@@ -37,6 +37,18 @@ extension Shell {
 
     /// Parse and execute a bash source string. Returns the exit status of
     /// the last command run (or `.success` if the input was empty).
+    ///
+    /// **State propagates.** A script that runs `cd /tmp`, `export X=1`,
+    /// or `trap 'echo bye' EXIT` mutates `self`, so a later
+    /// ``run(_:)`` call on the same `Shell` sees the new cwd, the
+    /// exported variable, and (until cleared) the trap. This is the
+    /// REPL contract — `source`, `eval`, `find -exec`, and
+    /// ``Shell/sourceProfileIfPresent(at:filenames:)`` all rely on it.
+    ///
+    /// Embedders running each call as an independent "invocation"
+    /// (e.g. an LLM-agent `bash` tool whose calls shouldn't share
+    /// state) should use ``runIsolated(_:)`` instead — that variant
+    /// confines mutations to a fresh subshell.
     @discardableResult
     public func run(_ source: String) async throws -> ExitStatus {
         let parts = try BashSyntax.parse(source)

--- a/Tests/BashInterpreterTests/RunIsolatedTests.swift
+++ b/Tests/BashInterpreterTests/RunIsolatedTests.swift
@@ -99,10 +99,13 @@ import Testing
     /// isolated invocation, so a file the run writes is visible to the
     /// next call. Only the in-memory shell state (env, traps, cwd) is
     /// confined to the subshell.
+    ///
+    /// Uses `NSTemporaryDirectory()` rather than `/tmp` so the test
+    /// runs on Windows too (where `/tmp` doesn't exist).
     @Test func fileSystemSideEffectsPropagateAcrossRunIsolated() async throws {
         let cap = CapturingShell()
-        cap.shell.environment.workingDirectory = "/"
-        let marker = "/tmp/swift-bash-runIsolated-\(UUID().uuidString)"
+        let marker = NSTemporaryDirectory()
+            + "swift-bash-runIsolated-\(UUID().uuidString)"
         defer { try? FileManager.default.removeItem(atPath: marker) }
 
         _ = try await cap.shell.runIsolated("echo hi > '\(marker)'")

--- a/Tests/BashInterpreterTests/RunIsolatedTests.swift
+++ b/Tests/BashInterpreterTests/RunIsolatedTests.swift
@@ -1,0 +1,125 @@
+import Foundation
+import Testing
+@testable import BashInterpreter
+
+/// Coverage for ``Shell/runIsolated(_:)`` / ``Shell/runCapturingIsolated(_:)``
+/// — the "each call is its own bash process invocation" entry point.
+///
+/// The companion ``Shell/run(_:)`` path keeps REPL semantics (state
+/// propagates so `source` / `eval` / profile loading work). Tests for
+/// that contract live in `BuiltinsTests` and elsewhere.
+@Suite(.timeLimit(.minutes(1))) struct RunIsolatedTests {
+
+    // MARK: - issue #46 — state must not leak across runIsolated calls
+
+    /// Working directory mutations made by the first call don't show
+    /// up in the second. Both calls land on the same starting cwd.
+    @Test func cwdDoesNotLeakAcrossRunIsolated() async throws {
+        let cap = CapturingShell()
+        cap.shell.environment.workingDirectory = "/"
+
+        _ = try await cap.shell.runIsolated("cd /tmp")
+        #expect(cap.shell.environment.workingDirectory == "/")
+
+        let pwd = try await cap.shell.runCapturingIsolated("pwd")
+        #expect(pwd.stdout == "/\n")
+    }
+
+    /// `export` in an isolated call doesn't propagate to the parent
+    /// shell or to a later isolated call.
+    @Test func exportedVarsDoNotLeakAcrossRunIsolated() async throws {
+        let cap = CapturingShell()
+
+        _ = try await cap.shell.runIsolated("export STATE_LEAK_TEST=leaked_value")
+        #expect(cap.shell.environment["STATE_LEAK_TEST"] == nil)
+
+        let second = try await cap.shell.runCapturingIsolated(
+            #"echo "STATE_LEAK_TEST=${STATE_LEAK_TEST-unset}""#)
+        #expect(second.stdout == "STATE_LEAK_TEST=unset\n")
+    }
+
+    /// A `trap … EXIT` registered in the first invocation must NOT
+    /// be visible (or fire again) in the second. The trap still fires
+    /// once at the end of its own invocation, so anything it writes
+    /// to the filesystem is observable — that's correct EXIT semantics,
+    /// matching real bash.
+    @Test func exitTrapDoesNotLeakAcrossRunIsolated() async throws {
+        let cap = CapturingShell()
+
+        let first = try await cap.shell.runCapturingIsolated(
+            "trap 'echo trap_fired' EXIT")
+        // Trap fires when the isolated invocation ends.
+        #expect(first.stdout == "trap_fired\n")
+        // … but the parent shell has no leftover trap.
+        #expect(cap.shell.traps["EXIT"] == nil)
+
+        let second = try await cap.shell.runCapturingIsolated(
+            #"echo "TRAP=$(trap -p EXIT)""#)
+        // Second invocation sees no trap from the first.
+        #expect(second.stdout == "TRAP=\n")
+    }
+
+    /// `set -e` in the first invocation must not stick to the parent
+    /// (it's a per-process flag in real bash).
+    @Test func setOptionsDoNotLeakAcrossRunIsolated() async throws {
+        let cap = CapturingShell()
+
+        _ = try await cap.shell.runIsolated("set -e")
+        #expect(cap.shell.errexit == false)
+
+        _ = try await cap.shell.runIsolated("set -u")
+        #expect(cap.shell.nounset == false)
+    }
+
+    /// Function definitions made in one invocation don't carry into the
+    /// next — each is its own shell.
+    @Test func functionDefinitionsDoNotLeakAcrossRunIsolated() async throws {
+        let cap = CapturingShell()
+
+        _ = try await cap.shell.runIsolated("greet() { echo hi; }")
+
+        let result = try await cap.shell.runCapturingIsolated("greet")
+        #expect(result.exitStatus == ExitStatus(127))
+        #expect(result.stderr.contains("greet"))
+    }
+
+    // MARK: - parent-shell state IS visible inside an isolated run
+
+    /// Variables set on the parent shell before the call are visible
+    /// inside the isolated run (copy semantics, not "blank slate").
+    @Test func parentEnvVisibleInsideRunIsolated() async throws {
+        let cap = CapturingShell()
+        cap.shell.environment["GREETING"] = "hello"
+
+        let result = try await cap.shell.runCapturingIsolated("echo $GREETING")
+        #expect(result.stdout == "hello\n")
+    }
+
+    /// Filesystem and process table are shared by reference across an
+    /// isolated invocation, so a file the run writes is visible to the
+    /// next call. Only the in-memory shell state (env, traps, cwd) is
+    /// confined to the subshell.
+    @Test func fileSystemSideEffectsPropagateAcrossRunIsolated() async throws {
+        let cap = CapturingShell()
+        cap.shell.environment.workingDirectory = "/"
+        let marker = "/tmp/swift-bash-runIsolated-\(UUID().uuidString)"
+        defer { try? FileManager.default.removeItem(atPath: marker) }
+
+        _ = try await cap.shell.runIsolated("echo hi > '\(marker)'")
+
+        let check = try await cap.shell.runCapturingIsolated(
+            "[ -f '\(marker)' ] && echo present || echo missing")
+        #expect(check.stdout == "present\n")
+    }
+
+    // MARK: - persistent run() still propagates (regression guard)
+
+    /// Sanity check that the persistent ``run(_:)`` path keeps its
+    /// REPL contract — exports persist for the next ``run(_:)`` call
+    /// on the same shell.
+    @Test func runStillPropagatesStateByDesign() async throws {
+        let cap = CapturingShell()
+        try await cap.shell.run("export PERSIST_VAR=persistent")
+        #expect(cap.shell.environment["PERSIST_VAR"] == "persistent")
+    }
+}

--- a/Tests/BashInterpreterTests/RunIsolatedTests.swift
+++ b/Tests/BashInterpreterTests/RunIsolatedTests.swift
@@ -112,6 +112,24 @@ import Testing
         #expect(check.stdout == "present\n")
     }
 
+    /// The parent shell's `interactive` flag (iBash-style REPL
+    /// formatting: drop `: line N:` from diagnostics) must carry into
+    /// the isolated subshell. Without this an embedder that switches
+    /// its captured path from `runCapturing` to `runCapturingIsolated`
+    /// would suddenly see `iBash: line 1: foo: command not found`
+    /// instead of `iBash: foo: command not found`.
+    @Test func interactiveFlagPropagatesIntoRunIsolated() async throws {
+        let cap = CapturingShell()
+        cap.shell.scriptName = "iBash"
+        cap.shell.interactive = true
+
+        let result = try await cap.shell.runCapturingIsolated("nosuchcommand")
+        #expect(result.stderr == "iBash: nosuchcommand: command not found\n")
+        // Parent stayed interactive — sanity check the flag itself
+        // didn't leak the wrong direction either.
+        #expect(cap.shell.interactive == true)
+    }
+
     // MARK: - persistent run() still propagates (regression guard)
 
     /// Sanity check that the persistent ``run(_:)`` path keeps its


### PR DESCRIPTION
## Summary

- Adds `Shell.runIsolated(_:)` and `Shell.runCapturingIsolated(_:)` — explicit "this call is its own bash process invocation" entry points. Each runs the script in a fresh `copy()` of the shell, so cwd / exported vars / traps / `set` & `shopt` flags / function definitions don't propagate back to `self`. Filesystem, `processTable`, and stdio sinks remain shared by reference, so external side effects still happen.
- Documents `Shell.run(_:)`'s REPL contract explicitly in its docstring and points at `runIsolated` for the agent-style use case.
- Adds a new "REPL state vs. isolated invocations" section in `Docs/BashInterpreter.md`.

## Why

Issue #46 reports that state leaks across separate SwiftBash "invocations" when an embedder reuses one `Shell` instance. The leak is real for callers that drive a shell with repeated `shell.run(...)` calls (e.g. an LLM-agent bash tool): `Shell.run` mutates `self`, so `cd /tmp`, `export X=1`, and `trap … EXIT` all stick around for the next call.

We can't just flip `Shell.run` to isolate — `eval` / `source` / `find -exec` / `xargs` / `sourceProfileIfPresent` / `trap` firing all need REPL semantics (and ~1600 test sites rely on them too). So this adds isolation as an opt-in alongside, and documents which axis is which.

Embedders that need fresh-state-per-call (e.g. iBash's coder bash runner) switch their captured path from `shell.runCapturing(source)` → `shell.runCapturingIsolated(source)`. The interactive terminal keeps `run(_:)`.

## Test plan

- [x] `swift test --no-parallel` — 1935 → 1943 tests, all green
- [x] New `RunIsolatedTests` suite covers each leak axis the issue calls out (cwd, exported vars, EXIT trap, `set -e/-u`, function definitions) plus the "parent env IS visible inside the isolated call / FS side effects DO propagate / `run` keeps its REPL contract" complements.

🤖 Generated with [Claude Code](https://claude.com/claude-code)