### PR TITLE
Get the Sqlite3Shell driver from SQLiteKit, not SwiftPorts

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -143,6 +143,15 @@ let package = Package(
         // Pinned to `main` until SwiftPorts ships a tagged release.
         .package(url: "https://github.com/Cocoanetics/SwiftPorts",
                  branch: "main"),
+        // SQLiteKit — the SQLite SDK and its ArgumentParser-free
+        // `Sqlite3Shell` CLI driver (the argv parser + dot-command / REPL
+        // engine). `Shell+Sqlite3.swift` registers the `sqlite3` builtin from
+        // `Sqlite3Shell` via a native ShellKit command, so it works on every
+        // platform — Android included. (The SDK was extracted from SwiftPorts;
+        // the shell driver followed it, so this is now a direct dependency.)
+        // Pinned to `main` until SQLiteKit ships a tagged release.
+        .package(url: "https://github.com/Cocoanetics/SQLiteKit",
+                 branch: "main"),
         // SwiftScript — Swift tree-walking interpreter that reads
         // its IO / FS / network / identity / exit through
         // `ShellKit.Shell.current`. The `BashSwiftScript` target
@@ -195,12 +204,12 @@ let package = Package(
                 "BashInterpreter",
                 .product(name: "ArgumentParser", package: "swift-argument-parser"),
                 .product(name: "Crypto", package: "swift-crypto"),
-                // sqlite3's shell driver — SwiftPorts' ArgumentParser-free
+                // sqlite3's shell driver — SQLiteKit's ArgumentParser-free
                 // `Sqlite3Shell` (Parser + `Sqlite3Executable`). Depended on
-                // unconditionally (incl. Android): it builds wherever
-                // SQLiteKit does, and `Shell+Sqlite3.swift` registers the
+                // unconditionally (incl. Android): it builds wherever the
+                // SQLiteKit SDK does, and `Shell+Sqlite3.swift` registers the
                 // `sqlite3` builtin from it via a native ShellKit command.
-                .product(name: "Sqlite3Shell", package: "SwiftPorts"),
+                .product(name: "Sqlite3Shell", package: "SQLiteKit"),
                 // The rest of the SwiftPorts CLI family (jq / gh / glab /
                 // git / the archive + compression set / rg / fd),
                 // registered as builtins by `registerSwiftPortsCommands()`.


### PR DESCRIPTION
## What

The sqlite3 shell driver moved from SwiftPorts into the
[Cocoanetics/SQLiteKit](https://github.com/Cocoanetics/SQLiteKit) package
(alongside the SDK it was already built on). This repoints the `sqlite3`
builtin's dependency accordingly.

## Changes

- Add a direct **SQLiteKit** package dependency (pinned to `main`).
- `BashCommandKit` now takes `Sqlite3Shell` from `package: "SQLiteKit"`
  instead of `package: "SwiftPorts"`.

`Shell+Sqlite3.swift` is unchanged — the module is still named `Sqlite3Shell`
and the `Sqlite3Executable.run(...)` entry point is the same, so the `sqlite3`
builtin keeps working on every platform (the driver stays ArgumentParser-free,
Android included).

## Verification

Verified on **macOS** against the SQLiteKit + SwiftPorts branches:
`BashCommandKit` and the `swift-bash` executable build cleanly. Linux /
Windows / Android via CI.

## Merge order

Requires **Cocoanetics/SQLiteKit#1** (new `Sqlite3Shell` product) and
**Cocoanetics/SwiftPorts#57** (drops SwiftPorts' own `Sqlite3Shell`, avoiding
a duplicate-module clash) to merge first — both are pinned to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
