### PR TITLE
Sandbox.bashWorkspace: temporaryDirectory + authorizeNetwork (refs #69)

### DIFF
--- a/Sources/BashInterpreter/API/Sandbox+BashWorkspace.swift
+++ b/Sources/BashInterpreter/API/Sandbox+BashWorkspace.swift
@@ -33,11 +33,26 @@ extension ShellKit.Sandbox {
     /// temp dir (the same value `$TMPDIR` carries inside the sandbox)
     /// so ``Shell/temporaryDirectory`` agrees with bash, scripts using
     /// `$TMPDIR`, and FileManager-backed callers.
-    public static func bashWorkspace(workspace: String) -> ShellKit.Sandbox {
+    /// - Parameter temporaryDirectory: the host dir reported as
+    ///   ``Shell/temporaryDirectory``. Defaults to
+    ///   `NSTemporaryDirectory()` (the CLI's choice); an embedder that
+    ///   isolates `/tmp` per session (e.g. a per-document subdir) passes
+    ///   its own. The `/tmp` carve-out still covers it as long as it
+    ///   sits under one of the accepted temp prefixes.
+    /// - Parameter authorizeNetwork: embedder policy for non-file URLs
+    ///   (e.g. routing host access through a permission prompt) while
+    ///   still reusing this file-URL gate — `/tmp` carve-out included.
+    ///   When `nil`, non-file URLs are denied (the base gate's
+    ///   `allowedHosts: []`), matching the CLI's offline default.
+    public static func bashWorkspace(
+        workspace: String,
+        temporaryDirectory: URL? = nil,
+        authorizeNetwork: (@Sendable (URL) async throws -> Void)? = nil
+    ) -> ShellKit.Sandbox {
         let workspaceURL = URL(fileURLWithPath: workspace,
                                isDirectory: true)
-        let tmpURL = URL(fileURLWithPath: NSTemporaryDirectory(),
-                         isDirectory: true)
+        let tmpURL = temporaryDirectory
+            ?? URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
         let baseSandbox = ShellKit.Sandbox.rooted(
             at: workspaceURL,
             allowedHosts: [])
@@ -55,14 +70,23 @@ extension ShellKit.Sandbox {
             cachesDirectory: baseSandbox.cachesDirectory,
             homeDirectory: baseSandbox.homeDirectory,
             authorize: { url in
+                // Non-file URLs go through the embedder's network policy
+                // when supplied; otherwise the deny-all base gate stands.
+                guard url.isFileURL else {
+                    if let authorizeNetwork {
+                        try await authorizeNetwork(url)
+                    } else {
+                        try await baseSandbox.authorize(url)
+                    }
+                    return
+                }
                 do {
                     try await baseSandbox.authorize(url)
                 } catch let denial as ShellKit.Sandbox.Denial {
-                    guard url.isFileURL else { throw denial }
-                    // Unresolved virtual path must be under one of the
-                    // accepted temp prefixes. Compare against
-                    // `standardizedFileURL` so `/tmp/./foo` and
-                    // `/tmp/foo` agree.
+                    // File URL denied by the workspace root — allow it
+                    // only if it lands under an accepted temp prefix.
+                    // Compare against `standardizedFileURL` so
+                    // `/tmp/./foo` and `/tmp/foo` agree.
                     let unresolved = url.standardizedFileURL.path
                     guard Self.pathIsInTemp(unresolved) else { throw denial }
                     // Canonical (symlink-resolved) path must stay in a

--- a/Tests/BashInterpreterTests/BashWorkspaceSandboxTests.swift
+++ b/Tests/BashInterpreterTests/BashWorkspaceSandboxTests.swift
@@ -141,4 +141,52 @@ import ShellKit
         let actual = sandbox.temporaryDirectory.standardizedFileURL.path
         #expect(actual == expected)
     }
+
+    @Test func temporaryDirectoryOverrideIsReported() async throws {
+        // An embedder (e.g. iBash, isolating /tmp per document) passes
+        // its own temp dir; the gate reports it, and a file URL under it
+        // is still authorized by the carve-out.
+        let custom = URL(fileURLWithPath: NSTemporaryDirectory(),
+                         isDirectory: true)
+            .appendingPathComponent("custom-\(UUID().uuidString)",
+                                    isDirectory: true)
+        let sandbox = ShellKit.Sandbox.bashWorkspace(
+            workspace: "/batch", temporaryDirectory: custom)
+        #expect(sandbox.temporaryDirectory.standardizedFileURL.path
+                == custom.standardizedFileURL.path)
+        try await sandbox.authorize(custom.appendingPathComponent("f"))
+    }
+
+    @Test func authorizeNetworkRoutesNonFileURLs() async throws {
+        let recorder = URLRecorder()
+        let sandbox = ShellKit.Sandbox.bashWorkspace(workspace: "/batch") { url in
+            await recorder.record(url)
+        }
+        // Non-file URL → the embedder's closure handles it.
+        try await sandbox.authorize(URL(string: "https://api.example.com/x")!)
+        #expect(await recorder.hosts == ["api.example.com"])
+        // File URLs keep using the workspace + /tmp carve-out, never the
+        // network closure.
+        try await sandbox.authorize(URL(fileURLWithPath: "/batch/f"))
+        try await sandbox.authorize(URL(fileURLWithPath: "/tmp/f"))
+        #expect(await recorder.hosts.count == 1)
+    }
+
+    @Test func authorizeNetworkCanDeny() async throws {
+        struct Blocked: Error {}
+        let sandbox = ShellKit.Sandbox.bashWorkspace(workspace: "/batch") { _ in
+            throw Blocked()
+        }
+        await #expect(throws: Blocked.self) {
+            try await sandbox.authorize(
+                URL(string: "https://blocked.example/")!)
+        }
+        // …a /tmp file URL is still allowed (carve-out unaffected).
+        try await sandbox.authorize(URL(fileURLWithPath: "/tmp/ok"))
+    }
+}
+
+private actor URLRecorder {
+    private(set) var hosts: [String] = []
+    func record(_ url: URL) { hosts.append(url.host ?? "") }
 }


### PR DESCRIPTION
Refs #69.

Adds two optional params to `Sandbox.bashWorkspace(workspace:)` so an embedder can reuse this gate's file-URL handling — **including the `/tmp` carve-out** — instead of hand-rolling its own:

- **`temporaryDirectory:`** — the host dir reported as `Shell.temporaryDirectory`. Defaults to `NSTemporaryDirectory()` (the CLI's choice); an embedder isolating `/tmp` per session (iBash uses a per-document subdir) passes its own. The carve-out still covers it as long as it sits under an accepted temp prefix.
- **`authorizeNetwork:`** — embedder policy for non-file URLs (e.g. routing host access through a permission prompt). When `nil`, non-file URLs are denied — the CLI's offline default.

Background: #69's `git init` under `/tmp` failure [isn't a SwiftBash bug](https://github.com/Cocoanetics/SwiftBash/issues/69#issuecomment-4626508061) — the CLI's `bashWorkspace` gate already authorizes `/tmp` file URLs. It's the iBash embedder, which hand-rolls its own gate (`installShellSandbox`) without the carve-out. The two things stopping iBash from simply *using* `bashWorkspace` were its per-document temp dir and `PermissionBroker` network routing; these params remove both blockers.

Both default to current behavior, so `bashWorkspace(workspace:)` and all existing callers are unchanged. File URLs keep the workspace root + `/tmp` carve-out (with the symlink re-check) exactly as before.

**Tests** (`BashWorkspaceSandboxTests`, 12/12 green): a custom `temporaryDirectory` is reported and stays authorized; the network closure is invoked for network URLs (and *not* for file URLs) and can deny; existing gate coverage unchanged.

The iBash side (rewriting `installShellSandbox` to use this) lands on iBash's `main`; this PR is the SwiftBash half. I'll close #69 once both are in.
