### PR TITLE
BashCommandKit: register sqlite3 from SwiftPorts Sqlite3Shell (works on Android)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -76,7 +76,10 @@ let swiftPortsCommandProducts: [Target.Dependency] = buildingForAndroid ? [] : [
     .product(name: "Lz4Command", package: "SwiftPorts"),
     .product(name: "RgCommand", package: "SwiftPorts"),
     .product(name: "FdCommand", package: "SwiftPorts"),
-    .product(name: "Sqlite3Command", package: "SwiftPorts"),
+    // NB: sqlite3 is NOT here. It's registered from the
+    // ArgumentParser-free `Sqlite3Shell` product (a direct, unconditional
+    // BashCommandKit dependency below) so the `sqlite3` builtin works on
+    // Android too — see `Shell+Sqlite3.swift`.
 ]
 
 var products: [Product] = [
@@ -192,8 +195,14 @@ let package = Package(
                 "BashInterpreter",
                 .product(name: "ArgumentParser", package: "swift-argument-parser"),
                 .product(name: "Crypto", package: "swift-crypto"),
-                // The SwiftPorts CLI family (jq / gh / glab / git / the
-                // archive + compression set / rg / fd / sqlite3),
+                // sqlite3's shell driver — SwiftPorts' ArgumentParser-free
+                // `Sqlite3Shell` (Parser + `Sqlite3Executable`). Depended on
+                // unconditionally (incl. Android): it builds wherever
+                // SQLiteKit does, and `Shell+Sqlite3.swift` registers the
+                // `sqlite3` builtin from it via a native ShellKit command.
+                .product(name: "Sqlite3Shell", package: "SwiftPorts"),
+                // The rest of the SwiftPorts CLI family (jq / gh / glab /
+                // git / the archive + compression set / rg / fd),
                 // registered as builtins by `registerSwiftPortsCommands()`.
                 // Each reads/writes through `Shell.current`, so pipes /
                 // redirection / `$(...)` capture all just work. The list

--- a/Sources/BashCommandKit/API/Shell+Sqlite3.swift
+++ b/Sources/BashCommandKit/API/Shell+Sqlite3.swift
@@ -1,0 +1,70 @@
+import BashInterpreter
+import Sqlite3Shell
+
+extension Shell {
+
+    /// Register `sqlite3` — SwiftPorts' SQLite shell port — as a builtin.
+    ///
+    /// Unlike the rest of the SwiftPorts CLI family (`jq` / `gh` / `git` /
+    /// the archive + compression set), which ``registerSwiftPortsCommands()``
+    /// installs from ArgumentParser-based `*Command` products and which are
+    /// dropped on Android, `sqlite3` is driven through the
+    /// ArgumentParser-free ``Sqlite3Shell/Sqlite3Executable`` via a native
+    /// ShellKit ``Command``. That target builds on every platform, so this
+    /// builtin works everywhere — Android included. It is therefore
+    /// registered unconditionally from ``registerStandardCommands()``,
+    /// outside the `#if !os(Android)` gate the rest of the family sits behind.
+    ///
+    /// The driver reads/writes through ``Shell/current`` (stdin / stdout /
+    /// stderr) and resolves + authorizes database / `.read` / `.backup`
+    /// paths through the host sandbox, so the builtin participates fully in
+    /// pipes / `<` `>` redirection / `$(...)` capture, exactly like the
+    /// bridged ones.
+    ///
+    /// Installed at `/usr/bin/sqlite3` (where real macOS ships it); it isn't
+    /// in `BinCatalog`, so the explicit-path overload is used. The
+    /// registry-driven `BinCatalogOverlay` surfaces it under `/usr/bin` from
+    /// this install alone, so `ls /usr/bin/sqlite3`, `[ -x … ]`, and
+    /// tool-presence checks all succeed — not just `which sqlite3`.
+    public func registerSqlite3() {
+        install(Sqlite3Builtin(), at: "/usr/bin/sqlite3")
+    }
+}
+
+/// Bridges SwiftPorts' ``Sqlite3Shell/Sqlite3Executable`` (the
+/// ArgumentParser-free `sqlite3` driver) to a ShellKit ``Command``.
+///
+/// The whole argv is handed to the driver, which does SQLite's single-dash
+/// long-option parsing (`-csv`, `-header`, `-separator X`, …), dot-command
+/// dispatch, and the REPL itself — no ArgumentParser involved, so this
+/// compiles and runs on Android where the `Sqlite3` `AsyncParsableCommand`
+/// wrapper can't. The bridged ``AsyncParsableCommandBridge`` it replaces was
+/// pure passthrough for this command anyway (the `Sqlite3` type captures
+/// argv with `.captureForPassthrough` and forwards it verbatim), so behavior
+/// is unchanged on the platforms that had it.
+struct Sqlite3Builtin: Command {
+    let name = "sqlite3"
+
+    func run(_ argv: [String]) async throws -> ExitStatus {
+        // `Sqlite3Executable` expects argv without the command name, per the
+        // `execve` convention `ArgumentParserBridge.dispatch` also follows.
+        let args = Array(argv.dropFirst())
+
+        // Uniform GNU-style `--version` banner, matching
+        // `ArgumentParserBridge.dispatch` (the path the other builtins take).
+        // `sqlite3 -version` (single dash, the spelling real sqlite3 uses)
+        // is left to the driver, which reports the SQLite library version.
+        if args.first == "--version" {
+            Shell.bashCurrent.stdout(
+                "sqlite3 (SwiftBash) \(SwiftBashVersion.packageVersion)\n")
+            return .success
+        }
+
+        let code = try await Sqlite3Executable.run(
+            argv: args,
+            stdin: Shell.current.stdin,
+            stdout: Shell.current.stdout,
+            stderr: Shell.current.stderr)
+        return ExitStatus(code)
+    }
+}

--- a/Sources/BashCommandKit/API/Shell+StandardCommands.swift
+++ b/Sources/BashCommandKit/API/Shell+StandardCommands.swift
@@ -173,6 +173,13 @@ extension Shell {
         registerSwiftPortsCommands()
         #endif
 
+        // sqlite3 — registered unconditionally (Android included). It drives
+        // SwiftPorts' ArgumentParser-free `Sqlite3Shell` via a native
+        // ShellKit command rather than the Android-dropped `*Command`
+        // layer, so it builds and runs on every platform. See
+        // `Shell+Sqlite3.swift`.
+        registerSqlite3()
+
         // fgrep / egrep are thin grep aliases. Resolve `grep` from the
         // *running* shell rather than capturing the registering shell —
         // works correctly inside subshells too, and avoids reference

--- a/Sources/BashCommandKit/API/Shell+SwiftPortsCommands.swift
+++ b/Sources/BashCommandKit/API/Shell+SwiftPortsCommands.swift
@@ -21,7 +21,6 @@ import GzipCommand
 import JqCommand
 import Lz4Command
 import RgCommand
-import Sqlite3Command
 import TarCommand
 import UnzipCommand
 import XzCommand
@@ -101,14 +100,12 @@ extension Shell {
         // convention used for the rest of the SwiftPorts surface.
         install(FdCommand.self, at: "/usr/local/bin/fd")
 
-        // sqlite3 — SwiftPorts' SQLite shell port over the vendored
-        // CSQLite amalgamation. Like fd, it isn't in ShellKit's
-        // BinCatalog, so use the explicit-path overload (real macOS
-        // ships it at /usr/bin/sqlite3); bare install(_:) would trap.
-        // The registry-driven BinCatalogOverlay surfaces it under
-        // /usr/bin from this install alone, so `ls`/`[ -x ]`/presence
-        // checks work without any BinCatalog (ShellKit) change.
-        install(Sqlite3.self, at: "/usr/bin/sqlite3")
+        // NB: `sqlite3` is registered separately by `registerSqlite3()`
+        // (called unconditionally from `registerStandardCommands()`), not
+        // here. It drives SwiftPorts' ArgumentParser-free `Sqlite3Shell`
+        // through a native ShellKit command, so it works on Android too —
+        // unlike this `#if !os(Android)`-gated family. See
+        // `Shell+Sqlite3.swift`.
 
         // Archive family.
         install(TarCommand.self)

--- a/Tests/BashCommandKitTests/Sqlite3CommandTests.swift
+++ b/Tests/BashCommandKitTests/Sqlite3CommandTests.swift
@@ -1,0 +1,101 @@
+import Testing
+import Foundation
+@testable import BashInterpreter
+@testable import BashCommandKit
+
+/// `sqlite3` is registered (via `registerSqlite3()`) from SwiftPorts'
+/// ArgumentParser-free `Sqlite3Shell` driver through a native ShellKit
+/// command, so — unlike the rest of the SwiftPorts CLI family — it builds
+/// and runs on every platform. These tests are intentionally **not** gated
+/// off Android: they run on the emulator in CI and are what proves the
+/// `sqlite3` builtin works there.
+@Suite(.timeLimit(.minutes(1))) struct Sqlite3CommandTests {
+
+    private func makeShell() throws -> (CapturingShell, String) {
+        let base = NSTemporaryDirectory()
+        let dir = (base as NSString).appendingPathComponent("sqlite3-\(UUID())")
+        try FileManager.default.createDirectory(
+            atPath: dir, withIntermediateDirectories: true)
+        let cap = CapturingShell()
+        cap.shell.registerStandardCommands()
+        cap.shell.environment.workingDirectory = dir
+        return (cap, dir)
+    }
+
+    private func cleanup(_ path: String) {
+        try? FileManager.default.removeItem(atPath: path)
+    }
+
+    @Test func inlineSelectAgainstMemory() async throws {
+        let (cap, dir) = try makeShell(); defer { cleanup(dir) }
+        let status = try await cap.shell.run("sqlite3 :memory: \"SELECT 1 + 1;\"")
+        #expect(status == .success)
+        #expect(cap.stdout == "2\n")
+    }
+
+    @Test func multiStatementInlineCrud() async throws {
+        let (cap, dir) = try makeShell(); defer { cleanup(dir) }
+        let status = try await cap.shell.run(
+            "sqlite3 :memory: \"CREATE TABLE t(id INTEGER PRIMARY KEY, name TEXT);"
+            + " INSERT INTO t(name) VALUES('a'),('b'); SELECT id || ':' || name FROM t;\"")
+        #expect(status == .success)
+        #expect(cap.stdout == "1:a\n2:b\n")
+    }
+
+    @Test func scriptViaStdin() async throws {
+        let (cap, dir) = try makeShell(); defer { cleanup(dir) }
+        // Feed SQL on stdin (no trailing SQL arg) — the read-all-stdin path.
+        try await cap.shell.run(
+            "printf 'CREATE TABLE t(x);\\nINSERT INTO t VALUES(7),(8);\\nSELECT sum(x) FROM t;\\n'"
+            + " | sqlite3 :memory:")
+        #expect(cap.stdout == "15\n")
+    }
+
+    @Test func csvModeWithHeader() async throws {
+        let (cap, dir) = try makeShell(); defer { cleanup(dir) }
+        try await cap.shell.run(
+            "sqlite3 -csv -header :memory: \"SELECT 1 AS a, 'x' AS b;\"")
+        #expect(cap.stdout == "a,b\n1,x\n")
+    }
+
+    @Test func dotTablesIntrospection() async throws {
+        let (cap, dir) = try makeShell(); defer { cleanup(dir) }
+        try await cap.shell.run(
+            "printf 'CREATE TABLE foo(a);\\nCREATE TABLE bar(b);\\n.tables\\n' | sqlite3 :memory:")
+        #expect(cap.stdout.contains("foo"))
+        #expect(cap.stdout.contains("bar"))
+    }
+
+    /// A file-backed database round-trips across two invocations — this
+    /// drives `Shell.resolve` + `Shell.authorize` (the sandbox gate), the
+    /// path that distinguishes the in-process port from a forked binary.
+    @Test func fileBackedRoundTrip() async throws {
+        let (cap, dir) = try makeShell(); defer { cleanup(dir) }
+        let create = try await cap.shell.run(
+            "sqlite3 data.db \"CREATE TABLE t(x); INSERT INTO t VALUES(42);\"")
+        #expect(create == .success)
+        let read = try await cap.shell.run("sqlite3 data.db \"SELECT x FROM t;\"")
+        #expect(read == .success)
+        #expect(cap.stdout == "42\n")
+        // The database file actually landed on disk in the working dir.
+        #expect(FileManager.default.fileExists(
+            atPath: (dir as NSString).appendingPathComponent("data.db")))
+    }
+
+    @Test func doubleDashVersionGivesUniformBanner() async throws {
+        let (cap, dir) = try makeShell(); defer { cleanup(dir) }
+        // `--version` (double dash) gets SwiftBash's uniform builtin banner,
+        // matching the ArgumentParser bridge the other commands route through.
+        try await cap.shell.run("sqlite3 --version")
+        #expect(cap.stdout == "sqlite3 (SwiftBash) \(SwiftBashVersion.packageVersion)\n")
+    }
+
+    @Test func singleDashVersionGivesSQLiteVersion() async throws {
+        let (cap, dir) = try makeShell(); defer { cleanup(dir) }
+        // `-version` (single dash, real sqlite3's spelling) is handled by the
+        // driver and reports the SQLite library version, not the banner.
+        try await cap.shell.run("sqlite3 -version")
+        #expect(cap.stdout.hasSuffix(" (64-bit)\n"))
+        #expect(!cap.stdout.contains("SwiftBash"))
+    }
+}


### PR DESCRIPTION
## Summary

Makes the `sqlite3` builtin work on **every** platform, Android included.

Previously `sqlite3` was dropped on Android along with the rest of the SwiftPorts ArgumentParser `*Command` family (the explicit-module scanner trips a spurious `Android`↔`ArgumentParser` cycle). But the sqlite3 *driver* — SwiftPorts' `Sqlite3Executable` + `Parser` — has no ArgumentParser dependency; only the thin `Sqlite3: AsyncParsableCommand` wrapper does. It was just trapped in the dropped target.

## Upstream change (already on SwiftPorts `main`)

Cocoanetics/SwiftPorts@3552791 splits the ArgumentParser-free driver into a new `Sqlite3Shell` target that builds on Android. `Sqlite3Command` now wraps it; the `sqlite3` executable is unchanged. `Sqlite3Tests` was repointed at `Sqlite3Shell` and un-gated, so it runs on the emulator too (61 tests).

## This PR (SwiftBash)

- **Package.swift**: depend on the `Sqlite3Shell` product *unconditionally* (Android included); drop `Sqlite3Command` from the Android-gated command-product list. Pins bumped to latest `main` — ShellKit `e140863`, SwiftPorts `3552791`.
- **`Shell+Sqlite3.swift`** (new): registers `sqlite3` via a native `ShellKit.Command` (`Sqlite3Builtin`) that forwards argv to `Sqlite3Executable.run` — no ArgumentParser. Called unconditionally from `registerStandardCommands()`, outside the `#if !os(Android)` gate the rest of the family sits behind.
- **`Shell+SwiftPortsCommands.swift`**: dropped the old `install(Sqlite3.self)` + its import.
- **`Sqlite3CommandTests`** (new, NOT Android-gated): in-memory + file-backed round-trips, csv mode, `.tables`, both `--version` spellings. Runs on the Android emulator in CI — the proof the builtin works there.

Behavior is unchanged on platforms that already had it: `--version` keeps the uniform SwiftBash banner; `-version` (real sqlite3's spelling) reports the SQLite library version.

## Verification

- macOS: full build + suite green — **1951** Swift-Testing + **120** XCTest, 0 failures.
- Android gating checked via `TARGET_OS_ANDROID=1 swift package dump-package`: BashCommandKit pulls in **only** `Sqlite3Shell` (none of the `*Command` products); SwiftPorts vends `Sqlite3Shell` while dropping `Sqlite3Command`/`sqlite3`.
- The real Android emulator build/test runs in the `build-android` CI job (here and in SwiftPorts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)