### PR TITLE
BashInterpreter: harden POSIX errno handling in RealFileSystem

### DIFF
--- a/Sources/BashInterpreter/FileSystems/RealFileSystem+POSIX.swift
+++ b/Sources/BashInterpreter/FileSystems/RealFileSystem+POSIX.swift
@@ -143,9 +143,18 @@ public extension RealFileSystem {
 }
 
 func fsError(op operation: String, path: String) -> FileSystemError {
-    let msg = String(cString: strerror(errno))
-    if errno == ENOENT { return .notFound(path) }
-    if errno == EACCES || errno == EPERM { return .permissionDenied(path) }
-    return .io("\(operation) \(path) failed: \(msg)")
+    // Capture `errno` once, up front. It's a thread-local global that any
+    // intervening libc call — `strerror` included — is permitted to
+    // overwrite, so re-reading it after the message lookup (as this used
+    // to) risks classifying the error off a clobbered value.
+    let code = errno
+    switch code {
+    case ENOENT:
+        return .notFound(path)
+    case EACCES, EPERM:
+        return .permissionDenied(path)
+    default:
+        return .io("\(operation) \(path) failed: \(String(cString: strerror(code)))")
+    }
 }
 #endif

--- a/Sources/BashInterpreter/FileSystems/RealFileSystem+Xattr.swift
+++ b/Sources/BashInterpreter/FileSystems/RealFileSystem+Xattr.swift
@@ -78,8 +78,8 @@ public extension RealFileSystem {
         let result = path.withCString { pathPtr in
             name.withCString { namePtr in removexattr(pathPtr, namePtr, 0) }
         }
-        // ENOATTR (93 on macOS) is fine — silent no-op.
-        if result < 0 && errno != 93 {
+        // ENOATTR ("attribute not found") is fine — silent no-op.
+        if result < 0 && errno != ENOATTR {
             throw fsError(op: "removexattr", path: path)
         }
     }
@@ -141,8 +141,8 @@ public extension RealFileSystem {
         let result = path.withCString { pathPtr in
             name.withCString { namePtr in removexattr(pathPtr, namePtr) }
         }
-        // ENODATA (61 on Linux) means "no such attribute" — silent no-op.
-        if result < 0 && errno != 61 {
+        // ENODATA ("attribute not found") means no such attribute — silent no-op.
+        if result < 0 && errno != ENODATA {
             throw fsError(op: "removexattr", path: path)
         }
     }


### PR DESCRIPTION
## What

Two small, dependency-free cleanups to the POSIX error handling in `RealFileSystem`, both in the "stop hand-handling raw `errno`" vein:

1. **`fsError(op:path:)`** — the central `errno` → `FileSystemError` mapper (used by `chmod`/`chown`/`symlink`/`link` and every `*xattr` op) read the thread-local `errno` global four times, including *after* `strerror()`, which the C standard explicitly permits to overwrite `errno`. An unlucky clobber could classify the failure off a stale value. Now captures `errno` once and switches over the named constants.

2. **`removeXattr` "attribute not found" guard** — replaced the raw magic numbers with their named constants: `ENOATTR` on Darwin (was `93`) and `ENODATA` on Linux/Android (was `61`), so the intent reads from the code rather than a comment.

No behavior change on the common paths — pure readability + robustness.

## Background

Fell out of an evaluation of whether [apple/swift-system](https://github.com/apple/swift-system) could replace hand-rolled POSIX code in the Swift* family. Conclusion: not worth a new dependency on a core multi-platform target — its `Errno` would have touched only this one function, its `FileSystem`/`Stat` metadata API (the real prize for `RealFileSystem`) is still future-gated (`@available(System 99, *)`) and `#if !os(Windows)`, and its Windows tier is officially "Unstable". So this is the dependency-free version of that cleanup.

## Verification

- `swift build --build-tests` clean on macOS (full package graph, 0 errors).
- `RealFileSystemTests` — **23/23 pass** (exercises the `fsError` error-mapping paths: not-found / already-exists / remove).
- Runtime-checked the refactored mapping against real syscalls: failed `chmod` → `ENOENT` → `.notFound`; `EACCES`/`EPERM` → `.permissionDenied`; else → `.io(strerror)` — identical to before.

> An earlier CI run on this branch failed for an **unrelated** reason: SwiftBash resolves `SwiftPorts: branch main` fresh on every build (its `Package.resolved` is gitignored), and that HEAD was momentarily mid-migration to GitKit 2.0.0 (`GitClient+Archive.swift` orphaned). Fixed upstream by Cocoanetics/SwiftPorts#63; a CI re-run resolves the fixed `SwiftPorts main` and is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)