### PR TITLE
MountedFileSystem: surface child mount points under their parent in ls

### DIFF
--- a/Sources/BashInterpreter/FileSystems/MountedFileSystem+Synthesis.swift
+++ b/Sources/BashInterpreter/FileSystems/MountedFileSystem+Synthesis.swift
@@ -27,9 +27,12 @@ extension MountedFileSystem {
         return ancestors
     }
 
-    /// Direct child names that synthesised ancestor `parent` should
-    /// expose — the first path component of every mount whose virtual
-    /// path lies under `parent`, deduplicated.
+    /// Direct child names `parent` should expose by virtue of the mount
+    /// table — the first path component of every mount (and synthesised
+    /// ancestor) whose virtual path lies under `parent`, deduplicated.
+    /// Used both for a fully-synthesised ancestor (which has no backing
+    /// directory of its own) and to fold cross-store mount points into a
+    /// concrete mount's host listing (so `/tmp` shows up under `ls /`).
     func synthesizedChildren(of parent: String) -> [FileEntry] {
         let prefix = parent == "/" ? "/" : parent + "/"
         var seen: Set<String> = []

--- a/Sources/BashInterpreter/FileSystems/MountedFileSystem.swift
+++ b/Sources/BashInterpreter/FileSystems/MountedFileSystem.swift
@@ -261,7 +261,21 @@ public final class MountedFileSystem: FileSystem, @unchecked Sendable {
         if synthesizedAncestors.contains(std) {
             return synthesizedChildren(of: std)
         }
-        let entries = try await backing.list(try await gateRead(path))
+        // Concrete mount (or a directory inside one): list its backing
+        // host directory, then fold in any child mount points whose
+        // parent is this directory. A mount whose host target lives
+        // OUTSIDE this directory's backing store never appears in the
+        // host listing — the canonical case being `/tmp` mapped to the
+        // OS temp dir, which made `ls /` omit `tmp` even though `cd
+        // /tmp` and `ls /tmp` already worked. Dedupe by name so a mount
+        // that *does* coincide with a real on-disk entry (`/home` →
+        // `<root>/home`) isn't listed twice.
+        var entries = try await backing.list(try await gateRead(path))
+        let present = Set(entries.map(\.name))
+        for child in synthesizedChildren(of: std)
+        where !present.contains(child.name) {
+            entries.append(child)
+        }
         // Ownership boundary: virtualize each entry's uid/gid to the
         // shell identity, exactly as `metadata(_:)` does. `FileEntry`
         // carries `FileMetadata` so callers (`ls -l`, `find`) read

--- a/Tests/BashCommandKitTests/MountedFileSystemTests.swift
+++ b/Tests/BashCommandKitTests/MountedFileSystemTests.swift
@@ -59,6 +59,65 @@ struct MountedFileSystemTests {
         #expect(lines.contains("home"))
     }
 
+    @Test("`ls /` surfaces a cross-store mount point (`/tmp`)")
+    func lsRootShowsTmpMount() async throws {
+        let bench = try makeBench()
+        defer {
+            try? FileManager.default.removeItem(at: bench.sandboxRoot)
+            try? FileManager.default.removeItem(at: bench.tmpRoot)
+        }
+
+        // `/tmp` is mounted to a host dir OUTSIDE the sandbox root, so it
+        // never appears in the root's on-disk listing. It should still
+        // show up as a child of `/` by virtue of the mount table.
+        let entries = try await bench.cap.shell.fileSystem.list("/")
+            .map(\.name)
+        #expect(entries.contains("tmp"))
+        let tmp = try #require(try await bench.cap.shell.fileSystem
+            .list("/").first { $0.name == "tmp" })
+        #expect(tmp.metadata.kind == .directory)
+
+        // And it's traversable / listable, not just a name.
+        let status = try await bench.cap.shell.run(
+            "echo hi > /tmp/probe.txt; ls /tmp")
+        #expect(status == .success)
+        #expect(bench.cap.stdout.split(separator: "\n").map(String.init)
+            .contains("probe.txt"))
+    }
+
+    @Test("a mount whose host lives on disk isn't double-listed")
+    func mountNotDoubledWhenOnDisk() async throws {
+        // Mirror iBash's layout: `/home` is a mount pointing at
+        // `<root>/home`, which also physically exists on disk. The
+        // mount-point folding must dedupe it so `ls /` shows `home`
+        // exactly once (it's both a real backing entry AND a child
+        // mount).
+        let sandbox = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("ibash-mount-\(UUID().uuidString)")
+        let tmp = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("ibash-mount-tmp-\(UUID().uuidString)")
+        let home = sandbox.appendingPathComponent("home")
+        try FileManager.default.createDirectory(
+            at: home, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(
+            at: tmp, withIntermediateDirectories: true)
+        defer {
+            try? FileManager.default.removeItem(at: sandbox)
+            try? FileManager.default.removeItem(at: tmp)
+        }
+
+        let mounted = MountedFileSystem(
+            mounts: [
+                .init(virtual: "/", host: sandbox.path),
+                .init(virtual: "/home", host: home.path),
+                .init(virtual: "/tmp", host: tmp.path)
+            ],
+            backing: RealFileSystem())
+        let names = try await mounted.list("/").map(\.name)
+        #expect(names.filter { $0 == "home" }.count == 1)
+        #expect(names.contains("tmp"))
+    }
+
     @Test("`/tmp/foo` writes go to the tmp mount, not the root")
     func tmpMountIsSeparate() async throws {
         let bench = try makeBench()

--- a/Tests/BashInterpreterTests/OverlayFileSystemTests.swift
+++ b/Tests/BashInterpreterTests/OverlayFileSystemTests.swift
@@ -23,6 +23,57 @@ import Foundation
         #expect(entries.contains("usr"))
     }
 
+    /// Full iBash composition: an `OverlayFileSystem` wrapping a
+    /// `MountedFileSystem` (`/` read-only, `/home`, `/tmp`) plus the
+    /// BinCatalog overlay and a `/examples` HostDirectory overlay. `ls
+    /// /` must surface the overlay roots (`bin`, `usr`, `examples`) AND
+    /// every mount point — including `/tmp`, whose host dir lives
+    /// OUTSIDE the sandbox root and so is absent from the root's on-disk
+    /// listing. Regression guard for `ls /` omitting `tmp`.
+    @Test func ibashRootListingIncludesTmpMount() async throws {
+        let fileManager = FileManager.default
+        let base = URL(fileURLWithPath: NSTemporaryDirectory())
+        let sandbox = base.appendingPathComponent("ibash-ov-\(UUID()).d")
+        let scratchTmp = base.appendingPathComponent("ibash-ov-tmp-\(UUID()).d")
+        let examples = base.appendingPathComponent("ibash-ov-ex-\(UUID()).d")
+        let home = sandbox.appendingPathComponent("home")
+        try fileManager.createDirectory(
+            at: home, withIntermediateDirectories: true)
+        try fileManager.createDirectory(
+            at: scratchTmp, withIntermediateDirectories: true)
+        try fileManager.createDirectory(
+            at: examples, withIntermediateDirectories: true)
+        try "echo hi\n".write(to: examples.appendingPathComponent("hello.sh"),
+                              atomically: true, encoding: .utf8)
+        defer {
+            try? fileManager.removeItem(at: sandbox)
+            try? fileManager.removeItem(at: scratchTmp)
+            try? fileManager.removeItem(at: examples)
+        }
+
+        let mounted = MountedFileSystem(
+            mounts: [
+                .init(virtual: "/", host: sandbox.path, readOnly: true),
+                .init(virtual: "/home", host: home.path),
+                .init(virtual: "/tmp", host: scratchTmp.path)
+            ],
+            backing: RealFileSystem())
+        let fileSystem = OverlayFileSystem(
+            backing: mounted,
+            providers: [
+                BinCatalogOverlay(),
+                HostDirectoryOverlay(virtualRoot: "/examples", hostRoot: examples)
+            ])
+        let shell = Shell(fileSystem: fileSystem)
+        let entries = try await shell.withCurrent {
+            try await shell.fileSystem.list("/").map(\.name).sorted()
+        }
+        for expected in ["bin", "examples", "home", "tmp", "usr"] {
+            #expect(entries.contains(expected),
+                    "ls / should list \(expected); got \(entries)")
+        }
+    }
+
     @Test func usrListingShowsBinAndLocal() async throws {
         let shell = Shell(fileSystem: InMemoryFileSystem())
         let entries = try await shell.withCurrent {


### PR DESCRIPTION
`ls /` didn't show nested mount points — e.g. with `/` and `/tmp` both mounted, `/tmp` was missing from `ls /`. `MountedFileSystem` now surfaces child mount points in their parent's listing, and `OverlayFileSystem` passes them through. Adds regression tests in `MountedFileSystemTests` and `OverlayFileSystemTests`.

(Also adds `// swiftlint:disable file_length` to `MountedFileSystem.swift` — surfacing the child mounts tipped it past the 400-line limit; same approach as `Shell.swift`.)