### PR TITLE
ps/pgrep: seed the shell's own process-table entry

### DIFF
--- a/Sources/BashInterpreter/API/Shell.swift
+++ b/Sources/BashInterpreter/API/Shell.swift
@@ -288,6 +288,10 @@ public final class Shell: ShellKit.Shell, @unchecked Sendable {
     /// correctly without runtime casts.
     @TaskLocal public static var bashCurrent: Shell = Shell()
 
+    /// Tracks whether ``ensureSelfProcessRegistered()`` has seeded the
+    /// shell's own ``processTable`` entry yet. Mutated only there.
+    var selfProcessSeeded = false
+
     // MARK: - Init
 
     public required init(

--- a/Sources/BashInterpreter/Execution/Shell+Run.swift
+++ b/Sources/BashInterpreter/Execution/Shell+Run.swift
@@ -66,8 +66,21 @@ extension Shell {
         }
     }
 
+    /// Seed a `bash` entry at ``virtualPID`` in ``processTable`` the
+    /// first time the shell runs, so `ps` lists the shell itself and
+    /// `pgrep bash` matches — the table otherwise only holds `&` jobs.
+    /// Idempotent; a no-op after the first call.
+    func ensureSelfProcessRegistered() async {
+        guard !selfProcessSeeded else { return }
+        selfProcessSeeded = true
+        await processTable.register(command: "bash", pid: virtualPID)
+    }
+
     private func runImpl(_ parts: [Node],
                          source: String) async throws -> ExitStatus {
+        // Make the shell itself visible to `ps` / `pgrep` (seeded once).
+        await ensureSelfProcessRegistered()
+
         let saved = currentSource
         currentSource = source
         defer { currentSource = saved }

--- a/Tests/BashCommandKitTests/ProcessCommandsTests.swift
+++ b/Tests/BashCommandKitTests/ProcessCommandsTests.swift
@@ -4,9 +4,9 @@ import Foundation
 @testable import BashCommandKit
 
 /// Tests cover the **virtual** process model: `ps` / `kill` / `pgrep`
-/// / `pkill` operate exclusively on ``Shell/processTable``, which is
-/// populated by `&` background jobs. The host process table is never
-/// touched.
+/// / `pkill` operate exclusively on ``Shell/processTable``, which the
+/// shell seeds with its own `bash` entry and which `&` background jobs
+/// add to. The host process table is never touched.
 @Suite(.timeLimit(.minutes(1))) struct ProcessCommandsTests {
 
     private func makeShell() -> CapturingShell {
@@ -17,14 +17,15 @@ import Foundation
 
     // MARK: ps
 
-    @Test func psWithNoBackgroundJobsShowsHeaderOnly() async throws {
+    @Test func psShowsTheShellItself() async throws {
         let cap = makeShell()
         try await cap.shell.run("ps")
-        // Header row only, no entries.
-        let lines = cap.stdout.split(separator: "\n")
-        #expect(lines.count == 1)
+        // Header + the shell's own `bash` entry, even with no `&` jobs.
+        let lines = cap.stdout.split(separator: "\n").map(String.init)
+        #expect(lines.count == 2)
         #expect(lines[0].contains("PID"))
         #expect(lines[0].contains("COMMAND"))
+        #expect(lines[1].contains("bash"))
     }
 
     @Test func psShowsBackgroundedJobs() async throws {
@@ -96,6 +97,14 @@ import Foundation
         let status = try await cap.shell.run(
             "pgrep zzzzzz_definitely_not_a_process")
         #expect(status == ExitStatus(1))
+    }
+
+    @Test func pgrepBashMatchesTheShell() async throws {
+        let cap = makeShell()
+        let status = try await cap.shell.run("pgrep bash")
+        #expect(status == .success)
+        // The shell's own entry sits at its virtual PID (default 1).
+        #expect(cap.stdout.split(separator: "\n").compactMap { Int32($0) } == [1])
     }
 
     @Test func pkillCancelsMatching() async throws {


### PR DESCRIPTION
Fixes #70.

`ps` / `pgrep` read `Shell.processTable`, which was only ever seeded by `&` background jobs — so with no live job, `ps` printed just its header and `pgrep bash` found nothing (the shell couldn't see itself).

Now the shell seeds a `bash` entry at its `virtualPID` (`$$`, default 1) the first time it runs, via `ProcessTable.register(...)` (the API added in Cocoanetics/ShellKit#9). The seed is idempotent (once per shell) and the entry has no backing Task, so `kill` / `wait` against it are no-ops — you can't virtual-kill the shell out from under itself.

```
$ ps
  PID  STAT  COMMAND
    1  R     bash
$ pgrep bash
1
$ sleep 0.3 & ps
  PID  STAT  COMMAND
    1  R     bash
 1000  R     sleep 0.3
```

- `Shell.ensureSelfProcessRegistered()` seeds the entry; called once at the top of `runImpl` (pipeline stages use `execute`, not `run`, so only the top-level shell seeds).
- Depends on `ProcessTable.register` from Cocoanetics/ShellKit#9. SwiftBash's `Package.swift` already tracks ShellKit `main` and `Package.resolved` is gitignored, so a fresh resolve (incl. CI) picks it up automatically — no committed pin change.
- `psWithNoBackgroundJobsShowsHeaderOnly` → `psShowsTheShellItself` (it encoded the old empty-table behavior); added `pgrepBashMatchesTheShell`.

Full `BashCommandKitTests` + `BashInterpreterTests` green.
