### PR TITLE
Parser/interpreter: support the time reserved word

### DIFF
--- a/Sources/BashInterpreter/Execution/Shell+Pipeline.swift
+++ b/Sources/BashInterpreter/Execution/Shell+Pipeline.swift
@@ -19,10 +19,19 @@ extension Shell {
     func executePipeline(parts: [Node]) async throws -> ExitStatus {
         var index = 0
         var invert = false
-        if !parts.isEmpty,
-           case .reservedWord(let word) = parts[0].kind, word == "!" {
+        var timed = false
+        // `time` reserved word — measures the whole pipeline. (`-p`/`--`
+        // were dropped by the parser; we emit one real/user/sys block.)
+        if index < parts.count,
+           case .reservedWord(let word) = parts[index].kind, word == "time" {
+            timed = true
+            index += 1
+        }
+        // Optional leading `!` that inverts the final exit status.
+        if index < parts.count,
+           case .reservedWord(let word) = parts[index].kind, word == "!" {
             invert = true
-            index = 1
+            index += 1
         }
 
         var stages: [Node] = []
@@ -54,6 +63,9 @@ extension Shell {
         let template = self  // captured for use in per-stage closure
 
         let pipefailMode = pipefail
+        // Start the clock for a `time`-prefixed pipeline just before the
+        // stages run, so the measurement covers the pipeline itself.
+        let timingStart = timed ? Date() : nil
         let status = try await withThrowingTaskGroup(
             of: (Int, ExitStatus).self
         ) { group in
@@ -143,6 +155,11 @@ extension Shell {
             return stageStatuses.last ?? .success
         }
 
+        // `time` reports to the shell's stderr after the pipeline ends.
+        if let timingStart {
+            stderr(bashTimeReport(elapsed: Date().timeIntervalSince(timingStart)))
+        }
+
         // `!`-prefixed pipelines disable errexit on the inverted
         // result (matching bash). Tell the enclosing executeList to
         // skip its next errexit check.
@@ -155,4 +172,14 @@ extension Shell {
         lastExitStatus = status
         return status
     }
+}
+
+/// Format a `time` report block (`real` / `user` / `sys`) for stderr.
+/// SwiftBash has no CPU-time accounting, so `user`/`sys` are reported
+/// as `0m0.000s`, matching the `\time` builtin's output shape.
+private func bashTimeReport(elapsed seconds: TimeInterval) -> String {
+    let minutes = Int(seconds / 60)
+    let secs = seconds - Double(minutes) * 60
+    let real = String(format: "%dm%.3fs", minutes, secs)
+    return "\nreal\t\(real)\nuser\t0m0.000s\nsys\t0m0.000s\n"
 }

--- a/Sources/BashSyntax/Parser/Parser+List.swift
+++ b/Sources/BashSyntax/Parser/Parser+List.swift
@@ -45,7 +45,7 @@ extension Parser {
         case .word, .assignmentWord, .redirectWord, .number,
              .leftParen, .leftCurly,
              .ifKw, .whileKw, .untilKw, .forKw, .caseKw,
-             .functionKw, .bang, .less, .greater, .lessLess, .lessLessMinus,
+             .functionKw, .bang, .timeKw, .less, .greater, .lessLess, .lessLessMinus,
              .lessLessLess, .lessAnd, .greaterAnd, .lessGreater, .greaterBar,
              .greaterGreater, .andGreater, .andGreaterGreater,
              .arithCommand:
@@ -105,23 +105,42 @@ extension Parser {
     // MARK: Pipeline + bang
 
     func parsePipelineCommand() throws -> Node {
-        var bangNode: Node?
+        // Reserved-word prefixes, in bash order: `time [-p] [--]` then
+        // an optional `!`. `time` measures the whole pipeline; its
+        // `-p` / `--` companions are accepted and dropped (we emit one
+        // real/user/sys block regardless of the POSIX-format request).
+        var prefix: [Node] = []
+        if peek().type == .timeKw {
+            let token = try next()
+            prefix.append(Node(kind: .reservedWord(token.value),
+                               range: token.range))
+            // `-p` (POSIX format) then `--` (end of options), in bash
+            // order. The tokenizer emits these as plain words; accept
+            // and drop them — we emit one real/user/sys block anyway.
+            if peek().type == .timeOpt
+                || (peek().type == .word && peek().value == "-p") {
+                _ = try next()
+            }
+            if peek().type == .timeIgn
+                || (peek().type == .word && peek().value == "--") {
+                _ = try next()
+            }
+        }
         if peek().type == .bang {
             let token = try next()
-            bangNode = Node(kind: .reservedWord(token.value), range: token.range)
+            prefix.append(Node(kind: .reservedWord(token.value),
+                               range: token.range))
         }
 
         let pipe = try parsePipeline()
-        if let bangNode {
-            var parts: [Node]
-            if case .pipeline(let existing) = pipe.kind {
-                parts = [bangNode] + existing
-            } else {
-                parts = [bangNode, pipe]
-            }
-            return Node(kind: .pipeline(parts: parts), range: spanOf(parts))
+        guard !prefix.isEmpty else { return pipe }
+        var parts: [Node]
+        if case .pipeline(let existing) = pipe.kind {
+            parts = prefix + existing
+        } else {
+            parts = prefix + [pipe]
         }
-        return pipe
+        return Node(kind: .pipeline(parts: parts), range: spanOf(parts))
     }
 
     func parsePipeline() throws -> Node {

--- a/Tests/BashCommandKitTests/TimeCommandsTests.swift
+++ b/Tests/BashCommandKitTests/TimeCommandsTests.swift
@@ -48,4 +48,47 @@ import Foundation
         let status = try await cap.shell.run("timeout 1s echo ok")
         #expect(status == .success)
     }
+
+    // MARK: `time` reserved word (the keyword handler, not `\time`)
+
+    @Test func timeKeywordRunsAndReports() async throws {
+        let cap = makeShell()
+        let status = try await cap.shell.run("time echo hi")
+        #expect(status == .success)
+        #expect(cap.stdout == "hi\n")
+        #expect(cap.stderr.contains("real"))
+        #expect(cap.stderr.contains("user"))
+        #expect(cap.stderr.contains("sys"))
+    }
+
+    @Test func timeKeywordInsideGroup() async throws {
+        // The exact construct from the bug report.
+        let cap = makeShell()
+        let status = try await cap.shell.run("{ time sleep 0.02; }")
+        #expect(status == .success)
+        #expect(cap.stderr.contains("real"))
+    }
+
+    @Test func timeKeywordTimesWholePipeline() async throws {
+        let cap = makeShell()
+        let status = try await cap.shell.run("time echo a | wc -c")
+        #expect(status == .success)
+        #expect(cap.stdout.contains("2"))
+        #expect(cap.stderr.contains("real"))
+    }
+
+    @Test func timeKeywordPosixFlagIsDropped() async throws {
+        // `-p` / `--` are accepted and dropped, not run as a command.
+        let cap = makeShell()
+        let status = try await cap.shell.run("time -p echo hi")
+        #expect(status == .success)
+        #expect(cap.stdout == "hi\n")
+    }
+
+    @Test func timeKeywordPropagatesFailure() async throws {
+        let cap = makeShell()
+        let status = try await cap.shell.run("time false")
+        #expect(status == .failure)
+        #expect(cap.stderr.contains("real"))
+    }
 }


### PR DESCRIPTION
Fixes #68.

`time` is tokenized as a reserved word (`.timeKw`), but the parser had no rule for it, so every `time …` — `time sleep 1`, `{ time sleep 0.2; }` — failed with `unexpected token time`. (The escaped `\time` form reached the `TimeCommand` builtin; the keyword itself never worked.)

Now `time [-p] [--] pipeline` parses as a pipeline prefix (mirroring `!`) and the interpreter times the whole pipeline, printing a `real`/`user`/`sys` block to stderr after it finishes:

```
$ { time sleep 0.05; }

real	0m0.054s
user	0m0.000s
sys	0m0.000s
```

- **Parser** (`parsePipelineCommand`): consumes `time`, then an optional `-p` (POSIX format) and `--`, prepending a `.reservedWord("time")` to the pipeline; `.timeKw` added to `canStartCommand`.
- **Interpreter** (`executePipeline`): strips the leading `time` reserved word, wraps the stage TaskGroup in a wall-clock measurement, and emits the report. `user`/`sys` are `0m0.000s` (no CPU-time accounting) — the same shape as the `\time` builtin.

Notes: `time` measures the *whole* pipeline (`time a | b`); `-p`/`--` are accepted and dropped (the tokenizer emits them as plain words, so the parser matches by value); `\time` still dispatches to `TimeCommand`; and `time` as a plain argument (`echo time`) is unaffected (it's only `.timeKw` at command-start).

**Tests** (`TimeCommandsTests`): `time echo hi`, `{ time sleep …; }` (the reported case), whole-pipeline timing, `-p` dropped, failure propagation. Full `BashInterpreterTests` + `BashSyntaxTests` (1121) green.
