### PR TITLE
stat: report the virtual identity, matching ls -l (fixes #65)

### DIFF
--- a/Sources/BashCommandKit/Commands/StatCommand.swift
+++ b/Sources/BashCommandKit/Commands/StatCommand.swift
@@ -9,8 +9,9 @@ import Foundation
 /// substituted (subset of GNU): `%n` name, `%s` size, `%y` mtime
 /// (ISO 8601 in UTC), `%F` file type word, `%a` permissions in
 /// octal, `%A` symbolic mode, `%N` quoted name (with -> for symlinks),
-/// `%U` owner user (always "user" since we don't carry uid mappings),
-/// `%G` owner group ("group"), `%h` hard link count (always 1).
+/// `%u`/`%U` owner uid/name, `%g`/`%G` group gid/name — all from the
+/// shell's virtual `HostInfo` (so `stat` agrees with `ls -l` rather
+/// than leaking the real host's ids), `%h` hard link count (always 1).
 public struct StatCommand: ParsableBashCommand {
     public static let configuration = CommandConfiguration(
         commandName: "stat",
@@ -74,6 +75,10 @@ public struct StatCommand: ParsableBashCommand {
     private func formatString(_ fmt: String, name: String,
                               meta: FileMetadata) -> String {
         var out = ""
+        // Ownership tracks the shell's virtual identity, not the
+        // backing inode — `stat` must agree with `ls -l` instead of
+        // surfacing the real host uid/gid a MountedFileSystem carries.
+        let host = Shell.bashCurrent.hostInfo
         let chars = Array(fmt)
         var index = 0
         while index < chars.count {
@@ -92,10 +97,10 @@ public struct StatCommand: ParsableBashCommand {
                     } else {
                         out += "'\(name)'"
                     }
-                case "u": out += String(meta.uid)
-                case "g": out += String(meta.gid)
-                case "U": out += "user"
-                case "G": out += "group"
+                case "u": out += String(host.uid)
+                case "g": out += String(host.gid)
+                case "U": out += host.userName
+                case "G": out += host.groupName
                 case "h": out += String(meta.linkCount)
                 case "%": out += "%"
                 default: out.append(char)
@@ -122,8 +127,10 @@ public struct StatCommand: ParsableBashCommand {
         summary += "  Size: \(meta.size)\t\(FsTools.typeWord(meta.kind))\n"
         let modeStr = String(format: "%04o", meta.mode)
         let symbolicMode = FsTools.symbolicMode(kind: meta.kind, mode: meta.mode)
-        let uidStr = String(format: "%5d", meta.uid)
-        let gidStr = String(format: "%5d", meta.gid)
+        // Virtual identity, not the backing inode (see formatString).
+        let host = Shell.bashCurrent.hostInfo
+        let uidStr = String(format: "%5d", host.uid)
+        let gidStr = String(format: "%5d", host.gid)
         summary += "Access: (\(modeStr)/\(symbolicMode))  "
         summary += "Uid: (\(uidStr))   Gid: (\(gidStr))\n"
         summary += "Access: \(FsTools.iso8601(meta.accessedAt))\n"

--- a/Tests/BashCommandKitTests/FsToolsCommandsTests.swift
+++ b/Tests/BashCommandKitTests/FsToolsCommandsTests.swift
@@ -31,6 +31,32 @@ import Foundation
         #expect(cap.stdout == "f 2\n")
     }
 
+    // Ownership must come from the shell's virtual `HostInfo`, not the
+    // real inode the temp file carries (which would leak the host's
+    // uid/gid) — `stat` has to agree with `ls -l`. Use ids distinct
+    // from both the real host and the old hardcoded "user"/"group".
+    @Test func statOwnershipTracksVirtualIdentity() async throws {
+        let (cap, dir) = try makeShellWithDir(); defer { cleanup(dir) }
+        try "x".write(toFile: dir + "/f", atomically: true, encoding: .utf8)
+        var info = cap.shell.hostInfo
+        info.uid = 4242; info.userName = "alice"
+        info.gid = 99; info.groupName = "crew"
+        cap.shell.hostInfo = info
+        try await cap.shell.run("stat -c '%u %U %g %G' f")
+        #expect(cap.stdout == "4242 alice 99 crew\n")
+    }
+
+    @Test func statDefaultSummaryUsesVirtualUidGid() async throws {
+        let (cap, dir) = try makeShellWithDir(); defer { cleanup(dir) }
+        try "x".write(toFile: dir + "/f", atomically: true, encoding: .utf8)
+        var info = cap.shell.hostInfo
+        info.uid = 4242; info.gid = 99
+        cap.shell.hostInfo = info
+        try await cap.shell.run("stat f")
+        #expect(cap.stdout.contains("Uid: ( 4242)"))
+        #expect(cap.stdout.contains("Gid: (   99)"))
+    }
+
     #if !os(Windows)
     @Test func chmodChangesPermissions() async throws {
         let (cap, dir) = try makeShellWithDir(); defer { cleanup(dir) }


### PR DESCRIPTION
Fixes #65.

`stat` rendered ownership straight from `FileMetadata.uid` / `.gid` — the real inode the backing `MountedFileSystem` carries — and hardcoded `%U` / `%G` to `"user"` / `"group"`. So `stat` disagreed with `ls -l` and leaked the host's real uid/gid (e.g. `Uid: (  501)   Gid: (   20)` on macOS).

Now `%u` / `%U` / `%g` / `%G` and the default-summary `Uid:` / `Gid:` all read from `Shell.bashCurrent.hostInfo` — the same virtual identity `ls -l` uses — so the two agree and no host id leaks.

**Tests** (`FsToolsCommandsTests`):
- `statOwnershipTracksVirtualIdentity` — sets a custom `hostInfo`, asserts `stat -c '%u %U %g %G'` reflects it (`4242 alice 99 crew`).
- `statDefaultSummaryUsesVirtualUidGid` — the no-`-c` summary path.

Both write a real temp file, so before the fix they'd have shown the host's ids.
