### PR TITLE
xxd/od/realpath: GNU option compatibility (-g, -A/-N/-t, multi-path)

### DIFF
--- a/Sources/BashCommandKit/Commands/CLIOptionScanner.swift
+++ b/Sources/BashCommandKit/Commands/CLIOptionScanner.swift
@@ -1,0 +1,40 @@
+import Foundation
+
+/// Tiny helper for hand-rolled option parsing in commands that take
+/// `captureForPassthrough` argv.
+///
+/// SwiftBash's `ParsableBashCommand` bridge runs ArgumentParser in a
+/// mode that does **not** accept value-bearing short options in their
+/// attached form (`-g1`, `-N64`, `-tx1`) — only the separated `-g 1`.
+/// GNU/BSD users routinely write the attached form, so commands that
+/// want to honour it scan their own argv with this helper instead.
+enum CLIOptionScanner {
+
+    /// Match a value-bearing option at `argv[index]` in either the
+    /// attached (`-gN`, `--long=N`) or separated (`-g N`, `--long N`)
+    /// form.
+    ///
+    /// - Returns: the option's value and how many argv slots it
+    ///   consumed (1 for an attached form, 2 for a separated one), or
+    ///   `nil` if `argv[index]` is not this option.
+    static func value(_ arg: String, short: Character, long: String,
+                      argv: [String], at index: Int)
+        -> (value: String, advance: Int)? {
+        let shortFlag = "-\(short)"
+        let longFlag = "--\(long)"
+        // Separated: `-g 1` / `--groupsize 1`.
+        if arg == shortFlag || arg == longFlag {
+            guard index + 1 < argv.count else { return nil }
+            return (argv[index + 1], 2)
+        }
+        // Attached short: `-g1`.
+        if arg.hasPrefix(shortFlag), arg.count > shortFlag.count {
+            return (String(arg.dropFirst(shortFlag.count)), 1)
+        }
+        // Attached long: `--groupsize=1`.
+        if arg.hasPrefix(longFlag + "=") {
+            return (String(arg.dropFirst(longFlag.count + 1)), 1)
+        }
+        return nil
+    }
+}

--- a/Sources/BashCommandKit/Commands/OdCommand.swift
+++ b/Sources/BashCommandKit/Commands/OdCommand.swift
@@ -2,42 +2,45 @@ import ArgumentParser
 import BashInterpreter
 import Foundation
 
-/// `od [-c] [-x] [-b] [FILE]` — octal (default) / character / hex dump.
+/// `od [-A RADIX] [-N COUNT] [-t TYPE] [-b] [-x] [-c] [FILE]` — dump
+/// bytes in octal / hex / decimal / character form.
 ///
-/// Default rows pack 16 bytes; the address column is octal (matching
-/// `od`'s tradition). Pick *one* mode flag — multiple just last-wins.
+/// Rows pack 16 bytes. `-A RADIX` sets the address-column base (`o`
+/// octal [default], `d`, `x`, or `n` = none). `-N COUNT` formats at
+/// most COUNT bytes. `-t TYPE` selects an output type:
+///   - `x[1248]` hex, `o[1248]` octal, `u[1248]` unsigned decimal,
+///     `d[1248]` signed decimal (the digit is bytes-per-unit,
+///     default 4), and
+///   - `c` named / escaped characters.
 ///
-/// - default / `-b`: octal bytes, each `\000`–`\377`
-/// - `-x`: 2-byte hex words (little-endian byte order on the host)
-/// - `-c`: characters with C-style escapes (`\n`, `\t`, …) for
-///   non-printables
+/// Options accept both attached (`-tx1`, `-An`, `-N64`) and separated
+/// (`-t x1`) forms. Legacy `-b` (octal bytes), `-x` (2-byte hex words)
+/// and `-c` (characters) are kept as shorthands and render exactly as
+/// before.
 ///
-/// Out of scope (low-frequency): `-A` address radix override,
-/// `-N COUNT`, `-j SKIP`, `-t TYPE` arbitrary type strings.
+/// Out of scope: `-j SKIP`, letter sizes (`dI` / `xL` …), the `a`
+/// named type, and stacking multiple `-t` specs per row.
 public struct OdCommand: ParsableBashCommand {
     public static let configuration = CommandConfiguration(
         commandName: "od",
-        abstract: "Dump bytes in octal / hex / character format."
+        abstract: "Dump bytes in octal / hex / decimal / character format."
     )
 
-    @Flag(name: .customShort("b"), help: "Octal bytes (the default).")
-    public var octal: Bool = false
-
-    @Flag(name: .customShort("x"), help: "Two-byte hex words.")
-    public var hex: Bool = false
-
-    @Flag(name: .customShort("c"),
-          help: "Characters with C-style escapes for non-printables.")
-    public var chars: Bool = false
-
-    @Argument(help: "Input file. Reads stdin if empty.")
-    public var input: String?
+    // Hand-rolled scan (see ``CLIOptionScanner``) so attached short
+    // options — `-An`, `-tx1`, `-N64` — parse the way GNU/BSD `od`
+    // accepts them; the ArgumentParser bridge only takes the
+    // separated form for value-bearing short options.
+    @Argument(parsing: .captureForPassthrough,
+              help: "[-A RADIX] [-N COUNT] [-t TYPE] [-b|-x|-c] [FILE]")
+    public var rawArgv: [String] = []
 
     public init() {}
 
     public mutating func execute() async throws -> ExitStatus {
+        guard let options = parseArguments() else { return ExitStatus(1) }
+
         let data: Data
-        if let file = input, file != "-" {
+        if let file = options.file, file != "-" {
             do {
                 data = try await Shell.bashCurrent.readDataAtPath(file)
             } catch {
@@ -48,26 +51,111 @@ public struct OdCommand: ParsableBashCommand {
             data = await Shell.bashCurrent.stdin.readAllData()
         }
 
-        let mode: Mode = chars ? .chars : (hex ? .hex : .octal)
-        let bytes = [UInt8](data)
+        var bytes = [UInt8](data)
+        if let limit = options.readLimit { bytes = Array(bytes.prefix(limit)) }
+
+        // `-t` selects the GNU-style typed renderer; otherwise fall
+        // back to the legacy `-b`/`-x`/`-c` modes (kept byte-for-byte).
+        if let type = options.type {
+            try renderTyped(bytes: bytes, type: type, radix: options.radix)
+        } else {
+            try renderLegacy(bytes: bytes, mode: options.mode,
+                             radix: options.radix)
+        }
+        return .success
+    }
+
+    // MARK: - Argument parsing
+
+    private struct Options {
+        var mode: Mode = .octal
+        var radix: AddressRadix = .octal
+        var readLimit: Int?
+        var type: OdOutputType?
+        var file: String?
+    }
+
+    // Scan `rawArgv`. Emits a diagnostic and returns `nil` on any bad
+    // option (the caller then exits 1).
+    // swiftlint:disable:next cyclomatic_complexity
+    private func parseArguments() -> Options? {
+        var options = Options()
+        var index = 0
+        while index < rawArgv.count {
+            let arg = rawArgv[index]
+            if arg == "--" {
+                index += 1
+                if index < rawArgv.count { options.file = rawArgv[index] }
+                break
+            }
+            switch arg {
+            case "-b": options.mode = .octal; index += 1; continue
+            case "-x": options.mode = .hex; index += 1; continue
+            case "-c": options.mode = .chars; index += 1; continue
+            default: break
+            }
+            if let match = CLIOptionScanner.value(
+                arg, short: "A", long: "address-radix", argv: rawArgv, at: index) {
+                guard let radix = AddressRadix(parsing: match.value) else {
+                    Shell.bashCurrent.stderr(
+                        "od: invalid address base '\(match.value)'\n")
+                    return nil
+                }
+                options.radix = radix; index += match.advance; continue
+            }
+            if let match = CLIOptionScanner.value(
+                arg, short: "N", long: "read-bytes", argv: rawArgv, at: index) {
+                guard let count = Int(match.value), count >= 0 else {
+                    Shell.bashCurrent.stderr(
+                        "od: invalid byte count: \(match.value)\n")
+                    return nil
+                }
+                options.readLimit = count; index += match.advance; continue
+            }
+            if let match = CLIOptionScanner.value(
+                arg, short: "t", long: "format", argv: rawArgv, at: index) {
+                guard let type = OdOutputType(parsing: match.value) else {
+                    Shell.bashCurrent.stderr(
+                        "od: invalid type string '\(match.value)'\n")
+                    return nil
+                }
+                options.type = type; index += match.advance; continue
+            }
+            if arg == "-" || !arg.hasPrefix("-") {
+                options.file = arg; index += 1; continue
+            }
+            Shell.bashCurrent.stderr("od: invalid option: \(arg)\n")
+            return nil
+        }
+        return options
+    }
+
+    // MARK: - Legacy -b / -x / -c
+
+    enum Mode { case octal, hex, chars }
+
+    private func renderLegacy(bytes: [UInt8], mode: Mode,
+                              radix: AddressRadix) throws {
         var offset = 0
         while offset < bytes.count {
             try Task.checkCancellation()
             let end = min(offset + 16, bytes.count)
-            Shell.bashCurrent.stdout(format(offset: offset,
-                                row: Array(bytes[offset..<end]),
-                                mode: mode) + "\n")
+            Shell.bashCurrent.stdout(
+                format(offset: offset, row: Array(bytes[offset..<end]),
+                       mode: mode, radix: radix) + "\n")
             offset = end
         }
-        // od traditionally prints the final offset on a line of its own.
-        Shell.bashCurrent.stdout(String(format: "%07o", bytes.count) + "\n")
-        return .success
+        // od traditionally prints the final offset on its own line —
+        // suppressed entirely with `-A n`.
+        if let tail = radix.address(bytes.count) {
+            Shell.bashCurrent.stdout(tail + "\n")
+        }
     }
 
-    private enum Mode { case octal, hex, chars }
-
-    private func format(offset: Int, row: [UInt8], mode: Mode) -> String {
-        let prefix = String(format: "%07o ", offset)
+    private func format(offset: Int, row: [UInt8], mode: Mode,
+                        radix: AddressRadix) -> String {
+        // The legacy address column keeps its historical trailing space.
+        let prefix = radix.address(offset).map { $0 + " " } ?? ""
         switch mode {
         case .octal:
             return prefix + row.map { String(format: " %03o", $0) }.joined()
@@ -86,6 +174,59 @@ public struct OdCommand: ParsableBashCommand {
             return prefix + words.joined()
         case .chars:
             return prefix + row.map { Self.escapeChar($0) }.joined()
+        }
+    }
+
+    // MARK: - -A address radix
+
+    /// `-A` address radix. `.none` (`-A n`) suppresses both the address
+    /// column and the trailing offset line.
+    enum AddressRadix {
+        case octal, decimal, hex, none
+
+        init?(parsing raw: String) {
+            switch raw {
+            case "o": self = .octal
+            case "d": self = .decimal
+            case "x": self = .hex
+            case "n": self = .none
+            default: return nil
+            }
+        }
+
+        /// The 7-wide address string, or `nil` for `.none`.
+        func address(_ offset: Int) -> String? {
+            switch self {
+            case .octal: return String(format: "%07o", offset)
+            case .decimal: return String(format: "%07d", offset)
+            case .hex: return String(format: "%07x", offset)
+            case .none: return nil
+            }
+        }
+    }
+
+    // MARK: - -t typed output
+
+    private func renderTyped(bytes: [UInt8], type: OdOutputType,
+                             radix: AddressRadix) throws {
+        var offset = 0
+        while offset < bytes.count {
+            try Task.checkCancellation()
+            let end = min(offset + 16, bytes.count)
+            let row = Array(bytes[offset..<end])
+            // GNU style: the address has no trailing space; each unit
+            // carries its own leading space instead.
+            var line = radix.address(offset) ?? ""
+            if type.kind == .char {
+                line += row.map { Self.escapeChar($0) }.joined()
+            } else {
+                line += odNumericUnits(row: row, type: type)
+            }
+            Shell.bashCurrent.stdout(line + "\n")
+            offset = end
+        }
+        if let tail = radix.address(bytes.count) {
+            Shell.bashCurrent.stdout(tail + "\n")
         }
     }
 
@@ -117,4 +258,92 @@ public struct OdCommand: ParsableBashCommand {
         let pad = max(0, 3 - token.count)
         return " " + String(repeating: " ", count: pad) + token
     }
+}
+
+// MARK: - Typed-output helpers (file scope to keep the command small)
+
+/// A `-t` output type: a numeric base (`x`/`o`/`d`/`u`) with a byte
+/// width, or `c` (named / escaped characters, width 1). Letter sizes
+/// (`C`/`S`/`I`/`L`) and the `a` named type are out of scope.
+private struct OdOutputType {
+    enum Kind { case hex, octal, signedDecimal, unsignedDecimal, char }
+    let kind: Kind
+    let size: Int   // bytes per unit; 1 for `.char`
+
+    init?(parsing spec: String) {
+        guard let first = spec.first else { return nil }
+        let rest = spec.dropFirst()
+        if first == "c" {
+            guard rest.isEmpty else { return nil }
+            kind = .char; size = 1; return
+        }
+        let base: Kind
+        switch first {
+        case "x": base = .hex
+        case "o": base = .octal
+        case "d": base = .signedDecimal
+        case "u": base = .unsignedDecimal
+        default: return nil
+        }
+        let width: Int
+        if rest.isEmpty {
+            width = 4                       // GNU default: sizeof(int)
+        } else if let parsed = Int(rest), [1, 2, 4, 8].contains(parsed) {
+            width = parsed
+        } else {
+            return nil
+        }
+        kind = base; size = width
+    }
+}
+
+/// Assemble `row` into little-endian units of `type.size` bytes
+/// (padding a short trailing unit with 0) and format each.
+private func odNumericUnits(row: [UInt8], type: OdOutputType) -> String {
+    var out = ""
+    var index = 0
+    while index < row.count {
+        var value: UInt64 = 0
+        for byteIndex in 0..<type.size where index + byteIndex < row.count {
+            value |= UInt64(row[index + byteIndex]) << (8 * byteIndex)
+        }
+        out += " " + odFormatUnit(value, type: type)
+        index += type.size
+    }
+    return out
+}
+
+private func odFormatUnit(_ value: UInt64, type: OdOutputType) -> String {
+    let bits = type.size * 8
+    switch type.kind {
+    case .hex:
+        // Zero-padded to the unit width, matching od's hex columns.
+        return String(format: "%0\(type.size * 2)llx", value)
+    case .octal:
+        let width = Int((Double(bits) / 3.0).rounded(.up))
+        return String(format: "%0\(width)llo", value)
+    case .unsignedDecimal:
+        let maxValue = type.size < 8 ? (UInt64(1) << bits) - 1 : UInt64.max
+        return String(format: "%\(String(maxValue).count)llu", value)
+    case .signedDecimal:
+        let minValue: Int64 =
+            type.size < 8 ? -(Int64(1) << (bits - 1)) : Int64.min
+        return String(format: "%\(String(minValue).count)lld",
+                      odSignExtend(value, bits: bits))
+    case .char:
+        // Unreached — the typed `.char` path uses `escapeChar` directly
+        // — but keeps the switch exhaustive.
+        return OdCommand.escapeChar(UInt8(truncatingIfNeeded: value))
+    }
+}
+
+/// Sign-extend the low `bits` of `value` to a signed `Int64`.
+private func odSignExtend(_ value: UInt64, bits: Int) -> Int64 {
+    if bits >= 64 { return Int64(bitPattern: value) }
+    let mask = (UInt64(1) << bits) - 1
+    let low = value & mask
+    if low & (UInt64(1) << (bits - 1)) != 0 {
+        return Int64(bitPattern: low | ~mask)
+    }
+    return Int64(low)
 }

--- a/Sources/BashCommandKit/Commands/RealpathCommand.swift
+++ b/Sources/BashCommandKit/Commands/RealpathCommand.swift
@@ -2,19 +2,21 @@ import ArgumentParser
 import BashInterpreter
 import Foundation
 
-/// `realpath PATH` — resolve `PATH` to an absolute canonical path with
-/// symlinks followed and `.`/`..` components normalised.
+/// `realpath PATH...` — resolve each `PATH` to an absolute canonical
+/// path with symlinks followed and `.`/`..` components normalised,
+/// printing one resolved line per argument.
 ///
-/// By default the path must exist. Pass `-m` / `--missing` to allow
-/// non-existent path components (logical resolution only).
+/// By default each path must exist. Pass `-m` / `--missing` to allow
+/// non-existent path components (logical resolution only). Exit status
+/// is non-zero if any argument fails to resolve.
 public struct RealpathCommand: ParsableBashCommand {
     public static let configuration = CommandConfiguration(
         commandName: "realpath",
         abstract: "Resolve a path to its canonical absolute form."
     )
 
-    @Argument(help: "Path to resolve.")
-    public var path: String
+    @Argument(help: "Path(s) to resolve.")
+    public var paths: [String] = []
 
     @Flag(name: [.short, .long],
           help: "Allow path components that don't exist.")
@@ -23,15 +25,23 @@ public struct RealpathCommand: ParsableBashCommand {
     public init() {}
 
     public mutating func execute() async throws -> ExitStatus {
-        let absolute = Shell.bashCurrent.resolvePath(path)
-        do {
-            let resolved = try await Shell.bashCurrent.fileSystem.canonicalize(
-                absolute, allowMissing: missing)
-            Shell.bashCurrent.stdout(resolved + "\n")
-            return .success
-        } catch FileSystemError.notFound {
-            Shell.bashCurrent.stderr("realpath: \(path): No such file or directory\n")
-            return .failure
+        guard !paths.isEmpty else {
+            Shell.bashCurrent.stderr("realpath: missing operand\n")
+            return ExitStatus(1)
         }
+        var hadError = false
+        for path in paths {
+            let absolute = Shell.bashCurrent.resolvePath(path)
+            do {
+                let resolved = try await Shell.bashCurrent.fileSystem.canonicalize(
+                    absolute, allowMissing: missing)
+                Shell.bashCurrent.stdout(resolved + "\n")
+            } catch FileSystemError.notFound {
+                Shell.bashCurrent.stderr(
+                    "realpath: \(path): No such file or directory\n")
+                hadError = true
+            }
+        }
+        return hadError ? .failure : .success
     }
 }

--- a/Sources/BashCommandKit/Commands/XxdCommand.swift
+++ b/Sources/BashCommandKit/Commands/XxdCommand.swift
@@ -2,7 +2,8 @@ import ArgumentParser
 import BashInterpreter
 import Foundation
 
-/// `xxd [FILE]` — make a hex dump of FILE (or stdin).
+/// `xxd [-l LEN] [-g GROUPSIZE] [FILE]` — make a hex dump of FILE (or
+/// stdin).
 ///
 /// Default output: 16 bytes per row, hex grouped in 2-byte pairs, ASCII
 /// rendering on the right. Non-printable bytes show as `.`.
@@ -11,27 +12,30 @@ import Foundation
 /// 00000000: 6865 6c6c 6f20 776f 726c 640a            hello world.
 /// ```
 ///
-/// Out of scope for v1: `-r` reverse mode, `-p` plain mode, `-c COLS`,
-/// `-g GROUPSIZE`, `-s SEEK`. `-l LEN` is now supported. Defaults match
-/// macOS / vim `xxd`.
+/// `-l LEN` stops after LEN bytes (decimal, `0x…` hex, or `0…` octal);
+/// `-g GROUPSIZE` sets bytes per hex group (`-g0` = one continuous
+/// run). Both accept the attached (`-g1`) and separated (`-g 1`) forms.
+/// Out of scope: `-r` reverse, `-p` plain, `-c COLS`, `-s SEEK`.
 public struct XxdCommand: ParsableBashCommand {
     public static let configuration = CommandConfiguration(
         commandName: "xxd",
         abstract: "Hex dump (default 16-byte rows)."
     )
 
-    @Option(name: [.customShort("l"), .customLong("len")],
-            help: "Stop after dumping N bytes (decimal, or 0x… for hex).")
-    public var length: String?
-
-    @Argument(help: "Input file. Reads stdin if empty.")
-    public var input: String?
+    // Hand-rolled option scan (see ``CLIOptionScanner``) so the attached
+    // short forms GNU/BSD users expect — `-g1`, `-l0x40` — parse, which
+    // the ArgumentParser bridge rejects for value-bearing short options.
+    @Argument(parsing: .captureForPassthrough,
+              help: "[-l LEN] [-g N] [FILE]")
+    public var rawArgv: [String] = []
 
     public init() {}
 
     public mutating func execute() async throws -> ExitStatus {
+        guard let options = parseArguments() else { return ExitStatus(2) }
+
         let data: Data
-        if let file = input, file != "-" {
+        if let file = options.file, file != "-" {
             do {
                 data = try await Shell.bashCurrent.readDataAtPath(file)
             } catch {
@@ -47,14 +51,13 @@ public struct XxdCommand: ParsableBashCommand {
         // prefixed hex (`-l 0x40`), or `0`-prefixed octal (`-l 0100`);
         // we honour the common decimal and hex forms.
         let truncated: Data
-        if let lengthString = length {
+        if let lengthString = options.length {
             guard let limit = Self.parseLength(lengthString), limit >= 0 else {
                 Shell.bashCurrent.stderr(
                     "xxd: invalid length: \(lengthString)\n")
                 return ExitStatus(2)
             }
-            let safeLimit = min(limit, data.count)
-            truncated = data.prefix(safeLimit)
+            truncated = data.prefix(min(limit, data.count))
         } else {
             truncated = data
         }
@@ -67,13 +70,53 @@ public struct XxdCommand: ParsableBashCommand {
             // means cancellation lands within microseconds.
             try Task.checkCancellation()
             let end = min(offset + bytesPerRow, bytes.count)
-            let row = bytes[offset..<end]
             Shell.bashCurrent.stdout(Self.format(offset: offset,
-                                     row: Array(row),
-                                     bytesPerRow: bytesPerRow) + "\n")
+                                     row: Array(bytes[offset..<end]),
+                                     bytesPerRow: bytesPerRow,
+                                     groupSize: options.groupSize) + "\n")
             offset = end
         }
         return .success
+    }
+
+    private struct Options {
+        var length: String?
+        var groupSize: Int = 2
+        var file: String?
+    }
+
+    /// Scan `rawArgv`. Emits a diagnostic and returns `nil` on a bad
+    /// option (the caller then exits 2).
+    private func parseArguments() -> Options? {
+        var options = Options()
+        var index = 0
+        while index < rawArgv.count {
+            let arg = rawArgv[index]
+            if arg == "--" {
+                index += 1
+                if index < rawArgv.count { options.file = rawArgv[index] }
+                break
+            }
+            if arg == "-" || !arg.hasPrefix("-") {
+                options.file = arg; index += 1; continue
+            }
+            if let match = CLIOptionScanner.value(
+                arg, short: "l", long: "len", argv: rawArgv, at: index) {
+                options.length = match.value; index += match.advance; continue
+            }
+            if let match = CLIOptionScanner.value(
+                arg, short: "g", long: "groupsize", argv: rawArgv, at: index) {
+                guard let parsed = Int(match.value), parsed >= 0 else {
+                    Shell.bashCurrent.stderr(
+                        "xxd: invalid group size: \(match.value)\n")
+                    return nil
+                }
+                options.groupSize = parsed; index += match.advance; continue
+            }
+            Shell.bashCurrent.stderr("xxd: invalid option: \(arg)\n")
+            return nil
+        }
+        return options
     }
 
     /// Parse `-l N` argument: decimal (`64`), `0x`-prefixed hex
@@ -96,7 +139,7 @@ public struct XxdCommand: ParsableBashCommand {
     /// Render one xxd row. The hex column always has a fixed width so
     /// short trailing rows still align with the ASCII column.
     static func format(offset: Int, row: [UInt8],
-                       bytesPerRow: Int) -> String {
+                       bytesPerRow: Int, groupSize: Int) -> String {
         var hex = ""
         for idx in 0..<bytesPerRow {
             if idx < row.count {
@@ -104,8 +147,9 @@ public struct XxdCommand: ParsableBashCommand {
             } else {
                 hex += "  "
             }
-            // Group in pairs of 2 bytes (4 hex chars).
-            if idx % 2 == 1, idx + 1 < bytesPerRow {
+            // Separator after every `groupSize` bytes (0 = no grouping).
+            // Skipped after the final byte so short rows still align.
+            if groupSize > 0, (idx + 1) % groupSize == 0, idx + 1 < bytesPerRow {
                 hex += " "
             }
         }

--- a/Tests/BashCommandKitTests/OdCommandTests.swift
+++ b/Tests/BashCommandKitTests/OdCommandTests.swift
@@ -1,0 +1,57 @@
+import Testing
+import Foundation
+@testable import BashInterpreter
+@testable import BashCommandKit
+
+/// `od`'s `-A` / `-N` / `-t` options, exercised with the attached short
+/// forms (`-An`, `-tx1`, `-N3`) the report cited — these route through
+/// the hand-rolled scanner since the ArgumentParser bridge rejects
+/// joined short-option values.
+@Suite(.timeLimit(.minutes(1))) struct OdCommandTests {
+
+    private func makeShell() throws -> (CapturingShell, String) {
+        let dir = (NSTemporaryDirectory() as NSString)
+            .appendingPathComponent("od-\(UUID())")
+        try FileManager.default.createDirectory(
+            atPath: dir, withIntermediateDirectories: true)
+        let cap = CapturingShell()
+        cap.shell.registerStandardCommands()
+        cap.shell.environment.workingDirectory = dir
+        return (cap, dir)
+    }
+    private func cleanup(_ path: String) {
+        try? FileManager.default.removeItem(atPath: path)
+    }
+
+    @Test func typeHexBytesNoAddress() async throws {
+        let (cap, dir) = try makeShell(); defer { cleanup(dir) }
+        try await cap.shell.run("printf 'hello' | od -An -tx1")
+        #expect(cap.stdout == " 68 65 6c 6c 6f\n")
+    }
+
+    @Test func readLimitTruncates() async throws {
+        let (cap, dir) = try makeShell(); defer { cleanup(dir) }
+        try await cap.shell.run("printf 'hello' | od -An -tx1 -N3")
+        #expect(cap.stdout == " 68 65 6c\n")
+    }
+
+    @Test func decimalAddressRadix() async throws {
+        let (cap, dir) = try makeShell(); defer { cleanup(dir) }
+        try await cap.shell.run("printf 'hi' | od -Ad -tx1")
+        #expect(cap.stdout == "0000000 68 69\n0000002\n")
+    }
+
+    @Test func signedDecimalBytes() async throws {
+        let (cap, dir) = try makeShell(); defer { cleanup(dir) }
+        try Data([0x41, 0xFF]).write(to: URL(fileURLWithPath: dir + "/b"))
+        try await cap.shell.run("od -An -td1 b")
+        // 0x41 = 65; 0xFF read as a signed byte = -1. Width 4, space-pad.
+        #expect(cap.stdout == "   65   -1\n")
+    }
+
+    @Test func separatedFormStillWorks() async throws {
+        let (cap, dir) = try makeShell(); defer { cleanup(dir) }
+        try await cap.shell.run("printf 'hello' | od -A n -t x1")
+        #expect(cap.stdout == " 68 65 6c 6c 6f\n")
+    }
+}

--- a/Tests/BashCommandKitTests/RealpathCommandTests.swift
+++ b/Tests/BashCommandKitTests/RealpathCommandTests.swift
@@ -79,4 +79,17 @@ import Foundation
         #expect(cap.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
                 == "/Users/foo/docs")
     }
+
+    @Test func resolvesMultiplePaths() async throws {
+        let cap = makeShell()
+        try await cap.shell.run("realpath -m /a/b /c /e/f/g")
+        #expect(cap.stdout == "/a/b\n/c\n/e/f/g\n")
+    }
+
+    @Test func noArgumentsIsAnError() async throws {
+        let cap = makeShell()
+        let status = try await cap.shell.run("realpath")
+        #expect(!status.isSuccess)
+        #expect(cap.stderr.contains("missing operand"))
+    }
 }

--- a/Tests/BashCommandKitTests/TextUtilityTests.swift
+++ b/Tests/BashCommandKitTests/TextUtilityTests.swift
@@ -228,4 +228,20 @@ import Foundation
         #expect(cap.stdout
             == "00000000: 4142                                     AB\n")
     }
+
+    @Test func xxdGroupSizeOne() async throws {
+        let (cap, dir) = try makeShell(); defer { cleanup(dir) }
+        try await cap.shell.run("printf 'hello' | xxd -g1")
+        // -g1 spaces every byte; the default -g2 pairs them.
+        #expect(cap.stdout.hasPrefix("00000000: 68 65 6c 6c 6f "))
+        #expect(cap.stdout.hasSuffix("hello\n"))
+    }
+
+    @Test func xxdGroupSizeZero() async throws {
+        let (cap, dir) = try makeShell(); defer { cleanup(dir) }
+        try await cap.shell.run("printf 'hello' | xxd -g0")
+        // -g0 runs the hex together with no group separators.
+        #expect(cap.stdout.hasPrefix("00000000: 68656c6c6f "))
+        #expect(cap.stdout.hasSuffix("hello\n"))
+    }
 }


### PR DESCRIPTION
Fixes #66.

Adds the GNU/BSD options the report cited, across three commands:

- **`xxd -g GROUPSIZE`** — bytes per hex group (`-g1` = one byte each, `-g0` = no grouping). Default stays 2 (pairs), so existing output is unchanged.
- **`od -A RADIX` / `-N COUNT` / `-t TYPE`** — address radix (`o`/`d`/`x`/`n`), byte limit, and typed output (`x[1248]`, `o`, `u`, `d`, `c`). The legacy `-b`/`-x`/`-c` modes render byte-for-byte as before.
- **`realpath PATH...`** — accepts multiple paths, one resolved line each; non-zero exit if any fails.

### Why hand-rolled parsing
While implementing this I found SwiftBash's `ParsableBashCommand` bridge rejects **attached** value-bearing short options for *every* command — even the pre-existing `xxd -l3` errors with `Unknown option '-l3'`; only the separated `-l 3` parses. But the report's invocations are all attached (`xxd -g1`, `od -An -tx1 -N64`). So xxd and od now scan their own argv (the existing `StatCommand` pattern, `.captureForPassthrough`) through a small shared `CLIOptionScanner`, accepting both `-g1` and `-g 1`. realpath needs no scanner — its options are positional plus the `-m` flag.

This is scoped to the three commands; the broader bridge limitation (no joined short options for *any* ArgumentParser command) is left as-is — a candidate for a separate follow-up if you'd like it fixed globally.

### Verified — the exact report invocations
```
$ printf 'hello world' | xxd -g1
00000000: 68 65 6c 6c 6f 20 77 6f 72 6c 64                 hello world
$ printf 'hello world' | od -An -tx1 -N64
 68 65 6c 6c 6f 20 77 6f 72 6c 64
$ realpath -m /tmp /home
/tmp
/home
```

**Tests:** `xxd -g1`/`-g0` (`TextUtilityTests`); `od -An -tx1` / `-N` / `-Ad` / `-td1` / separated form (`OdCommandTests`); `realpath` multi-path + missing-operand (`RealpathCommandTests`). Full `BashCommandKitTests` (817) green.
