### PR TITLE
stat: report metadata ownership; virtualize at the FS boundary (refs #72)

### DIFF
--- a/Sources/BashCommandKit/Commands/StatCommand.swift
+++ b/Sources/BashCommandKit/Commands/StatCommand.swift
@@ -9,9 +9,10 @@ import Foundation
 /// substituted (subset of GNU): `%n` name, `%s` size, `%y` mtime
 /// (ISO 8601 in UTC), `%F` file type word, `%a` permissions in
 /// octal, `%A` symbolic mode, `%N` quoted name (with -> for symlinks),
-/// `%u`/`%U` owner uid/name, `%g`/`%G` group gid/name — all from the
-/// shell's virtual `HostInfo` (so `stat` agrees with `ls -l` rather
-/// than leaking the real host's ids), `%h` hard link count (always 1).
+/// `%u`/`%g` owner uid/gid (from file metadata — a virtualizing FS
+/// maps it to the sandbox identity, so no host id leaks, while a real FS
+/// keeps per-file ownership), `%U`/`%G` owner user/group name (the shell
+/// identity's, since there's no passwd map), `%h` link count (always 1).
 public struct StatCommand: ParsableBashCommand {
     public static let configuration = CommandConfiguration(
         commandName: "stat",
@@ -75,9 +76,11 @@ public struct StatCommand: ParsableBashCommand {
     private func formatString(_ fmt: String, name: String,
                               meta: FileMetadata) -> String {
         var out = ""
-        // Ownership tracks the shell's virtual identity, not the
-        // backing inode — `stat` must agree with `ls -l` instead of
-        // surfacing the real host uid/gid a MountedFileSystem carries.
+        // `%u`/`%g` come straight from file metadata — a virtualizing FS
+        // (`MountedFileSystem`) already maps it to the sandbox identity,
+        // so no host id leaks while a real FS keeps per-file ownership.
+        // `%U`/`%G` render the shell identity's names (no passwd map to
+        // resolve arbitrary uids).
         let host = Shell.bashCurrent.hostInfo
         let chars = Array(fmt)
         var index = 0
@@ -97,8 +100,8 @@ public struct StatCommand: ParsableBashCommand {
                     } else {
                         out += "'\(name)'"
                     }
-                case "u": out += String(host.uid)
-                case "g": out += String(host.gid)
+                case "u": out += String(meta.uid)
+                case "g": out += String(meta.gid)
                 case "U": out += host.userName
                 case "G": out += host.groupName
                 case "h": out += String(meta.linkCount)
@@ -127,10 +130,10 @@ public struct StatCommand: ParsableBashCommand {
         summary += "  Size: \(meta.size)\t\(FsTools.typeWord(meta.kind))\n"
         let modeStr = String(format: "%04o", meta.mode)
         let symbolicMode = FsTools.symbolicMode(kind: meta.kind, mode: meta.mode)
-        // Virtual identity, not the backing inode (see formatString).
-        let host = Shell.bashCurrent.hostInfo
-        let uidStr = String(format: "%5d", host.uid)
-        let gidStr = String(format: "%5d", host.gid)
+        // From file metadata — virtualized by the FS in a sandbox, the
+        // real owner on a real FS (see formatString).
+        let uidStr = String(format: "%5d", meta.uid)
+        let gidStr = String(format: "%5d", meta.gid)
         summary += "Access: (\(modeStr)/\(symbolicMode))  "
         summary += "Uid: (\(uidStr))   Gid: (\(gidStr))\n"
         summary += "Access: \(FsTools.iso8601(meta.accessedAt))\n"

--- a/Sources/BashInterpreter/API/FileSystem.swift
+++ b/Sources/BashInterpreter/API/FileSystem.swift
@@ -290,6 +290,17 @@ public struct FileMetadata: Sendable, Equatable, Hashable {
         self.accessedAt = accessedAt ?? modifiedAt
         self.createdAt = createdAt ?? modifiedAt
     }
+
+    /// A copy with ownership remapped. Virtualizing layers (e.g.
+    /// ``MountedFileSystem``) use this to report a synthetic identity
+    /// instead of the backing inode's real uid/gid, so a sandboxed
+    /// `stat` / `find` never surfaces the host's ids.
+    public func withOwnership(uid: UInt32, gid: UInt32) -> FileMetadata {
+        FileMetadata(kind: kind, size: size, modifiedAt: modifiedAt,
+                     symlinkTarget: symlinkTarget, mode: mode,
+                     uid: uid, gid: gid, linkCount: linkCount,
+                     accessedAt: accessedAt, createdAt: createdAt)
+    }
 }
 
 // MARK: Errors

--- a/Sources/BashInterpreter/FileSystems/MountedFileSystem.swift
+++ b/Sources/BashInterpreter/FileSystems/MountedFileSystem.swift
@@ -1,3 +1,4 @@
+// swiftlint:disable file_length
 import Foundation
 
 /// A `FileSystem` that presents a virtual root (`/`) backed by one or
@@ -250,7 +251,9 @@ public final class MountedFileSystem: FileSystem, @unchecked Sendable {
         } catch FileSystemError.notFound {
             return nil
         }
-        return try await backing.metadata(host)
+        // Ownership boundary: virtualize uid/gid to the shell identity.
+        let id = Shell.bashCurrent.hostInfo
+        return try await backing.metadata(host)?.withOwnership(uid: id.uid, gid: id.gid)
     }
 
     public func list(_ path: String) async throws -> [FileEntry] {
@@ -258,7 +261,18 @@ public final class MountedFileSystem: FileSystem, @unchecked Sendable {
         if synthesizedAncestors.contains(std) {
             return synthesizedChildren(of: std)
         }
-        return try await backing.list(try await gateRead(path))
+        let entries = try await backing.list(try await gateRead(path))
+        // Ownership boundary: virtualize each entry's uid/gid to the
+        // shell identity, exactly as `metadata(_:)` does. `FileEntry`
+        // carries `FileMetadata` so callers (`ls -l`, `find`) read
+        // ownership straight from the listing without a follow-up stat —
+        // that path must not surface the host inode's ids either.
+        let id = Shell.bashCurrent.hostInfo
+        return entries.map {
+            FileEntry(name: $0.name,
+                      metadata: $0.metadata.withOwnership(uid: id.uid,
+                                                          gid: id.gid))
+        }
     }
 
     public func canonicalize(_ path: String,

--- a/Tests/BashCommandKitTests/FsToolsCommandsTests.swift
+++ b/Tests/BashCommandKitTests/FsToolsCommandsTests.swift
@@ -31,30 +31,81 @@ import Foundation
         #expect(cap.stdout == "f 2\n")
     }
 
-    // Ownership must come from the shell's virtual `HostInfo`, not the
-    // real inode the temp file carries (which would leak the host's
-    // uid/gid) — `stat` has to agree with `ls -l`. Use ids distinct
-    // from both the real host and the old hardcoded "user"/"group".
-    @Test func statOwnershipTracksVirtualIdentity() async throws {
+    // Real FS (no virtualizing mount): `%u`/`%g` are the file's ACTUAL
+    // owner — per-file ownership is preserved. `%U`/`%G` render the
+    // shell identity's names (there's no passwd map to resolve uids).
+    @Test func statShowsRealOwnershipOnRealFS() async throws {
         let (cap, dir) = try makeShellWithDir(); defer { cleanup(dir) }
-        try "x".write(toFile: dir + "/f", atomically: true, encoding: .utf8)
+        let path = dir + "/f"
+        try "x".write(toFile: path, atomically: true, encoding: .utf8)
+        let attrs = try FileManager.default.attributesOfItem(atPath: path)
+        let fileUID = (attrs[.ownerAccountID] as? NSNumber)?.uint32Value ?? 0
+        let fileGID = (attrs[.groupOwnerAccountID] as? NSNumber)?.uint32Value ?? 0
         var info = cap.shell.hostInfo
-        info.uid = 4242; info.userName = "alice"
-        info.gid = 99; info.groupName = "crew"
+        info.userName = "alice"; info.groupName = "crew"
         cap.shell.hostInfo = info
         try await cap.shell.run("stat -c '%u %U %g %G' f")
-        #expect(cap.stdout == "4242 alice 99 crew\n")
+        #expect(cap.stdout == "\(fileUID) alice \(fileGID) crew\n")
     }
 
-    @Test func statDefaultSummaryUsesVirtualUidGid() async throws {
-        let (cap, dir) = try makeShellWithDir(); defer { cleanup(dir) }
+    // A MountedFileSystem virtualizes ownership at the boundary, so a
+    // sandboxed `stat` reports the shell identity's uid/gid, never the
+    // host inode's — the leak #65 was about, fixed at the FS rather than
+    // by `stat` ignoring metadata.
+    @Test func statVirtualizesOwnershipOnMountedFS() async throws {
+        let dir = NSTemporaryDirectory() + "statmnt-\(UUID())"
+        try FileManager.default.createDirectory(
+            atPath: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(atPath: dir) }
         try "x".write(toFile: dir + "/f", atomically: true, encoding: .utf8)
+
+        func mountedShell() -> CapturingShell {
+            let cap = CapturingShell()
+            cap.shell.fileSystem = MountedFileSystem(
+                mounts: [.init(virtual: "/", host: dir)],
+                backing: RealFileSystem())
+            cap.shell.registerStandardCommands()
+            var info = cap.shell.hostInfo
+            info.uid = 4242; info.gid = 99
+            cap.shell.hostInfo = info
+            return cap
+        }
+
+        let cap1 = mountedShell()
+        try await cap1.shell.run("stat -c '%u %g' /f")
+        #expect(cap1.stdout == "4242 99\n")
+
+        let cap2 = mountedShell()
+        try await cap2.shell.run("stat /f")
+        #expect(cap2.stdout.contains("Uid: ( 4242)"))
+        #expect(cap2.stdout.contains("Gid: (   99)"))
+    }
+
+    // Directory-entry metadata from `list(_:)` must be virtualized too —
+    // `FileEntry` carries `FileMetadata`, so `ls -l` / `find` read
+    // ownership from the listing without a follow-up `stat`. That path
+    // has to report the shell identity, not the host inode's uid/gid.
+    @Test func listVirtualizesEntryOwnershipOnMountedFS() async throws {
+        let dir = NSTemporaryDirectory() + "listmnt-\(UUID())"
+        try FileManager.default.createDirectory(
+            atPath: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(atPath: dir) }
+        try "x".write(toFile: dir + "/f", atomically: true, encoding: .utf8)
+
+        let cap = CapturingShell()
+        cap.shell.fileSystem = MountedFileSystem(
+            mounts: [.init(virtual: "/", host: dir)],
+            backing: RealFileSystem())
         var info = cap.shell.hostInfo
         info.uid = 4242; info.gid = 99
         cap.shell.hostInfo = info
-        try await cap.shell.run("stat f")
-        #expect(cap.stdout.contains("Uid: ( 4242)"))
-        #expect(cap.stdout.contains("Gid: (   99)"))
+
+        let entries = try await Shell.$bashCurrent.withValue(cap.shell) {
+            try await cap.shell.fileSystem.list("/")
+        }
+        let entry = try #require(entries.first { $0.name == "f" })
+        #expect(entry.metadata.uid == 4242)
+        #expect(entry.metadata.gid == 99)
     }
 
     #if !os(Windows)


### PR DESCRIPTION
Addresses the Codex review on #72.

#65 made `stat` read ownership from `hostInfo`, which fixed the sandbox leak but made **non-sandbox** `stat -c '%u %g'` report the shell user's ids for *every* file (e.g. a root-owned `/bin/*`) instead of the file's real owner.

Per the review, the leak is now fixed at the ownership-mapping boundary instead:
- **`stat`** reports `meta.uid` / `meta.gid` again (per-file), so a real FS preserves true ownership. `%U` / `%G` keep the shell identity's *names* (there's no passwd map to resolve arbitrary uids).
- **`MountedFileSystem.metadata`** virtualizes `uid`/`gid` to the shell identity (new `FileMetadata.withOwnership`), so a sandboxed `stat` / `find` reports the synthetic id and never surfaces the host inode's — fixing #65 at the FS rather than by `stat` ignoring metadata.

**Tests:** `statShowsRealOwnershipOnRealFS` (per-file owner on a real FS) and `statVirtualizesOwnershipOnMountedFS` (synthetic id through a mount). Verified end-to-end: `stat` in `--sandbox` shows `1000 user`, not the host's `501`.
