### PR TITLE
Add a mount command (virtual mount table view)

### DIFF
--- a/Sources/BashCommandKit/API/Shell+StandardCommands.swift
+++ b/Sources/BashCommandKit/API/Shell+StandardCommands.swift
@@ -113,6 +113,9 @@ extension Shell {
         install(UnexpandCommand.self)
         install(FoldCommand.self)
         install(StatCommand.self)
+        // `mount` isn't in the BinCatalog — install off-catalog at its
+        // conventional path (matches the grep/sqlite3 wrappers).
+        install(MountCommand.self, at: "/usr/bin/mount")
         install(ReadlinkCommand.self)
         install(LnCommand.self)
         install(ChmodCommand.self)

--- a/Sources/BashCommandKit/Commands/MountCommand.swift
+++ b/Sources/BashCommandKit/Commands/MountCommand.swift
@@ -1,0 +1,54 @@
+import ArgumentParser
+import BashInterpreter
+
+/// `mount` — show the shell's virtual mount table.
+///
+/// SwiftBash has no host mount table; this lists the
+/// ``MountedFileSystem`` entries the embedder wired up — each virtual
+/// prefix, the host directory backing it, and whether it's read-only —
+/// in a `mount`-style line:
+///
+/// ```
+/// /private/tmp/sandbox on / type sandbox (ro)
+/// /private/tmp/sandbox/home on /home type sandbox (rw)
+/// /private/tmp/scratch on /tmp type sandbox (rw)
+/// ```
+///
+/// Operands are accepted and ignored — this is a read-only view of the
+/// sandbox, not a way to mount new filesystems inside it. A shell with
+/// no `MountedFileSystem` (e.g. a plain in-memory root) prints nothing.
+public struct MountCommand: ParsableBashCommand {
+    public static let configuration = CommandConfiguration(
+        commandName: "mount",
+        abstract: "Show the virtual mount table."
+    )
+
+    @Argument(parsing: .captureForPassthrough, help: "(ignored)")
+    public var rawArgv: [String] = []
+
+    public init() {}
+
+    public mutating func execute() async throws -> ExitStatus {
+        guard let mounted = Self.mountedFileSystem(
+            of: Shell.bashCurrent.fileSystem) else {
+            return .success
+        }
+        for mount in mounted.mountList {
+            let options = mount.readOnly ? "ro" : "rw"
+            Shell.bashCurrent.stdout(
+                "\(mount.host) on \(mount.virtual) type sandbox (\(options))\n")
+        }
+        return .success
+    }
+
+    /// Walk the shell's filesystem stack — an `OverlayFileSystem` wraps
+    /// the mount table — to find the underlying ``MountedFileSystem``.
+    static func mountedFileSystem(
+        of fileSystem: any FileSystem) -> MountedFileSystem? {
+        if let mounted = fileSystem as? MountedFileSystem { return mounted }
+        if let overlay = fileSystem as? OverlayFileSystem {
+            return mountedFileSystem(of: overlay.backing)
+        }
+        return nil
+    }
+}

--- a/Sources/BashInterpreter/FileSystems/MountedFileSystem.swift
+++ b/Sources/BashInterpreter/FileSystems/MountedFileSystem.swift
@@ -81,6 +81,10 @@ public final class MountedFileSystem: FileSystem, @unchecked Sendable {
 
     var allMountVirtuals: [String] { mounts.map(\.virtual) }
 
+    /// Mount table ordered by virtual path, for display by a `mount`
+    /// command (`mounts` is sorted longest-prefix first internally).
+    public var mountList: [Mount] { mounts.sorted { $0.virtual < $1.virtual } }
+
     // MARK: - Mount lookup
 
     /// Translate a virtual path to a host path, or return `nil` when

--- a/Tests/BashCommandKitTests/MountCommandTests.swift
+++ b/Tests/BashCommandKitTests/MountCommandTests.swift
@@ -1,0 +1,62 @@
+import Testing
+import Foundation
+@testable import BashInterpreter
+@testable import BashCommandKit
+
+@Suite(.timeLimit(.minutes(1))) struct MountCommandTests {
+
+    @Test func listsVirtualMountsOrderedByPath() async throws {
+        let sandbox = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("mount-\(UUID().uuidString)")
+        let tmp = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("mount-tmp-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(
+            at: sandbox, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(
+            at: tmp, withIntermediateDirectories: true)
+        defer {
+            try? FileManager.default.removeItem(at: sandbox)
+            try? FileManager.default.removeItem(at: tmp)
+        }
+
+        let mounted = MountedFileSystem(
+            mounts: [
+                .init(virtual: "/", host: sandbox.path, readOnly: true),
+                .init(virtual: "/home",
+                      host: sandbox.appendingPathComponent("home").path),
+                .init(virtual: "/tmp", host: tmp.path)
+            ],
+            backing: RealFileSystem())
+        let cap = CapturingShell()
+        cap.shell.fileSystem = mounted
+        cap.shell.registerStandardCommands()
+
+        let status = try await cap.shell.run("mount")
+        #expect(status == .success)
+
+        let lines = cap.stdout.split(separator: "\n").map(String.init)
+        #expect(lines.count == 3)
+        // Ordered by virtual path; read-only root carries (ro).
+        #expect(lines[0].contains(" on / type sandbox (ro)"))
+        #expect(lines[1].contains(" on /home type sandbox (rw)"))
+        #expect(lines[2].contains(" on /tmp type sandbox (rw)"))
+        // The host directory is named as the "device".
+        #expect(lines[2].hasPrefix(tmp.path))
+    }
+
+    @Test func nonMountedShellPrintsNothing() async throws {
+        let cap = CapturingShell()
+        cap.shell.registerStandardCommands()
+        let status = try await cap.shell.run("mount")
+        #expect(status == .success)
+        #expect(cap.stdout.isEmpty)
+    }
+
+    @Test func operandsAreIgnored() async throws {
+        let cap = CapturingShell()
+        cap.shell.registerStandardCommands()
+        // A plain in-memory shell: still succeeds, ignoring the operand.
+        let status = try await cap.shell.run("mount -l /somewhere")
+        #expect(status == .success)
+    }
+}


### PR DESCRIPTION
Fixes #67.

Adds a `mount` builtin that renders the shell's virtual mount table — the `MountedFileSystem` entries the embedder wired up — in `mount`-style lines:

```
$ swift-bash exec --sandbox ./work script.sh   # script is: mount
./work on /batch type sandbox (rw)
/var/folders/.../T on /tmp type sandbox (rw)
```

Each line is `<host-dir> on <virtual-prefix> type sandbox (<rw|ro>)`, ordered by virtual path. It's a read-only view (operands are accepted and ignored — you can't mount new filesystems into the sandbox), so it stays sandbox-safe. A shell with no `MountedFileSystem` (a plain in-memory root) prints nothing.

Plumbing:
- `MountedFileSystem.mountList` — a public, display-ordered view of the mounts (the internal array is sorted longest-prefix-first for resolution).
- `MountCommand` walks `OverlayFileSystem.backing` to find the underlying `MountedFileSystem`.
- Installed off-catalog at `/usr/bin/mount` (it has no `BinCatalog` entry — same pattern as the grep / sqlite3 wrappers).

Tests (`MountCommandTests`): ordered mounts with rw/ro, a non-mounted shell prints nothing, operands ignored.
