### PR TITLE
Own `BinCatalog` in BashInterpreter (move it out of the ShellKit leaf)

### DIFF
--- a/Sources/BashInterpreter/API/BashProcessLauncher.swift
+++ b/Sources/BashInterpreter/API/BashProcessLauncher.swift
@@ -18,10 +18,10 @@ import ShellKit
 /// - ``Executable/name(_:)`` is looked up by the supplied name as-is.
 /// - ``Executable/path(_:)`` resolves only when the supplied path
 ///   matches the canonical bin location for the name in
-///   ``ShellKit/BinCatalog`` (so `/bin/echo` and `/usr/bin/jq`
+///   ``BinCatalog`` (so `/bin/echo` and `/usr/bin/jq`
 ///   resolve, but `/tmp/echo` doesn't — that one would be running
 ///   *some* file on disk under a different command shape, not the
-///   registered `echo`). Mirrors ``VirtualBinFileSystem``'s
+///   registered `echo`). Mirrors ``BinCatalogOverlay``'s
 ///   synthesized-file rule on the bash side.
 /// - A miss throws ``ProcessLaunchUnresolved`` — for SwiftBash that
 ///   means "command not found." Bash itself never composes through

--- a/Sources/BashInterpreter/FileSystems/BinCatalog.swift
+++ b/Sources/BashInterpreter/FileSystems/BinCatalog.swift
@@ -1,0 +1,109 @@
+import Foundation
+
+/// Canonical "where this command would live on a real macOS system"
+/// catalog, owned by `BashInterpreter`.
+///
+/// Two consumers, both in this module:
+///
+/// 1. ``Shell/install(_:)`` (the bare, catalog-default overload) reads
+///    a command's canonical install path from ``knownPaths``.
+/// 2. ``BinCatalogOverlay`` takes the *directory geometry* of the
+///    synthetic `/bin`, `/usr/bin`, and `/usr/local/bin` from
+///    ``knownDirectories``. The *files* inside those directories come
+///    from the live command registry (``Shell/commandsByPath``), not
+///    from this map — so a command shows up wherever it's actually
+///    installed, cataloged or not.
+///
+/// The catalog is a static map of *known* command names → canonical
+/// absolute path. Names not in the map are treated as shell-only
+/// built-ins (`cd`, `export`, `eval`, …) — they have no file on disk.
+///
+/// It mirrors what a recent macOS ships under `/bin` and `/usr/bin`.
+/// When a command is both a bash built-in *and* a file on disk
+/// (`echo`, `printf`, `pwd`, `test`, `[`, `kill`, `wait`, `true`,
+/// `false`), the file path wins — matching what `/usr/bin/which`
+/// reports on a real macOS system.
+enum BinCatalog {
+
+    /// Map of command name → canonical absolute path. Names not in
+    /// this map are treated as shell-only built-ins.
+    static let knownPaths: [String: String] = {
+        var paths: [String: String] = [:]
+
+        // /bin — the small set of commands macOS keeps in /bin.
+        for name in [
+            "bash", "cat", "chmod", "cp", "dash", "date", "dd", "df",
+            "echo", "expr", "hostname", "kill", "link", "ln", "ls",
+            "mkdir", "mv", "ps", "pwd", "realpath", "rm", "rmdir",
+            "sh", "sleep", "stty", "sync", "test", "[", "unlink"
+        ] { paths[name] = "/bin/\(name)" }
+
+        // /usr/bin — everything else we ship that would normally be
+        // installed there on macOS. The trailing group (`clear`,
+        // `open`, `pbcopy`, `pbpaste`, `say`) are macOS-specific
+        // tools; embedders register them through their own platform
+        // shim (iBash's `AppleBuiltins`) but the canonical install
+        // location is `/usr/bin` on real macOS, so listings here
+        // match what users see on their host.
+        for name in [
+            "awk", "base64", "basename", "bc", "cmp", "column", "comm",
+            "cut", "diff", "dirname", "du", "egrep", "env", "expand",
+            "false", "fgrep", "find", "fold", "gunzip", "groups",
+            "gzip", "head", "id", "join", "jq", "less", "md5", "md5sum",
+            "mktemp", "more", "nl", "od", "paste", "patch", "pgrep", "pkill",
+            "printenv", "printf", "readlink", "rev", "sed", "seq",
+            "sha1sum", "sha256sum", "shasum", "sort", "split",
+            "stat", "strings", "tac", "tail", "tar", "tee", "time",
+            "timeout", "touch", "tr", "tree", "true", "truncate",
+            "uname", "unexpand", "uniq", "wait", "wc", "which",
+            "whoami", "xargs", "xattr", "xxd", "yes",
+            "clear", "open", "pbcopy", "pbpaste", "say"
+        ] { paths[name] = "/usr/bin/\(name)" }
+
+        // Third-party commonly-installed utilities (Homebrew /
+        // user-installed). We slot them under /usr/local/bin so
+        // their location matches the convention macOS users expect.
+        for name in [
+            "rg", "yq",
+            // SwiftPorts CLI surface — git/gh/glab and the
+            // compression family ship via the BashCommandKit /
+            // SwiftPorts registration, but `which` and `compgen -c`
+            // still need a canonical path entry to find them.
+            "git", "gh", "glab",
+            "zip", "unzip",
+            "bzip2", "bunzip2", "bzcat",
+            "zstd", "unzstd", "zstdcat",
+            "xz", "unxz", "xzcat",
+            "lz4", "unlz4", "lz4cat", "zcat",
+            // In-process script interpreters. Both routes work —
+            // `swift-js hello.js` finds the closure command in
+            // `shell.commands`, and `#!/usr/bin/env swift-js` finds
+            // the matching ``ScriptInterpreter`` — and they share
+            // backing logic. The catalog entry is here so
+            // `which swift-js` reports `/usr/local/bin/swift-js`
+            // rather than dropping back to "not found".
+            "swift", "swift-script", "swift-js", "node", "bun"
+        ] {
+            paths[name] = "/usr/local/bin/\(name)"
+        }
+
+        // Embedder-supplied CLIs that ship as primary system tools
+        // belong in /usr/bin alongside `awk`, `sed`, `find`, etc.
+        // Whether `coder` actually surfaces in `ls /usr/bin` depends
+        // on whether the host shell registers it; this entry just
+        // declares where it WOULD live on a hypothetical "real"
+        // install.
+        paths["coder"] = "/usr/bin/coder"
+
+        // `curl` ships at /usr/bin/curl on macOS.
+        paths["curl"] = "/usr/bin/curl"
+
+        return paths
+    }()
+
+    /// All directories that contain at least one entry. Drives the
+    /// directory geometry the synthetic FS overlay exposes.
+    static let knownDirectories: Set<String> = {
+        Set(knownPaths.values.map { ($0 as NSString).deletingLastPathComponent })
+    }()
+}

--- a/Tests/BashInterpreterTests/BashProcessLauncherTests.swift
+++ b/Tests/BashInterpreterTests/BashProcessLauncherTests.swift
@@ -45,7 +45,7 @@ import Testing
     @Test func launcherDispatchesCanonicalBinPath() async throws {
         // `Executable.path("/bin/echo")` should reach the shell's
         // registered `echo` — that's the canonical bin path per
-        // `BinCatalog`, so it matches `VirtualBinFileSystem`'s
+        // `BinCatalog`, so it matches `BinCatalogOverlay`'s
         // synthesized-file rule on the bash side.
         let shell = Shell()
         shell.installShellBuiltin(name: "echo") { argv in

--- a/Tests/BashSwiftScriptTests/BashSwiftScriptTests.swift
+++ b/Tests/BashSwiftScriptTests/BashSwiftScriptTests.swift
@@ -297,7 +297,7 @@ import ShellKit
         // `BashProcessLauncher` against `BinCatalog.knownPaths` — the
         // canonical path matches, so it dispatches to the registered
         // `echo` builtin (not the host'shell `/bin/echo`). Mirrors the
-        // `VirtualBinFileSystem` synthesized-file rule from the bash
+        // `BinCatalogOverlay` synthesized-file rule from the bash
         // side.
         //
         // To make the routing visible (host `/bin/echo` produces


### PR DESCRIPTION
Relocates `BinCatalog` from the ShellKit leaf into SwiftBash. Closes #62.

`BinCatalog`'s only consumers are in `BashInterpreter` (bare `install(_:)` default-path lookup + `BinCatalogOverlay`'s directory geometry), and its contents are this shell's builtin surface (`swift-js`, `coder`, `glab`, `git`, the compression family) — shell policy, not generic host knowledge. ShellKit itself never referenced it.

### Changes
- New `Sources/BashInterpreter/FileSystems/BinCatalog.swift`, `internal` (no consumer outside BashInterpreter; was `public` only for the cross-module access it no longer needs). Drops the unused `names(in:)` and the dead `VirtualBinFileSystem` doc references.
- Fix stale `VirtualBinFileSystem` mentions in `BashProcessLauncher` and two test comments.

### Coordination
- Companion: **Cocoanetics/ShellKit#7** removes the now-dead copy.
- The local `BinCatalog` **shadows** ShellKit's still-present re-exported one (`@_exported import ShellKit`) — verified: `BashInterpreter` builds against ShellKit `main`. So **merge this first**, then the ShellKit removal (reverse order would briefly break SwiftBash `main`).
- Stacked on #61 (base `feat/sqlite3-builtin`) so the diff is just the move; GitHub retargets it to `main` once #61 lands.

### Verified
- Final state (local `BinCatalog` + ShellKit without it, via `swift package edit`): `swift build` + overlay/path/launcher/swift-script suites green.
- Transition state (ShellKit `main` still has it): `BashInterpreter` builds (shadowing).
- iBash macOS app builds against the combined local state.