### PR TITLE
Address Codex review: mount path leak (P1), ! time order, od operands

### DIFF
--- a/Sources/BashCommandKit/Commands/MountCommand.swift
+++ b/Sources/BashCommandKit/Commands/MountCommand.swift
@@ -5,13 +5,15 @@ import BashInterpreter
 ///
 /// SwiftBash has no host mount table; this lists the
 /// ``MountedFileSystem`` entries the embedder wired up — each virtual
-/// prefix, the host directory backing it, and whether it's read-only —
-/// in a `mount`-style line:
+/// prefix and whether it's read-only — in a `mount`-style line. The
+/// host directory backing each mount is deliberately **not** shown, so
+/// host paths stay out of the sandbox (matching `pwd` / `realpath` /
+/// diagnostics); the device column is a synthetic `sandbox` label:
 ///
 /// ```
-/// /private/tmp/sandbox on / type sandbox (ro)
-/// /private/tmp/sandbox/home on /home type sandbox (rw)
-/// /private/tmp/scratch on /tmp type sandbox (rw)
+/// sandbox on / type sandbox (ro)
+/// sandbox on /home type sandbox (rw)
+/// sandbox on /tmp type sandbox (rw)
 /// ```
 ///
 /// Operands are accepted and ignored — this is a read-only view of the
@@ -33,10 +35,29 @@ public struct MountCommand: ParsableBashCommand {
             of: Shell.bashCurrent.fileSystem) else {
             return .success
         }
-        for mount in mounted.mountList {
+        let table = mounted.mountList
+        var seen = Set<String>()
+        for mount in table {
+            // Resolve the mountpoint to its virtual spelling before
+            // printing. Some mounts exist only as a real-path alias: the
+            // CLI mounts `$TMPDIR`'s host path (e.g. `/var/folders/…/T`)
+            // next to `/tmp` so `$TMPDIR` resolves, and printing that
+            // virtual verbatim would leak a host path. When another mount
+            // exposes this one's `virtual` (itself a host path) under a
+            // cleaner name, print that name; the de-dup below then folds
+            // the alias into `/tmp`. A genuine `/tmp → /tmp` mount (Linux,
+            // where `NSTemporaryDirectory()` normalises to `/tmp`) has no
+            // such alias and stays visible.
+            let mountPoint = table.first {
+                $0.host == mount.virtual && $0.virtual != mount.virtual
+            }?.virtual ?? mount.virtual
+            guard seen.insert(mountPoint).inserted else { continue }
             let options = mount.readOnly ? "ro" : "rw"
+            // Synthetic `sandbox` device — never the real `mount.host`
+            // backing path, which would leak the host workspace / temp
+            // container path into the sandbox.
             Shell.bashCurrent.stdout(
-                "\(mount.host) on \(mount.virtual) type sandbox (\(options))\n")
+                "sandbox on \(mountPoint) type sandbox (\(options))\n")
         }
         return .success
     }

--- a/Sources/BashCommandKit/Commands/OdCommand.swift
+++ b/Sources/BashCommandKit/Commands/OdCommand.swift
@@ -39,19 +39,9 @@ public struct OdCommand: ParsableBashCommand {
     public mutating func execute() async throws -> ExitStatus {
         guard let options = parseArguments() else { return ExitStatus(1) }
 
-        let data: Data
-        if let file = options.file, file != "-" {
-            do {
-                data = try await Shell.bashCurrent.readDataAtPath(file)
-            } catch {
-                Shell.bashCurrent.stderr("od: \(file): \(error)\n")
-                return .failure
-            }
-        } else {
-            data = await Shell.bashCurrent.stdin.readAllData()
-        }
+        let input = await readInput(options.files)
 
-        var bytes = [UInt8](data)
+        var bytes = [UInt8](input.data)
         if let limit = options.readLimit { bytes = Array(bytes.prefix(limit)) }
 
         // `-t` selects the GNU-style typed renderer; otherwise fall
@@ -62,7 +52,38 @@ public struct OdCommand: ParsableBashCommand {
             try renderLegacy(bytes: bytes, mode: options.mode,
                              radix: options.radix)
         }
-        return .success
+        // Dump whatever was read, then report failure if any operand was
+        // unreadable — a bad trailing path must not discard valid output
+        // already accepted from earlier operands (GNU od).
+        return input.allRead ? .success : .failure
+    }
+
+    /// Read all operands concatenated (GNU od); an empty list or `-`
+    /// means stdin. On a read failure it emits a diagnostic, skips that
+    /// operand, and keeps going, so bytes already read from earlier (and
+    /// later readable) operands are still returned. `ok` is false when
+    /// any operand failed.
+    private func readInput(_ files: [String]) async
+        -> (data: Data, allRead: Bool) {
+        if files.isEmpty {
+            return (await Shell.bashCurrent.stdin.readAllData(), true)
+        }
+        var combined = Data()
+        var allRead = true
+        for file in files {
+            if file == "-" {
+                combined.append(await Shell.bashCurrent.stdin.readAllData())
+                continue
+            }
+            do {
+                combined.append(
+                    try await Shell.bashCurrent.readDataAtPath(file))
+            } catch {
+                Shell.bashCurrent.stderr("od: \(file): \(error)\n")
+                allRead = false
+            }
+        }
+        return (combined, allRead)
     }
 
     // MARK: - Argument parsing
@@ -72,12 +93,12 @@ public struct OdCommand: ParsableBashCommand {
         var radix: AddressRadix = .octal
         var readLimit: Int?
         var type: OdOutputType?
-        var file: String?
+        var files: [String] = []
     }
 
     // Scan `rawArgv`. Emits a diagnostic and returns `nil` on any bad
     // option (the caller then exits 1).
-    // swiftlint:disable:next cyclomatic_complexity
+    // swiftlint:disable:next cyclomatic_complexity function_body_length
     private func parseArguments() -> Options? {
         var options = Options()
         var index = 0
@@ -85,7 +106,9 @@ public struct OdCommand: ParsableBashCommand {
             let arg = rawArgv[index]
             if arg == "--" {
                 index += 1
-                if index < rawArgv.count { options.file = rawArgv[index] }
+                while index < rawArgv.count {
+                    options.files.append(rawArgv[index]); index += 1
+                }
                 break
             }
             switch arg {
@@ -122,7 +145,7 @@ public struct OdCommand: ParsableBashCommand {
                 options.type = type; index += match.advance; continue
             }
             if arg == "-" || !arg.hasPrefix("-") {
-                options.file = arg; index += 1; continue
+                options.files.append(arg); index += 1; continue
             }
             Shell.bashCurrent.stderr("od: invalid option: \(arg)\n")
             return nil

--- a/Sources/BashInterpreter/Execution/Shell+Pipeline.swift
+++ b/Sources/BashInterpreter/Execution/Shell+Pipeline.swift
@@ -17,21 +17,22 @@ extension Shell {
     // local to the closure that captures it.
     // swiftlint:disable:next cyclomatic_complexity function_body_length
     func executePipeline(parts: [Node]) async throws -> ExitStatus {
+        // Strip leading reserved-word prefixes — `time` (measures the
+        // whole pipeline; `-p`/`--` already dropped by the parser) and
+        // `!` (inverts the final status). They may appear in either
+        // order (`time ! …`, `! time …`).
         var index = 0
         var invert = false
         var timed = false
-        // `time` reserved word — measures the whole pipeline. (`-p`/`--`
-        // were dropped by the parser; we emit one real/user/sys block.)
-        if index < parts.count,
-           case .reservedWord(let word) = parts[index].kind, word == "time" {
-            timed = true
-            index += 1
-        }
-        // Optional leading `!` that inverts the final exit status.
-        if index < parts.count,
-           case .reservedWord(let word) = parts[index].kind, word == "!" {
-            invert = true
-            index += 1
+        prefixLoop: while index < parts.count {
+            guard case .reservedWord(let word) = parts[index].kind else {
+                break
+            }
+            switch word {
+            case "time": timed = true; index += 1
+            case "!": invert = true; index += 1
+            default: break prefixLoop
+            }
         }
 
         var stages: [Node] = []

--- a/Sources/BashSyntax/Parser/Parser+List.swift
+++ b/Sources/BashSyntax/Parser/Parser+List.swift
@@ -105,31 +105,38 @@ extension Parser {
     // MARK: Pipeline + bang
 
     func parsePipelineCommand() throws -> Node {
-        // Reserved-word prefixes, in bash order: `time [-p] [--]` then
-        // an optional `!`. `time` measures the whole pipeline; its
-        // `-p` / `--` companions are accepted and dropped (we emit one
-        // real/user/sys block regardless of the POSIX-format request).
+        // Reserved-word prefixes: `time [-p] [--]` and `!`. bash nests
+        // them recursively, so they appear in either order (`time ! …`
+        // and `! time …` both parse). Consume at most one of each, in
+        // whatever order they arrive. `time`'s `-p` / `--` companions are
+        // accepted and dropped (we emit one real/user/sys block anyway).
         var prefix: [Node] = []
-        if peek().type == .timeKw {
-            let token = try next()
-            prefix.append(Node(kind: .reservedWord(token.value),
-                               range: token.range))
-            // `-p` (POSIX format) then `--` (end of options), in bash
-            // order. The tokenizer emits these as plain words; accept
-            // and drop them — we emit one real/user/sys block anyway.
-            if peek().type == .timeOpt
-                || (peek().type == .word && peek().value == "-p") {
-                _ = try next()
+        var sawTime = false
+        var sawBang = false
+        while true {
+            if !sawTime, peek().type == .timeKw {
+                sawTime = true
+                let token = try next()
+                prefix.append(Node(kind: .reservedWord(token.value),
+                                   range: token.range))
+                if peek().type == .timeOpt
+                    || (peek().type == .word && peek().value == "-p") {
+                    _ = try next()
+                }
+                if peek().type == .timeIgn
+                    || (peek().type == .word && peek().value == "--") {
+                    _ = try next()
+                }
+                continue
             }
-            if peek().type == .timeIgn
-                || (peek().type == .word && peek().value == "--") {
-                _ = try next()
+            if !sawBang, peek().type == .bang {
+                sawBang = true
+                let token = try next()
+                prefix.append(Node(kind: .reservedWord(token.value),
+                                   range: token.range))
+                continue
             }
-        }
-        if peek().type == .bang {
-            let token = try next()
-            prefix.append(Node(kind: .reservedWord(token.value),
-                               range: token.range))
+            break
         }
 
         let pipe = try parsePipeline()

--- a/Tests/BashCommandKitTests/MountCommandTests.swift
+++ b/Tests/BashCommandKitTests/MountCommandTests.swift
@@ -40,8 +40,56 @@ import Foundation
         #expect(lines[0].contains(" on / type sandbox (ro)"))
         #expect(lines[1].contains(" on /home type sandbox (rw)"))
         #expect(lines[2].contains(" on /tmp type sandbox (rw)"))
-        // The host directory is named as the "device".
-        #expect(lines[2].hasPrefix(tmp.path))
+        // Synthetic device label — the host backing path must NOT leak.
+        #expect(lines.allSatisfy { $0.hasPrefix("sandbox on ") })
+        #expect(!cap.stdout.contains(sandbox.path))
+        #expect(!cap.stdout.contains(tmp.path))
+    }
+
+    @Test func keepsSelfMountWhereVirtualEqualsHost() async throws {
+        // The Linux sandbox mounts /tmp → NSTemporaryDirectory(), which
+        // normalises to "/tmp" (virtual == host). That's a genuine mount,
+        // not a $TMPDIR real-path alias, so `mount` must still list it.
+        let mounted = MountedFileSystem(
+            mounts: [
+                .init(virtual: "/", host: "/workspace", readOnly: true),
+                .init(virtual: "/tmp", host: "/tmp")
+            ],
+            backing: RealFileSystem())
+        let cap = CapturingShell()
+        cap.shell.fileSystem = mounted
+        cap.shell.registerStandardCommands()
+
+        let status = try await cap.shell.run("mount")
+        #expect(status == .success)
+        let lines = cap.stdout.split(separator: "\n").map(String.init)
+        #expect(lines.count == 2)
+        #expect(lines.contains { $0.contains(" on /tmp type sandbox (rw)") })
+    }
+
+    @Test func collapsesRealPathAliasMount() async throws {
+        // macOS sandbox: /tmp → $TMPDIR's host path, plus a self-mapping
+        // alias mounting that host path under its own (host) name so a
+        // literal `$TMPDIR` still resolves. `mount` must fold the alias
+        // into /tmp and never print the host path.
+        let hostTmp = "/var/folders/ab/cdef/T"
+        let mounted = MountedFileSystem(
+            mounts: [
+                .init(virtual: "/", host: "/workspace", readOnly: true),
+                .init(virtual: "/tmp", host: hostTmp),
+                .init(virtual: hostTmp, host: hostTmp)
+            ],
+            backing: RealFileSystem())
+        let cap = CapturingShell()
+        cap.shell.fileSystem = mounted
+        cap.shell.registerStandardCommands()
+
+        let status = try await cap.shell.run("mount")
+        #expect(status == .success)
+        let lines = cap.stdout.split(separator: "\n").map(String.init)
+        #expect(lines.count == 2)   // /, /tmp — the alias folded in
+        #expect(lines.contains { $0.contains(" on /tmp type sandbox") })
+        #expect(!cap.stdout.contains("folders"))   // no host path leaks
     }
 
     @Test func nonMountedShellPrintsNothing() async throws {

--- a/Tests/BashCommandKitTests/OdCommandTests.swift
+++ b/Tests/BashCommandKitTests/OdCommandTests.swift
@@ -54,4 +54,26 @@ import Foundation
         try await cap.shell.run("printf 'hello' | od -A n -t x1")
         #expect(cap.stdout == " 68 65 6c 6c 6f\n")
     }
+
+    @Test func multipleFilesConcatenate() async throws {
+        // GNU od concatenates multiple operands — `od a b` must not
+        // silently drop `a` and dump only `b`.
+        let (cap, dir) = try makeShell(); defer { cleanup(dir) }
+        try Data([0x41]).write(to: URL(fileURLWithPath: dir + "/a"))
+        try Data([0x42]).write(to: URL(fileURLWithPath: dir + "/b"))
+        try await cap.shell.run("od -An -tx1 a b")
+        #expect(cap.stdout == " 41 42\n")
+    }
+
+    @Test func dumpsReadableOperandsThenErrorsOnMissing() async throws {
+        // A bad trailing operand must not discard output already read
+        // from an earlier one: `od good missing` dumps `good`, reports
+        // the error on stderr, and exits non-zero (GNU od).
+        let (cap, dir) = try makeShell(); defer { cleanup(dir) }
+        try Data([0x41]).write(to: URL(fileURLWithPath: dir + "/good"))
+        let status = try await cap.shell.run("od -An -tx1 good missing")
+        #expect(cap.stdout == " 41\n")
+        #expect(status == .failure)
+        #expect(cap.stderr.contains("missing"))
+    }
 }

--- a/Tests/BashCommandKitTests/TimeCommandsTests.swift
+++ b/Tests/BashCommandKitTests/TimeCommandsTests.swift
@@ -91,4 +91,15 @@ import Foundation
         #expect(status == .failure)
         #expect(cap.stderr.contains("real"))
     }
+
+    @Test func timeKeywordInversionEitherOrder() async throws {
+        // `! time …` and `time ! …` both parse; both time the pipeline
+        // and invert the status (false → success).
+        for line in ["! time false", "time ! false"] {
+            let cap = makeShell()
+            let status = try await cap.shell.run(line)
+            #expect(status == .success, "\(line)")
+            #expect(cap.stderr.contains("real"), "\(line)")
+        }
+    }
 }


### PR DESCRIPTION
Addresses the Codex review comments I merged past on #74, #75, and #73.

- **`mount` (#74, P1 — host path leak):** `mount` printed `mount.host`, the real backing dir, so a sandboxed script could recover the workspace / temp-container host path. Now it renders a synthetic `sandbox` device, and skips self-alias mounts (`virtual == host`, e.g. the CLI's `$TMPDIR` real-path spelling) so no host path leaks via the device **or** the mountpoint column.
- **`time` (#75 — inversion order):** `! time foo` (inversion before `time`) is valid bash but failed to parse. The parser now consumes `!` and `time [-p] [--]` in either order (`! time …` and `time ! …`), and the interpreter strips both leading prefixes in any order.
- **`od` (#73 — multi-operand):** `od a b` silently dumped only `b`. Operands now concatenate (GNU `od` semantics); `-` and the empty list mean stdin.

**Tests:** `mount` asserts no host path leaks; `time` covers both `! time false` / `time ! false`; `od a b` concatenates. Full `BashCommandKit` + `BashSyntax` + `BashInterpreter` suites green (4 pre-existing timing-tolerance tests flake only under parallel load; all pass in isolation).
